### PR TITLE
Connect radar product view signals in layer constructor, rather than …

### DIFF
--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -77,6 +77,15 @@ public:
 RadarProductLayer::RadarProductLayer(std::shared_ptr<MapContext> context) :
     GenericLayer(context), p(std::make_unique<RadarProductLayerImpl>())
 {
+   auto radarProductView = context->radar_product_view();
+   connect(radarProductView.get(),
+           &view::RadarProductView::ColorTableUpdated,
+           this,
+           [this]() { p->colorTableNeedsUpdate_ = true; });
+   connect(radarProductView.get(),
+           &view::RadarProductView::SweepComputed,
+           this,
+           [this]() { p->sweepNeedsUpdate_ = true; });
 }
 RadarProductLayer::~RadarProductLayer() = default;
 
@@ -144,16 +153,6 @@ void RadarProductLayer::Initialize()
    gl.glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
    gl.glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
    gl.glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-
-   auto radarProductView = context()->radar_product_view();
-   connect(radarProductView.get(),
-           &view::RadarProductView::ColorTableUpdated,
-           this,
-           [this]() { p->colorTableNeedsUpdate_ = true; });
-   connect(radarProductView.get(),
-           &view::RadarProductView::SweepComputed,
-           this,
-           [this]() { p->sweepNeedsUpdate_ = true; });
 }
 
 void RadarProductLayer::UpdateSweep()


### PR DESCRIPTION
…initialize

If the radar product view updates at precisely the right time, color tables might not be initialized properly. The Initialize function would not have been able to properly update color tables, and the view signal would be emitted prior to the signals and slots being connected.