### PR TITLE
Fix local images on Linux

### DIFF
--- a/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
+++ b/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
@@ -394,7 +394,7 @@ TextureAtlas::Impl::LoadImage(const std::string& imagePath)
    if (url.isLocalFile())
    {
       QString suffix = QFileInfo(qImagePath).suffix().toLower();
-      QString qLocalImagePath = url.toLocalFile();
+      QString qLocalImagePath = url.toString(QUrl::PreferLocalFile);
 
       if (suffix == "svg")
       {

--- a/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
+++ b/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
@@ -390,17 +390,19 @@ TextureAtlas::Impl::LoadImage(const std::string& imagePath)
 
    QUrl url = QUrl::fromUserInput(qImagePath);
 
+
    if (url.isLocalFile())
    {
       QString suffix = QFileInfo(qImagePath).suffix().toLower();
+      QString qLocalImagePath = url.toLocalFile();
 
       if (suffix == "svg")
       {
-         image = ReadSvgFile(qImagePath);
+         image = ReadSvgFile(qLocalImagePath);
       }
       else
       {
-         image = ReadPngFile(qImagePath);
+         image = ReadPngFile(qLocalImagePath);
       }
    }
    else


### PR DESCRIPTION
Fixes #238
Uses `url.toString(QUrl::PreferLocalFile);` to avoid having file names with `file:///` at the start. Has not been tested on Windows to ensure it does not break local files there. 