### PR TITLE
Allow Custom Map Styles

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_provider.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_provider.cpp
@@ -178,6 +178,11 @@ static const std::unordered_map<MapProvider, MapProviderInfo> mapProviderInfo_ {
            .drawBelow_ {"aeroway_runway", "Aeroway"}}}}},
    {MapProvider::Unknown, MapProviderInfo {}}};
 
+bool MapStyle::IsValid() const
+{
+   return !url_.empty() && !drawBelow_.empty();
+}
+
 MapProvider GetMapProvider(const std::string& name)
 {
    auto result =

--- a/scwx-qt/source/scwx/qt/map/map_provider.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_provider.hpp
@@ -28,6 +28,8 @@ struct MapStyle
    std::string              name_;
    std::string              url_;
    std::vector<std::string> drawBelow_;
+
+   bool IsValid() const;
 };
 
 struct MapProviderInfo

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -93,6 +93,11 @@ public:
       nmeaBaudRate_.SetMinimum(1);
       nmeaBaudRate_.SetMaximum(999999999);
 
+      customStyleDrawLayer_.SetTransform([](const std::string& value)
+                                         { return boost::trim_copy(value); });
+      customStyleUrl_.SetTransform([](const std::string& value)
+                                   { return boost::trim_copy(value); });
+
       clockFormat_.SetValidator(
          SCWX_SETTINGS_ENUM_VALIDATOR(scwx::util::ClockFormat,
                                       scwx::util::ClockFormatIterator(),
@@ -130,6 +135,9 @@ public:
 
    SettingsVariable<bool>        antiAliasingEnabled_ {"anti_aliasing_enabled"};
    SettingsVariable<std::string> clockFormat_ {"clock_format"};
+   SettingsVariable<std::string> customStyleDrawLayer_ {
+      "custom_style_draw_layer"};
+   SettingsVariable<std::string> customStyleUrl_ {"custom_style_url"};
    SettingsVariable<bool>        debugEnabled_ {"debug_enabled"};
    SettingsVariable<std::string> defaultAlertAction_ {"default_alert_action"};
    SettingsVariable<std::string> defaultRadarSite_ {"default_radar_site"};
@@ -158,8 +166,10 @@ public:
 GeneralSettings::GeneralSettings() :
     SettingsCategory("general"), p(std::make_unique<Impl>())
 {
-   RegisterVariables({&p->antiAliasingEnabled_, //
+   RegisterVariables({&p->antiAliasingEnabled_,
                       &p->clockFormat_,
+                      &p->customStyleDrawLayer_,
+                      &p->customStyleUrl_,
                       &p->debugEnabled_,
                       &p->defaultAlertAction_,
                       &p->defaultRadarSite_,
@@ -199,6 +209,16 @@ SettingsVariable<bool>& GeneralSettings::anti_aliasing_enabled() const
 SettingsVariable<std::string>& GeneralSettings::clock_format() const
 {
    return p->clockFormat_;
+}
+
+SettingsVariable<std::string>& GeneralSettings::custom_style_draw_layer() const
+{
+   return p->customStyleDrawLayer_;
+}
+
+SettingsVariable<std::string>& GeneralSettings::custom_style_url() const
+{
+   return p->customStyleUrl_;
 }
 
 SettingsVariable<bool>& GeneralSettings::debug_enabled() const
@@ -340,6 +360,8 @@ bool operator==(const GeneralSettings& lhs, const GeneralSettings& rhs)
 {
    return (lhs.p->antiAliasingEnabled_ == rhs.p->antiAliasingEnabled_ &&
            lhs.p->clockFormat_ == rhs.p->clockFormat_ &&
+           lhs.p->customStyleDrawLayer_ == rhs.p->customStyleDrawLayer_ &&
+           lhs.p->customStyleUrl_ == rhs.p->customStyleUrl_ &&
            lhs.p->debugEnabled_ == rhs.p->debugEnabled_ &&
            lhs.p->defaultAlertAction_ == rhs.p->defaultAlertAction_ &&
            lhs.p->defaultRadarSite_ == rhs.p->defaultRadarSite_ &&

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -52,6 +52,7 @@ public:
 
       antiAliasingEnabled_.SetDefault(true);
       clockFormat_.SetDefault(defaultClockFormatValue);
+      customStyleDrawLayer_.SetDefault(".*\\.annotations\\.points");
       debugEnabled_.SetDefault(false);
       defaultAlertAction_.SetDefault(defaultDefaultAlertActionValue);
       defaultRadarSite_.SetDefault("KLSX");
@@ -102,6 +103,8 @@ public:
          SCWX_SETTINGS_ENUM_VALIDATOR(scwx::util::ClockFormat,
                                       scwx::util::ClockFormatIterator(),
                                       scwx::util::GetClockFormatName));
+      customStyleDrawLayer_.SetValidator([](const std::string& value)
+                                         { return !value.empty(); });
       defaultAlertAction_.SetValidator(
          SCWX_SETTINGS_ENUM_VALIDATOR(types::AlertAction,
                                       types::AlertActionIterator(),

--- a/scwx-qt/source/scwx/qt/settings/general_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.hpp
@@ -25,12 +25,14 @@ public:
    GeneralSettings(GeneralSettings&&) noexcept;
    GeneralSettings& operator=(GeneralSettings&&) noexcept;
 
-   SettingsVariable<bool>&                       anti_aliasing_enabled() const;
-   SettingsVariable<std::string>&                clock_format() const;
-   SettingsVariable<bool>&                       debug_enabled() const;
-   SettingsVariable<std::string>&                default_alert_action() const;
-   SettingsVariable<std::string>&                default_radar_site() const;
-   SettingsVariable<std::string>&                default_time_zone() const;
+   SettingsVariable<bool>&        anti_aliasing_enabled() const;
+   SettingsVariable<std::string>& clock_format() const;
+   SettingsVariable<std::string>& custom_style_draw_layer() const;
+   SettingsVariable<std::string>& custom_style_url() const;
+   SettingsVariable<bool>&        debug_enabled() const;
+   SettingsVariable<std::string>& default_alert_action() const;
+   SettingsVariable<std::string>& default_radar_site() const;
+   SettingsVariable<std::string>& default_time_zone() const;
    SettingsContainer<std::vector<std::int64_t>>& font_sizes() const;
    SettingsVariable<std::int64_t>&               grid_height() const;
    SettingsVariable<std::int64_t>&               grid_width() const;

--- a/scwx-qt/source/scwx/qt/settings/settings_variable.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_variable.hpp
@@ -166,6 +166,13 @@ public:
    void SetMaximum(const T& value);
 
    /**
+    * Sets a custom transform function for the settings variable.
+    *
+    * @param transform Transform function
+    */
+   void SetTransform(std::function<T(const T&)> transform);
+
+   /**
     * Sets a custom validator function for the settings variable.
     *
     * @param validator Validator function

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -117,6 +117,8 @@ public:
           &theme_,
           &defaultAlertAction_,
           &clockFormat_,
+          &customStyleDrawLayer_,
+          &customStyleUrl_,
           &defaultTimeZone_,
           &positioningPlugin_,
           &nmeaBaudRate_,
@@ -222,6 +224,8 @@ public:
    settings::SettingsInterface<std::string>  mapTilerApiKey_ {};
    settings::SettingsInterface<std::string>  defaultAlertAction_ {};
    settings::SettingsInterface<std::string>  clockFormat_ {};
+   settings::SettingsInterface<std::string>  customStyleDrawLayer_ {};
+   settings::SettingsInterface<std::string>  customStyleUrl_ {};
    settings::SettingsInterface<std::string>  defaultTimeZone_ {};
    settings::SettingsInterface<std::string>  positioningPlugin_ {};
    settings::SettingsInterface<std::int64_t> nmeaBaudRate_ {};
@@ -565,6 +569,15 @@ void SettingsDialogImpl::SetupGeneralTab()
    mapTilerApiKey_.SetSettingsVariable(generalSettings.maptiler_api_key());
    mapTilerApiKey_.SetEditWidget(self_->ui->mapTilerApiKeyLineEdit);
    mapTilerApiKey_.SetResetButton(self_->ui->resetMapTilerApiKeyButton);
+
+   customStyleUrl_.SetSettingsVariable(generalSettings.custom_style_url());
+   customStyleUrl_.SetEditWidget(self_->ui->customMapUrlLineEdit);
+   customStyleUrl_.SetResetButton(self_->ui->resetCustomMapUrlButton);
+
+   customStyleDrawLayer_.SetSettingsVariable(
+      generalSettings.custom_style_draw_layer());
+   customStyleDrawLayer_.SetEditWidget(self_->ui->customMapLayerLineEdit);
+   customStyleDrawLayer_.SetResetButton(self_->ui->resetCustomMapLayerButton);
 
    defaultAlertAction_.SetSettingsVariable(
       generalSettings.default_alert_action());

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -135,9 +135,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>513</width>
-                <height>566</height>
+                <y>-113</y>
+                <width>511</width>
+                <height>669</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -482,6 +482,48 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="14" column="2">
+                   <widget class="QLineEdit" name="customMapUrlLineEdit"/>
+                  </item>
+                  <item row="15" column="2">
+                   <widget class="QLineEdit" name="customMapLayerLineEdit"/>
+                  </item>
+                  <item row="14" column="0">
+                   <widget class="QLabel" name="label_26">
+                    <property name="text">
+                     <string>Custom Map URL</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_27">
+                    <property name="text">
+                     <string>Custom Map Layer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="4">
+                   <widget class="QToolButton" name="resetCustomMapUrlButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="4">
+                   <widget class="QToolButton" name="resetCustomMapLayerButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>
@@ -568,8 +610,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>63</width>
-                    <height>18</height>
+                    <width>98</width>
+                    <height>28</height>
                    </rect>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_3">


### PR DESCRIPTION
Initial implementation to address #116, allowing custom map styles. The initial implementation has support for a single custom map style.

![image](https://github.com/dpaulat/supercell-wx/assets/2886605/1404dd47-cd3d-4ffa-aa6e-8bacc64b8f0b)

Supports both MapBox and MapTiler.  MapBox should have full support up to Mapbox GL JS API 1.10.0.  Newer SDK targets may work, but newer features may not function.  Newer features would have to be implemented in maplibre-native library.