### PR TITLE
Remove the GTK theme from Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,7 @@ jobs:
         cd ..
         mkdir -p plugins/
         cd plugins/
-        mkdir -p platformthemes/
         mkdir -p sqldrivers/
-        cp "${RUNNER_WORKSPACE}/Qt/${{ matrix.qt_version }}/${{ matrix.qt_arch }}/plugins/platformthemes/libqgtk3.so" platformthemes/
         cp "${RUNNER_WORKSPACE}/Qt/${{ matrix.qt_version }}/${{ matrix.qt_arch }}/plugins/sqldrivers/libqsqlite.so" sqldrivers/
         cd ..
         popd


### PR DESCRIPTION
Has the potential to cause a crash when opening a file dialog. GTK is deprecated in favor of Fusion.