### PR TITLE
Fix unhandled exception when Windows API fails to delete cached counties DB

### DIFF
--- a/scwx-qt/source/scwx/qt/config/county_database.cpp
+++ b/scwx-qt/source/scwx/qt/config/county_database.cpp
@@ -129,7 +129,14 @@ void Initialize()
    sqlite3_close(db);
 
    // Remove temporary file
-   std::filesystem::remove(countyDatabaseCache);
+   std::error_code err;
+
+   if (!std::filesystem::remove(countyDatabaseCache, err)) {
+      logger_->error(
+          "Unable to remove cached copy of database, error code: {} error category: {}",
+          err.value(),
+          err.category().name());
+   }
 
    initialized_ = true;
 }

--- a/scwx-qt/source/scwx/qt/config/county_database.cpp
+++ b/scwx-qt/source/scwx/qt/config/county_database.cpp
@@ -132,7 +132,7 @@ void Initialize()
    std::error_code err;
 
    if (!std::filesystem::remove(countyDatabaseCache, err)) {
-      logger_->error(
+      logger_->warn(
           "Unable to remove cached copy of database, error code: {} error category: {}",
           err.value(),
           err.category().name());


### PR DESCRIPTION
On my machine, for some reason the counties db temp file is created as readonly.

When the Init() method attempts to delete it, it fails with an ACCESS_DENIED error, and throws. This exception is unhandled, crashing the program.

This PR changes the delete file call to the overload that sets an error code, and logs the error if it occurs.