### PR TITLE
Fix warning about missing default codecs on first run

### DIFF
--- a/scwx-qt/source/scwx/qt/ui/setup/audio_codec_page.cpp
+++ b/scwx-qt/source/scwx/qt/ui/setup/audio_codec_page.cpp
@@ -164,10 +164,9 @@ bool AudioCodecPage::IsRequired()
    auto         oggCodecs =
       oggFormat.supportedAudioCodecs(QMediaFormat::ConversionMode::Decode);
 
-   // Setup is required if codec errors are not ignored, and the default codecs
-   // are not supported
-   return (!ignoreCodecErrors &&
-           !oggCodecs.contains(QMediaFormat::AudioCodec::Vorbis));
+   // Setup is required if codec errors are not ignored, and no Ogg support
+   // is found.
+   return (!ignoreCodecErrors && oggCodecs.empty());
 }
 
 } // namespace setup

--- a/scwx-qt/source/scwx/qt/ui/setup/audio_codec_page.cpp
+++ b/scwx-qt/source/scwx/qt/ui/setup/audio_codec_page.cpp
@@ -167,7 +167,7 @@ bool AudioCodecPage::IsRequired()
    // Setup is required if codec errors are not ignored, and the default codecs
    // are not supported
    return (!ignoreCodecErrors &&
-           oggCodecs.contains(QMediaFormat::AudioCodec::Vorbis));
+           !oggCodecs.contains(QMediaFormat::AudioCodec::Vorbis));
 }
 
 } // namespace setup


### PR DESCRIPTION
I'm packaging Supercell Wx for  `NixOS/nixpkgs` (see: https://github.com/NixOS/nixpkgs/pull/316266) and I noticed that on first run I get a warning about missing default codecs, even though I have the codecs in question installed. The audio playback works fine in the application itself.

This change fixed my issue and seems to align with the intent of the nearby comment.