### PR TITLE
Radar Site Audio Location Method and Radius

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -1466,6 +1466,7 @@ void MainWindowImpl::UpdateRadarSite()
       timelineManager_->SetRadarSite("?");
    }
 
+   alertManager_->SetRadarSite(radarSite);
    placefileManager_->SetRadarSite(radarSite);
 }
 

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
@@ -8,8 +8,6 @@
 #include <scwx/util/logger.hpp>
 #include <scwx/qt/config/radar_site.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
-#include <scwx/qt/settings/unit_settings.hpp>
-#include <scwx/qt/types/unit_types.hpp>
 
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
@@ -140,17 +138,12 @@ void AlertManager::Impl::HandleAlert(const types::TextEventKey& key,
    }
 
    settings::AudioSettings& audioSettings = settings::AudioSettings::Instance();
-   settings::UnitSettings&  unitSettings  = settings::UnitSettings::Instance();
    types::LocationMethod    locationMethod = types::GetLocationMethod(
       audioSettings.alert_location_method().GetValue());
    common::Coordinate currentCoordinate = CurrentCoordinate(locationMethod);
    std::string        alertCounty = audioSettings.alert_county().GetValue();
-
-   types::DistanceUnits radiusUnits =
-      types::GetDistanceUnitsFromName(unitSettings.distance_units().GetValue());
-   double radiusScale = types::GetDistanceUnitsScale(radiusUnits);
-   auto   alertRadius = units::length::kilometers<double>(
-      audioSettings.alert_radius().GetValue() / radiusScale);
+   auto               alertRadius = units::length::kilometers<double>(
+      audioSettings.alert_radius().GetValue());
 
    logger_->debug("alertRadius: {}", (double)alertRadius);
 

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
@@ -8,6 +8,8 @@
 #include <scwx/util/logger.hpp>
 #include <scwx/qt/config/radar_site.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
+#include <scwx/qt/settings/unit_settings.hpp>
+#include <scwx/qt/types/unit_types.hpp>
 
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
@@ -138,12 +140,19 @@ void AlertManager::Impl::HandleAlert(const types::TextEventKey& key,
    }
 
    settings::AudioSettings& audioSettings = settings::AudioSettings::Instance();
+   settings::UnitSettings&  unitSettings  = settings::UnitSettings::Instance();
    types::LocationMethod    locationMethod = types::GetLocationMethod(
       audioSettings.alert_location_method().GetValue());
    common::Coordinate currentCoordinate = CurrentCoordinate(locationMethod);
    std::string        alertCounty = audioSettings.alert_county().GetValue();
-   auto               alertRadius =
-      units::length::meters<double>(audioSettings.alert_radius().GetValue());
+
+   types::DistanceUnits radiusUnits =
+      types::GetDistanceUnitsFromName(unitSettings.distance_units().GetValue());
+   double radiusScale = types::GetDistanceUnitsScale(radiusUnits);
+   auto   alertRadius = units::length::kilometers<double>(
+      audioSettings.alert_radius().GetValue() / radiusScale);
+
+   logger_->debug("alertRadius: {}", (double)alertRadius);
 
    auto message = textEventManager_->message_list(key).at(messageIndex);
 

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
@@ -219,7 +219,8 @@ void AlertManager::Impl::UpdateLocationTracking(
    positionManager_->EnablePositionUpdates(uuid_, locationEnabled);
 }
 
-void AlertManager::SetRadarSite(std::shared_ptr<config::RadarSite> radarSite)
+void AlertManager::SetRadarSite(
+   const std::shared_ptr<config::RadarSite>& radarSite)
 {
    if (p->radarSite_ == radarSite)
    {

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
@@ -85,7 +85,8 @@ common::Coordinate AlertManager::Impl::CurrentCoordinate(
    settings::AudioSettings& audioSettings = settings::AudioSettings::Instance();
    common::Coordinate       coordinate {};
 
-   if (locationMethod == types::LocationMethod::Fixed)
+   if (locationMethod == types::LocationMethod::Fixed ||
+         locationMethod == types::LocationMethod::Radius)
    {
       coordinate.latitude_  = audioSettings.alert_latitude().GetValue();
       coordinate.longitude_ = audioSettings.alert_longitude().GetValue();
@@ -152,6 +153,15 @@ void AlertManager::Impl::HandleAlert(const types::TextEventKey& key,
 
          activeAtLocation = util::GeographicLib::AreaContainsPoint(
             alertCoordinates, currentCoordinate);
+      }
+      else if (locationMethod == types::LocationMethod::Radius)
+      {
+         auto alertCoordinates = segment->codedLocation_->coordinates();
+
+         activeAtLocation = util::GeographicLib::AreaInRangeOfPoint(
+               alertCoordinates,
+               currentCoordinate,
+               units::length::meters<double>(1e6));
       }
       else if (locationMethod == types::LocationMethod::County)
       {

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.cpp
@@ -106,16 +106,23 @@ common::Coordinate AlertManager::Impl::CurrentCoordinate(
    }
    else if (locationMethod == types::LocationMethod::RadarSite)
    {
+      std::string radarSiteSelection =
+         audioSettings.alert_radar_site().GetValue();
       std::shared_ptr<config::RadarSite> radarSite;
-      if (radarSite_ == nullptr)
+      if (radarSiteSelection == "default")
       {
-         std::string siteId =
-            settings::GeneralSettings::Instance().default_radar_site().GetValue();
+         std::string siteId = settings::GeneralSettings::Instance()
+                                 .default_radar_site()
+                                 .GetValue();
          radarSite = config::RadarSite::Get(siteId);
+      }
+      else if (radarSiteSelection == "follow")
+      {
+         radarSite = radarSite_;
       }
       else
       {
-         radarSite = radarSite_;
+         radarSite = config::RadarSite::Get(radarSiteSelection);
       }
 
       if (radarSite != nullptr)
@@ -144,8 +151,6 @@ void AlertManager::Impl::HandleAlert(const types::TextEventKey& key,
    std::string        alertCounty = audioSettings.alert_county().GetValue();
    auto               alertRadius = units::length::kilometers<double>(
       audioSettings.alert_radius().GetValue());
-
-   logger_->debug("alertRadius: {}", (double)alertRadius);
 
    auto message = textEventManager_->message_list(key).at(messageIndex);
 

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <scwx/qt/config/radar_site.hpp>
+
 #include <memory>
 
 #include <QObject>
@@ -20,7 +22,7 @@ public:
    explicit AlertManager();
    ~AlertManager();
 
-   void AlertManager::SetRadarSite(const std::string& radarSite);
+   void SetRadarSite(std::shared_ptr<config::RadarSite> radarSite);
    static std::shared_ptr<AlertManager> Instance();
 
 private:

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
@@ -20,6 +20,7 @@ public:
    explicit AlertManager();
    ~AlertManager();
 
+   void AlertManager::SetRadarSite(const std::string& radarSite);
    static std::shared_ptr<AlertManager> Instance();
 
 private:

--- a/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/alert_manager.hpp
@@ -22,7 +22,7 @@ public:
    explicit AlertManager();
    ~AlertManager();
 
-   void SetRadarSite(std::shared_ptr<config::RadarSite> radarSite);
+   void SetRadarSite(const std::shared_ptr<config::RadarSite>& radarSite);
    static std::shared_ptr<AlertManager> Instance();
 
 private:

--- a/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
@@ -37,12 +37,16 @@ public:
       alertLocationMethod_.SetDefault(defaultAlertLocationMethodValue);
       alertLatitude_.SetDefault(0.0);
       alertLongitude_.SetDefault(0.0);
+      alertRadius_.SetDefault(0.0);
       ignoreMissingCodecs_.SetDefault(false);
 
       alertLatitude_.SetMinimum(-90.0);
       alertLatitude_.SetMaximum(90.0);
       alertLongitude_.SetMinimum(-180.0);
       alertLongitude_.SetMaximum(180.0);
+      alertRadius_.SetMinimum(0.0);
+      alertRadius_.SetMaximum(9999999999);
+
 
       alertLocationMethod_.SetValidator(
          SCWX_SETTINGS_ENUM_VALIDATOR(types::LocationMethod,
@@ -86,6 +90,7 @@ public:
    SettingsVariable<std::string> alertLocationMethod_ {"alert_location_method"};
    SettingsVariable<double>      alertLatitude_ {"alert_latitude"};
    SettingsVariable<double>      alertLongitude_ {"alert_longitude"};
+   SettingsVariable<double>      alertRadius_ {"alert_radius"};
    SettingsVariable<std::string> alertCounty_ {"alert_county"};
    SettingsVariable<bool>        ignoreMissingCodecs_ {"ignore_missing_codecs"};
 
@@ -101,6 +106,7 @@ AudioSettings::AudioSettings() :
                       &p->alertLocationMethod_,
                       &p->alertLatitude_,
                       &p->alertLongitude_,
+                      &p->alertRadius_,
                       &p->alertCounty_,
                       &p->ignoreMissingCodecs_});
    RegisterVariables(p->variables_);
@@ -131,6 +137,11 @@ SettingsVariable<double>& AudioSettings::alert_latitude() const
 SettingsVariable<double>& AudioSettings::alert_longitude() const
 {
    return p->alertLongitude_;
+}
+
+SettingsVariable<double>& AudioSettings::alert_radius() const
+{
+   return p->alertRadius_;
 }
 
 SettingsVariable<std::string>& AudioSettings::alert_county() const
@@ -166,6 +177,7 @@ bool operator==(const AudioSettings& lhs, const AudioSettings& rhs)
            lhs.p->alertLocationMethod_ == rhs.p->alertLocationMethod_ &&
            lhs.p->alertLatitude_ == rhs.p->alertLatitude_ &&
            lhs.p->alertLongitude_ == rhs.p->alertLongitude_ &&
+           lhs.p->alertRadius_ == rhs.p->alertRadius_ &&
            lhs.p->alertCounty_ == rhs.p->alertCounty_ &&
            lhs.p->alertEnabled_ == rhs.p->alertEnabled_);
 }

--- a/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
@@ -185,6 +185,7 @@ bool operator==(const AudioSettings& lhs, const AudioSettings& rhs)
            lhs.p->alertLocationMethod_ == rhs.p->alertLocationMethod_ &&
            lhs.p->alertLatitude_ == rhs.p->alertLatitude_ &&
            lhs.p->alertLongitude_ == rhs.p->alertLongitude_ &&
+           lhs.p->alertRadarSite_ == rhs.p->alertRadarSite_ &&
            lhs.p->alertRadius_ == rhs.p->alertRadius_ &&
            lhs.p->alertCounty_ == rhs.p->alertCounty_ &&
            lhs.p->alertEnabled_ == rhs.p->alertEnabled_);

--- a/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/audio_settings.cpp
@@ -38,6 +38,7 @@ public:
       alertLatitude_.SetDefault(0.0);
       alertLongitude_.SetDefault(0.0);
       alertRadius_.SetDefault(0.0);
+      alertRadarSite_.SetDefault("default");
       ignoreMissingCodecs_.SetDefault(false);
 
       alertLatitude_.SetMinimum(-90.0);
@@ -90,6 +91,7 @@ public:
    SettingsVariable<std::string> alertLocationMethod_ {"alert_location_method"};
    SettingsVariable<double>      alertLatitude_ {"alert_latitude"};
    SettingsVariable<double>      alertLongitude_ {"alert_longitude"};
+   SettingsVariable<std::string> alertRadarSite_ {"alert_radar_site"};
    SettingsVariable<double>      alertRadius_ {"alert_radius"};
    SettingsVariable<std::string> alertCounty_ {"alert_county"};
    SettingsVariable<bool>        ignoreMissingCodecs_ {"ignore_missing_codecs"};
@@ -106,6 +108,7 @@ AudioSettings::AudioSettings() :
                       &p->alertLocationMethod_,
                       &p->alertLatitude_,
                       &p->alertLongitude_,
+                      &p->alertRadarSite_,
                       &p->alertRadius_,
                       &p->alertCounty_,
                       &p->ignoreMissingCodecs_});
@@ -137,6 +140,11 @@ SettingsVariable<double>& AudioSettings::alert_latitude() const
 SettingsVariable<double>& AudioSettings::alert_longitude() const
 {
    return p->alertLongitude_;
+}
+
+SettingsVariable<std::string>& AudioSettings::alert_radar_site() const
+{
+   return p->alertRadarSite_;
 }
 
 SettingsVariable<double>& AudioSettings::alert_radius() const

--- a/scwx-qt/source/scwx/qt/settings/audio_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/audio_settings.hpp
@@ -30,6 +30,7 @@ public:
    SettingsVariable<std::string>& alert_location_method() const;
    SettingsVariable<double>&      alert_latitude() const;
    SettingsVariable<double>&      alert_longitude() const;
+   SettingsVariable<double>&      alert_radius() const;
    SettingsVariable<std::string>& alert_county() const;
    SettingsVariable<bool>& alert_enabled(awips::Phenomenon phenomenon) const;
    SettingsVariable<bool>& ignore_missing_codecs() const;

--- a/scwx-qt/source/scwx/qt/settings/audio_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/audio_settings.hpp
@@ -31,6 +31,7 @@ public:
    SettingsVariable<double>&      alert_latitude() const;
    SettingsVariable<double>&      alert_longitude() const;
    SettingsVariable<double>&      alert_radius() const;
+   SettingsVariable<std::string>& alert_radar_site() const;
    SettingsVariable<std::string>& alert_county() const;
    SettingsVariable<bool>& alert_enabled(awips::Phenomenon phenomenon) const;
    SettingsVariable<bool>& ignore_missing_codecs() const;

--- a/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
@@ -56,7 +56,7 @@ public:
    std::function<T(const std::string&)> mapToValue_ {nullptr};
 
    double unitScale_ {1};
-   const std::string * unitAbbreiation_ {nullptr};
+   const std::string * unitAbbreviation_ {nullptr};
    bool unitEnabled_ {false};
 };
 
@@ -484,7 +484,7 @@ void SettingsInterface<T>::SetUnit(const double&      scale,
                                    const std::string& abbreviation)
 {
    p->unitScale_       = scale;
-   p->unitAbbreiation_ = &abbreviation;
+   p->unitAbbreviation_ = &abbreviation;
    p->unitEnabled_     = true;
    p->UpdateEditWidget();
    p->UpdateUnitLabel();
@@ -604,7 +604,7 @@ void SettingsInterface<T>::Impl::UpdateUnitLabel()
       return;
    }
 
-   unitLabel_->setText(QString::fromStdString(*unitAbbreiation_));
+   unitLabel_->setText(QString::fromStdString(*unitAbbreviation_));
 }
 
 template<class T>

--- a/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
@@ -55,9 +55,9 @@ public:
    std::function<std::string(const T&)> mapFromValue_ {nullptr};
    std::function<T(const std::string&)> mapToValue_ {nullptr};
 
-   double unitScale_ {1};
-   const std::string * unitAbbreviation_ {nullptr};
-   bool unitEnabled_ {false};
+   double                     unitScale_ {1};
+   std::optional<std::string> unitAbbreviation_ {};
+   bool                       unitEnabled_ {false};
 };
 
 template<class T>
@@ -483,9 +483,9 @@ template<class T>
 void SettingsInterface<T>::SetUnit(const double&      scale,
                                    const std::string& abbreviation)
 {
-   p->unitScale_       = scale;
-   p->unitAbbreviation_ = &abbreviation;
-   p->unitEnabled_     = true;
+   p->unitScale_        = scale;
+   p->unitAbbreviation_ = abbreviation;
+   p->unitEnabled_      = true;
    p->UpdateEditWidget();
    p->UpdateUnitLabel();
 }
@@ -604,7 +604,7 @@ void SettingsInterface<T>::Impl::UpdateUnitLabel()
       return;
    }
 
-   unitLabel_->setText(QString::fromStdString(*unitAbbreviation_));
+   unitLabel_->setText(QString::fromStdString(unitAbbreviation_.value_or("")));
 }
 
 template<class T>

--- a/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+class QLabel;
+
 namespace scwx
 {
 namespace qt
@@ -92,6 +94,13 @@ public:
    void SetResetButton(QAbstractButton* button) override;
 
    /**
+    * Sets the label for units from the settings dialog.
+    *
+    * @param label Unit label
+    */
+   void SetUnitLabel(QLabel* label);
+
+   /**
     * If the edit widget displays a different value than what is stored in the
     * settings variable, a mapping function must be provided in order to convert
     * the value used by the edit widget from the settings value.
@@ -108,6 +117,14 @@ public:
     * @param function Map to settings value function
     */
    void SetMapToValueFunction(std::function<T(const std::string&)> function);
+
+   /**
+    * Sets the unit to be used by this setting.
+    *
+    * @param scale The radio of the current unit to the base unit
+    * @param abbreviation The abreviation to be displayed
+    */
+   void SetUnit(const double& scale, const std::string& abbreviation);
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -69,7 +69,7 @@ public:
    SettingsVariable<std::string> echoTopsUnits_ {"echo_tops_units"};
    SettingsVariable<std::string> otherUnits_ {"other_units"};
    SettingsVariable<std::string> speedUnits_ {"speed_units"};
-   SettingsVariable<std::string> distanceUnits_ {"speed_units"};
+   SettingsVariable<std::string> distanceUnits_ {"distance_units"};
 };
 
 UnitSettings::UnitSettings() :

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -27,7 +27,7 @@ public:
       std::string defaultSpeedUnitsValue =
          types::GetSpeedUnitsName(types::SpeedUnits::Knots);
       std::string defaultDistanceUnitsValue =
-         types::GetDistanceUnitsName(types::DistanceUnits::Kilometers);
+         types::GetDistanceUnitsName(types::DistanceUnits::Miles);
 
       boost::to_lower(defaultAccumulationUnitsValue);
       boost::to_lower(defaultEchoTopsUnitsValue);

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -26,16 +26,20 @@ public:
          types::GetOtherUnitsName(types::OtherUnits::Default);
       std::string defaultSpeedUnitsValue =
          types::GetSpeedUnitsName(types::SpeedUnits::Knots);
+      std::string defaultDistanceUnitsValue =
+         types::GetDistanceUnitsName(types::DistanceUnits::Kilometers);
 
       boost::to_lower(defaultAccumulationUnitsValue);
       boost::to_lower(defaultEchoTopsUnitsValue);
       boost::to_lower(defaultOtherUnitsValue);
       boost::to_lower(defaultSpeedUnitsValue);
+      boost::to_lower(defaultDistanceUnitsValue);
 
       accumulationUnits_.SetDefault(defaultAccumulationUnitsValue);
       echoTopsUnits_.SetDefault(defaultEchoTopsUnitsValue);
       otherUnits_.SetDefault(defaultOtherUnitsValue);
       speedUnits_.SetDefault(defaultSpeedUnitsValue);
+      distanceUnits_.SetDefault(defaultDistanceUnitsValue);
 
       accumulationUnits_.SetValidator(
          SCWX_SETTINGS_ENUM_VALIDATOR(types::AccumulationUnits,
@@ -53,6 +57,10 @@ public:
          SCWX_SETTINGS_ENUM_VALIDATOR(types::SpeedUnits,
                                       types::SpeedUnitsIterator(),
                                       types::GetSpeedUnitsName));
+      distanceUnits_.SetValidator(
+         SCWX_SETTINGS_ENUM_VALIDATOR(types::DistanceUnits,
+                                      types::DistanceUnitsIterator(),
+                                      types::GetDistanceUnitsName));
    }
 
    ~Impl() {}
@@ -61,6 +69,7 @@ public:
    SettingsVariable<std::string> echoTopsUnits_ {"echo_tops_units"};
    SettingsVariable<std::string> otherUnits_ {"other_units"};
    SettingsVariable<std::string> speedUnits_ {"speed_units"};
+   SettingsVariable<std::string> distanceUnits_ {"speed_units"};
 };
 
 UnitSettings::UnitSettings() :
@@ -69,7 +78,8 @@ UnitSettings::UnitSettings() :
    RegisterVariables({&p->accumulationUnits_,
                       &p->echoTopsUnits_,
                       &p->otherUnits_,
-                      &p->speedUnits_});
+                      &p->speedUnits_,
+                      &p->distanceUnits_});
    SetDefaults();
 }
 UnitSettings::~UnitSettings() = default;
@@ -97,6 +107,11 @@ SettingsVariable<std::string>& UnitSettings::speed_units() const
    return p->speedUnits_;
 }
 
+SettingsVariable<std::string>& UnitSettings::distance_units() const
+{
+   return p->distanceUnits_;
+}
+
 UnitSettings& UnitSettings::Instance()
 {
    static UnitSettings generalSettings_;
@@ -108,7 +123,8 @@ bool operator==(const UnitSettings& lhs, const UnitSettings& rhs)
    return (lhs.p->accumulationUnits_ == rhs.p->accumulationUnits_ &&
            lhs.p->echoTopsUnits_ == rhs.p->echoTopsUnits_ &&
            lhs.p->otherUnits_ == rhs.p->otherUnits_ &&
-           lhs.p->speedUnits_ == rhs.p->speedUnits_);
+           lhs.p->speedUnits_ == rhs.p->speedUnits_ &&
+           lhs.p->distanceUnits_ == rhs.p->distanceUnits_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.hpp
@@ -29,6 +29,7 @@ public:
    SettingsVariable<std::string>& echo_tops_units() const;
    SettingsVariable<std::string>& other_units() const;
    SettingsVariable<std::string>& speed_units() const;
+   SettingsVariable<std::string>& distance_units() const;
 
    static UnitSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/types/location_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/location_types.cpp
@@ -15,7 +15,7 @@ namespace types
 static const std::unordered_map<LocationMethod, std::string>
    locationMethodName_ {{LocationMethod::Fixed, "Fixed"},
                         {LocationMethod::Track, "Track"},
-                        {LocationMethod::RadarSite, "RadarSite"},
+                        {LocationMethod::RadarSite, "Radar Site"},
                         {LocationMethod::County, "County"},
                         {LocationMethod::All, "All"},
                         {LocationMethod::Unknown, "?"}};

--- a/scwx-qt/source/scwx/qt/types/location_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/location_types.cpp
@@ -14,6 +14,7 @@ namespace types
 
 static const std::unordered_map<LocationMethod, std::string>
    locationMethodName_ {{LocationMethod::Fixed, "Fixed"},
+                        {LocationMethod::Radius, "Radius"},
                         {LocationMethod::Track, "Track"},
                         {LocationMethod::County, "County"},
                         {LocationMethod::All, "All"},

--- a/scwx-qt/source/scwx/qt/types/location_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/location_types.cpp
@@ -14,8 +14,8 @@ namespace types
 
 static const std::unordered_map<LocationMethod, std::string>
    locationMethodName_ {{LocationMethod::Fixed, "Fixed"},
-                        {LocationMethod::Radius, "Radius"},
                         {LocationMethod::Track, "Track"},
+                        {LocationMethod::RadarSite, "RadarSite"},
                         {LocationMethod::County, "County"},
                         {LocationMethod::All, "All"},
                         {LocationMethod::Unknown, "?"}};

--- a/scwx-qt/source/scwx/qt/types/location_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/location_types.hpp
@@ -14,8 +14,8 @@ namespace types
 enum class LocationMethod
 {
    Fixed,
-   Radius,
    Track,
+   RadarSite,
    County,
    All,
    Unknown

--- a/scwx-qt/source/scwx/qt/types/location_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/location_types.hpp
@@ -14,6 +14,7 @@ namespace types
 enum class LocationMethod
 {
    Fixed,
+   Radius,
    Track,
    County,
    All,

--- a/scwx-qt/source/scwx/qt/types/unit_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.cpp
@@ -101,12 +101,12 @@ static const std::unordered_map<DistanceUnits, std::string> distanceUnitsName_ {
    {DistanceUnits::User, "User-defined"},
    {DistanceUnits::Unknown, "?"}};
 
-static constexpr auto distanceUnitsBase_ = units::kilometers<float> {1.0f};
-static const std::unordered_map<DistanceUnits, float> distanceUnitsScale_ {
+static constexpr auto distanceUnitsBase_ = units::kilometers<double> {1.0f};
+static const std::unordered_map<DistanceUnits, double> distanceUnitsScale_ {
    {DistanceUnits::Kilometers,
-    (distanceUnitsBase_ / units::kilometers<float> {1.0f})},
+    (distanceUnitsBase_ / units::kilometers<double> {1.0f})},
    {DistanceUnits::Miles,
-    (distanceUnitsBase_ / units::miles<float> {1.0f})},
+    (distanceUnitsBase_ / units::miles<double> {1.0f})},
    {DistanceUnits::User, 1.0f},
    {DistanceUnits::Unknown, 1.0f}};
 
@@ -179,7 +179,7 @@ const std::string& GetDistanceUnitsName(DistanceUnits units)
    return distanceUnitsName_.at(units);
 }
 
-float GetDistanceUnitsScale(DistanceUnits units)
+double GetDistanceUnitsScale(DistanceUnits units)
 {
    return distanceUnitsScale_.at(units);
 }

--- a/scwx-qt/source/scwx/qt/types/unit_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.cpp
@@ -89,12 +89,35 @@ static const std::unordered_map<SpeedUnits, float> speedUnitsScale_ {
    {SpeedUnits::User, 1.0f},
    {SpeedUnits::Unknown, 1.0f}};
 
+static const std::unordered_map<DistanceUnits, std::string>
+   distanceUnitsAbbreviation_ {{DistanceUnits::Kilometers, "km"},
+                               {DistanceUnits::Miles, "mi"},
+                               {DistanceUnits::User, ""},
+                               {DistanceUnits::Unknown, ""}};
+
+static const std::unordered_map<DistanceUnits, std::string> distanceUnitsName_ {
+   {DistanceUnits::Kilometers, "Kilometers"},
+   {DistanceUnits::Miles, "Miles"},
+   {DistanceUnits::User, "User-defined"},
+   {DistanceUnits::Unknown, "?"}};
+
+static constexpr auto distanceUnitsBase_ = units::kilometers<float> {1.0f};
+static const std::unordered_map<DistanceUnits, float> distanceUnitsScale_ {
+   {DistanceUnits::Kilometers,
+    (distanceUnitsBase_ / units::kilometers<float> {1.0f})},
+   {DistanceUnits::Miles,
+    (distanceUnitsBase_ / units::miles<float> {1.0f})},
+   {DistanceUnits::User, 1.0f},
+   {DistanceUnits::Unknown, 1.0f}};
+
+
 SCWX_GET_ENUM(AccumulationUnits,
               GetAccumulationUnitsFromName,
               accumulationUnitsName_)
 SCWX_GET_ENUM(EchoTopsUnits, GetEchoTopsUnitsFromName, echoTopsUnitsName_)
 SCWX_GET_ENUM(OtherUnits, GetOtherUnitsFromName, otherUnitsName_)
 SCWX_GET_ENUM(SpeedUnits, GetSpeedUnitsFromName, speedUnitsName_)
+SCWX_GET_ENUM(DistanceUnits, GetDistanceUnitsFromName, distanceUnitsName_)
 
 const std::string& GetAccumulationUnitsAbbreviation(AccumulationUnits units)
 {
@@ -144,6 +167,21 @@ const std::string& GetSpeedUnitsName(SpeedUnits units)
 float GetSpeedUnitsScale(SpeedUnits units)
 {
    return speedUnitsScale_.at(units);
+}
+
+const std::string& GetDistanceUnitsAbbreviation(DistanceUnits units)
+{
+   return distanceUnitsAbbreviation_.at(units);
+}
+
+const std::string& GetDistanceUnitsName(DistanceUnits units)
+{
+   return distanceUnitsName_.at(units);
+}
+
+float GetDistanceUnitsScale(DistanceUnits units)
+{
+   return distanceUnitsScale_.at(units);
 }
 
 } // namespace types

--- a/scwx-qt/source/scwx/qt/types/unit_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.hpp
@@ -88,7 +88,7 @@ float              GetSpeedUnitsScale(SpeedUnits units);
 const std::string& GetDistanceUnitsAbbreviation(DistanceUnits units);
 const std::string& GetDistanceUnitsName(DistanceUnits units);
 DistanceUnits      GetDistanceUnitsFromName(const std::string& name);
-float              GetDistanceUnitsScale(DistanceUnits units);
+double             GetDistanceUnitsScale(DistanceUnits units);
 
 } // namespace types
 } // namespace qt

--- a/scwx-qt/source/scwx/qt/types/unit_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.hpp
@@ -56,6 +56,17 @@ typedef scwx::util::
    Iterator<SpeedUnits, SpeedUnits::KilometersPerHour, SpeedUnits::User>
       SpeedUnitsIterator;
 
+enum class DistanceUnits
+{
+   Kilometers,
+   Miles,
+   User,
+   Unknown
+};
+typedef scwx::util::
+   Iterator<DistanceUnits, DistanceUnits::Kilometers, DistanceUnits::User>
+      DistanceUnitsIterator;
+
 const std::string& GetAccumulationUnitsAbbreviation(AccumulationUnits units);
 const std::string& GetAccumulationUnitsName(AccumulationUnits units);
 AccumulationUnits  GetAccumulationUnitsFromName(const std::string& name);
@@ -73,6 +84,11 @@ const std::string& GetSpeedUnitsAbbreviation(SpeedUnits units);
 const std::string& GetSpeedUnitsName(SpeedUnits units);
 SpeedUnits         GetSpeedUnitsFromName(const std::string& name);
 float              GetSpeedUnitsScale(SpeedUnits units);
+
+const std::string& GetDistanceUnitsAbbreviation(DistanceUnits units);
+const std::string& GetDistanceUnitsName(DistanceUnits units);
+DistanceUnits      GetDistanceUnitsFromName(const std::string& name);
+float              GetDistanceUnitsScale(DistanceUnits units);
 
 } // namespace types
 } // namespace qt

--- a/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
@@ -102,6 +102,16 @@ public:
                               types::GetSpeedUnitsName);
       AddRow(speedUnits_, "Speed", speedComboBox);
 
+      QComboBox* distanceComboBox = new QComboBox(self);
+      distanceComboBox->setSizePolicy(QSizePolicy::Expanding,
+                                   QSizePolicy::Preferred);
+      distanceUnits_.SetSettingsVariable(unitSettings.distance_units());
+      SCWX_SETTINGS_COMBO_BOX(distanceUnits_,
+                              distanceComboBox,
+                              types::DistanceUnitsIterator(),
+                              types::GetDistanceUnitsName);
+      AddRow(distanceUnits_, "Distance", distanceComboBox);
+
       QComboBox* otherComboBox = new QComboBox(self);
       otherComboBox->setSizePolicy(QSizePolicy::Expanding,
                                    QSizePolicy::Preferred);
@@ -127,6 +137,7 @@ public:
    settings::SettingsInterface<std::string> echoTopsUnits_ {};
    settings::SettingsInterface<std::string> otherUnits_ {};
    settings::SettingsInterface<std::string> speedUnits_ {};
+   settings::SettingsInterface<std::string> distanceUnits_ {};
 };
 
 UnitSettingsWidget::UnitSettingsWidget(QWidget* parent) :

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -507,7 +507,6 @@ void SettingsDialogImpl::ConnectSignals()
             break;
 
          case QDialogButtonBox::ButtonRole::ResetRole: // Restore Defaults
-            logger_->info("ButtonRole Reset");
             ResetToDefault();
             break;
 

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -134,6 +134,7 @@ public:
           &alertAudioLocationMethod_,
           &alertAudioLatitude_,
           &alertAudioLongitude_,
+          &alertAudioRadius_,
           &alertAudioCounty_,
           &hoverTextWrap_,
           &tooltipMethod_,
@@ -252,6 +253,7 @@ public:
    settings::SettingsInterface<std::string> alertAudioLocationMethod_ {};
    settings::SettingsInterface<double>      alertAudioLatitude_ {};
    settings::SettingsInterface<double>      alertAudioLongitude_ {};
+   settings::SettingsInterface<double>      alertAudioRadius_ {};
    settings::SettingsInterface<std::string> alertAudioCounty_ {};
 
    std::unordered_map<awips::Phenomenon, settings::SettingsInterface<bool>>
@@ -474,6 +476,7 @@ void SettingsDialogImpl::ConnectSignals()
             break;
 
          case QDialogButtonBox::ButtonRole::ResetRole: // Restore Defaults
+            logger_->info("ButtonRole Reset");
             ResetToDefault();
             break;
 
@@ -900,6 +903,10 @@ void SettingsDialogImpl::SetupAudioTab()
 
          bool coordinateEntryEnabled =
             locationMethod == types::LocationMethod::Fixed;
+         bool radiusEntryEnable =
+            locationMethod == types::LocationMethod::Fixed ||
+            locationMethod == types::LocationMethod::Track ||
+            locationMethod == types::LocationMethod::RadarSite;
          bool countyEntryEnabled =
             locationMethod == types::LocationMethod::County;
 
@@ -911,6 +918,11 @@ void SettingsDialogImpl::SetupAudioTab()
             coordinateEntryEnabled);
          self_->ui->resetAlertAudioLongitudeButton->setEnabled(
             coordinateEntryEnabled);
+
+         self_->ui->alertAudioRadiusSpinBox->setEnabled(
+            radiusEntryEnable);
+         self_->ui->resetAlertAudioRadiusButton->setEnabled(
+            radiusEntryEnable);
 
          self_->ui->alertAudioCountyLineEdit->setEnabled(countyEntryEnabled);
          self_->ui->alertAudioCountySelectButton->setEnabled(
@@ -982,6 +994,11 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioLongitude_.SetEditWidget(self_->ui->alertAudioLongitudeSpinBox);
    alertAudioLongitude_.SetResetButton(
       self_->ui->resetAlertAudioLongitudeButton);
+
+   alertAudioRadius_.SetSettingsVariable(audioSettings.alert_radius());
+   alertAudioRadius_.SetEditWidget(self_->ui->alertAudioRadiusSpinBox);
+   alertAudioRadius_.SetResetButton(
+      self_->ui->resetAlertAudioRadiusButton);
 
    auto& alertAudioPhenomena = types::GetAlertAudioPhenomena();
    auto  alertAudioLayout =

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -14,12 +14,14 @@
 #include <scwx/qt/settings/palette_settings.hpp>
 #include <scwx/qt/settings/settings_interface.hpp>
 #include <scwx/qt/settings/text_settings.hpp>
+#include <scwx/qt/settings/unit_settings.hpp>
 #include <scwx/qt/types/alert_types.hpp>
 #include <scwx/qt/types/font_types.hpp>
 #include <scwx/qt/types/location_types.hpp>
 #include <scwx/qt/types/qt_types.hpp>
 #include <scwx/qt/types/text_types.hpp>
 #include <scwx/qt/types/time_types.hpp>
+#include <scwx/qt/types/unit_types.hpp>
 #include <scwx/qt/ui/county_dialog.hpp>
 #include <scwx/qt/ui/radar_site_dialog.hpp>
 #include <scwx/qt/ui/serial_port_dialog.hpp>
@@ -999,6 +1001,23 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioRadius_.SetEditWidget(self_->ui->alertAudioRadiusSpinBox);
    alertAudioRadius_.SetResetButton(
       self_->ui->resetAlertAudioRadiusButton);
+   alertAudioRadius_.SetUnitLabel(self_->ui->alertAudioRadiusUnitsLabel);
+
+   auto alertAudioRadiusUpdateUnits = [this](const std::string& newValue)
+   {
+      types::DistanceUnits radiusUnits =
+         types::GetDistanceUnitsFromName(newValue);
+      double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
+      std::string abbreviation =
+         types::GetDistanceUnitsAbbreviation(radiusUnits);
+
+      alertAudioRadius_.SetUnit(radiusScale, abbreviation);
+   };
+   settings::UnitSettings::Instance()
+      .distance_units()
+      .RegisterValueStagedCallback(alertAudioRadiusUpdateUnits);
+   alertAudioRadiusUpdateUnits(
+      settings::UnitSettings::Instance().distance_units().GetValue());
 
    auto& alertAudioPhenomena = types::GetAlertAudioPhenomena();
    auto  alertAudioLayout =

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -136,7 +136,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>270</width>
+                <width>511</width>
                 <height>647</height>
                </rect>
               </property>
@@ -610,7 +610,7 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>80</width>
+                    <width>66</width>
                     <height>18</height>
                    </rect>
                   </property>
@@ -691,15 +691,32 @@
               <string>Alerts</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_10">
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_14">
+              <item row="3" column="6">
+               <widget class="QToolButton" name="resetAlertAudioLongitudeButton">
                 <property name="text">
-                 <string>Latitude</string>
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1" colspan="2">
-               <widget class="QLineEdit" name="alertAudioSoundLineEdit"/>
+              <item row="5" column="1" colspan="2">
+               <widget class="QDoubleSpinBox" name="alertAudioRadiusSpinBox">
+                <property name="decimals">
+                 <number>2</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>9999999999999.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
               </item>
               <item row="2" column="6">
                <widget class="QToolButton" name="resetAlertAudioLatitudeButton">
@@ -712,11 +729,38 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="5">
-               <widget class="QToolButton" name="alertAudioSoundStopButton">
+              <item row="1" column="1" colspan="2">
+               <widget class="QComboBox" name="alertAudioLocationMethodComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0">
+               <widget class="QLabel" name="label_19">
+                <property name="text">
+                 <string>County</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QToolButton" name="resetAlertAudioSoundButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
                 <property name="icon">
                  <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/stop-solid.svg</normaloff>:/res/icons/font-awesome-6/stop-solid.svg</iconset>
+                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="3">
+               <widget class="QLabel" name="alertAudioRadiusUnitsLabel">
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -736,24 +780,6 @@
                 </property>
                </widget>
               </item>
-              <item row="5" column="3">
-               <widget class="QToolButton" name="alertAudioCountySelectButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QToolButton" name="resetAlertAudioSoundButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="6">
                <widget class="QToolButton" name="resetAlertAudioLocationMethodButton">
                 <property name="text">
@@ -765,13 +791,22 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="4">
-               <widget class="QToolButton" name="alertAudioSoundTestButton">
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/play-solid.svg</normaloff>:/res/icons/font-awesome-6/play-solid.svg</iconset>
+              <item row="0" column="3">
+               <widget class="QToolButton" name="alertAudioSoundSelectButton">
+                <property name="text">
+                 <string>...</string>
                 </property>
                </widget>
+              </item>
+              <item row="7" column="3">
+               <widget class="QToolButton" name="alertAudioCountySelectButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="2">
+               <widget class="QLineEdit" name="alertAudioSoundLineEdit"/>
               </item>
               <item row="2" column="1" colspan="2">
                <widget class="QDoubleSpinBox" name="alertAudioLatitudeSpinBox">
@@ -789,45 +824,29 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_16">
-                <property name="text">
-                 <string>Longitude</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="label_19">
-                <property name="text">
-                 <string>County</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QToolButton" name="alertAudioSoundSelectButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="2">
-               <widget class="QComboBox" name="alertAudioLocationMethodComboBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+              <item row="0" column="5">
+               <widget class="QToolButton" name="alertAudioSoundStopButton">
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/stop-solid.svg</normaloff>:/res/icons/font-awesome-6/stop-solid.svg</iconset>
                 </property>
                </widget>
               </item>
               <item row="5" column="6">
-               <widget class="QToolButton" name="resetAlertAudioCountyButton">
+               <widget class="QToolButton" name="resetAlertAudioRadiusButton">
                 <property name="text">
                  <string>...</string>
                 </property>
                 <property name="icon">
                  <iconset resource="../../../../scwx-qt.qrc">
                   <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Latitude</string>
                 </property>
                </widget>
               </item>
@@ -838,7 +857,7 @@
                 </property>
                </widget>
               </item>
-              <item row="5" column="2">
+              <item row="7" column="2">
                <widget class="QLabel" name="alertAudioCountyLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -851,7 +870,15 @@
                 </property>
                </widget>
               </item>
-              <item row="5" column="1">
+              <item row="0" column="4">
+               <widget class="QToolButton" name="alertAudioSoundTestButton">
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/play-solid.svg</normaloff>:/res/icons/font-awesome-6/play-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="1">
                <widget class="QLineEdit" name="alertAudioCountyLineEdit">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -871,8 +898,8 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="6">
-               <widget class="QToolButton" name="resetAlertAudioLongitudeButton">
+              <item row="7" column="6">
+               <widget class="QToolButton" name="resetAlertAudioCountyButton">
                 <property name="text">
                  <string>...</string>
                 </property>
@@ -882,31 +909,36 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
+              <item row="5" column="0">
                <widget class="QLabel" name="alertAudioRadiusLabel">
                 <property name="text">
                  <string>Radius</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1" colspan="2">
-               <widget class="QDoubleSpinBox" name="alertAudioRadiusSpinBox">
-                <property name="decimals">
-                 <number>2</number>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_16">
+                <property name="text">
+                 <string>Longitude</string>
                 </property>
-                <property name="minimum">
-                 <double>0.000000000000000</double>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_28">
+                <property name="text">
+                 <string>Radar Site</string>
                 </property>
-                <property name="maximum">
-                 <double>9999999999999.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
+               </widget>
+              </item>
+              <item row="4" column="3">
+               <widget class="QToolButton" name="alertAudioRadarSiteSelectButton">
+                <property name="text">
+                 <string>...</string>
                 </property>
                </widget>
               </item>
               <item row="4" column="6">
-               <widget class="QToolButton" name="resetAlertAudioRadiusButton">
+               <widget class="QToolButton" name="resetAlertAudioRadarSiteButton">
                 <property name="text">
                  <string>...</string>
                 </property>
@@ -916,12 +948,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="3">
-               <widget class="QLabel" name="alertAudioRadiusUnitsLabel">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
+              <item row="4" column="1" colspan="2">
+               <widget class="QComboBox" name="alertAudioRadarSiteComboBox"/>
               </item>
              </layout>
             </widget>

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -122,7 +122,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -135,9 +135,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-113</y>
-                <width>511</width>
-                <height>669</height>
+                <y>0</y>
+                <width>270</width>
+                <height>647</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -610,8 +610,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>98</width>
-                    <height>28</height>
+                    <width>80</width>
+                    <height>18</height>
                    </rect>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_3">
@@ -883,7 +883,7 @@
                </widget>
               </item>
               <item row="4" column="0">
-               <widget class="QLabel" name="label_28">
+               <widget class="QLabel" name="alertAudioRadiusLabel">
                 <property name="text">
                  <string>Radius</string>
                 </property>
@@ -892,7 +892,7 @@
               <item row="4" column="1" colspan="2">
                <widget class="QDoubleSpinBox" name="alertAudioRadiusSpinBox">
                 <property name="decimals">
-                 <number>4</number>
+                 <number>2</number>
                 </property>
                 <property name="minimum">
                  <double>0.000000000000000</double>
@@ -913,6 +913,13 @@
                 <property name="icon">
                  <iconset resource="../../../../scwx-qt.qrc">
                   <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="3">
+               <widget class="QLabel" name="alertAudioRadiusUnitsLabel">
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -698,6 +698,62 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="1" colspan="2">
+               <widget class="QLineEdit" name="alertAudioSoundLineEdit"/>
+              </item>
+              <item row="2" column="6">
+               <widget class="QToolButton" name="resetAlertAudioLatitudeButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QToolButton" name="alertAudioSoundStopButton">
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/stop-solid.svg</normaloff>:/res/icons/font-awesome-6/stop-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1" colspan="2">
+               <widget class="QDoubleSpinBox" name="alertAudioLongitudeSpinBox">
+                <property name="decimals">
+                 <number>4</number>
+                </property>
+                <property name="minimum">
+                 <double>-180.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.000100000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="3">
+               <widget class="QToolButton" name="alertAudioCountySelectButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QToolButton" name="resetAlertAudioSoundButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="6">
                <widget class="QToolButton" name="resetAlertAudioLocationMethodButton">
                 <property name="text">
@@ -709,6 +765,30 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="4">
+               <widget class="QToolButton" name="alertAudioSoundTestButton">
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/play-solid.svg</normaloff>:/res/icons/font-awesome-6/play-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1" colspan="2">
+               <widget class="QDoubleSpinBox" name="alertAudioLatitudeSpinBox">
+                <property name="decimals">
+                 <number>4</number>
+                </property>
+                <property name="minimum">
+                 <double>-90.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>90.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.000100000000000</double>
+                </property>
+               </widget>
+              </item>
               <item row="3" column="0">
                <widget class="QLabel" name="label_16">
                 <property name="text">
@@ -716,10 +796,71 @@
                 </property>
                </widget>
               </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="label_19">
+                <property name="text">
+                 <string>County</string>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="3">
                <widget class="QToolButton" name="alertAudioSoundSelectButton">
                 <property name="text">
                  <string>...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1" colspan="2">
+               <widget class="QComboBox" name="alertAudioLocationMethodComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="6">
+               <widget class="QToolButton" name="resetAlertAudioCountyButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../../../scwx-qt.qrc">
+                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_17">
+                <property name="text">
+                 <string>Sound</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="2">
+               <widget class="QLabel" name="alertAudioCountyLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QLineEdit" name="alertAudioCountyLineEdit">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -741,144 +882,37 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="5">
-               <widget class="QToolButton" name="alertAudioSoundStopButton">
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/stop-solid.svg</normaloff>:/res/icons/font-awesome-6/stop-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="6">
-               <widget class="QToolButton" name="resetAlertAudioLatitudeButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QToolButton" name="resetAlertAudioSoundButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QToolButton" name="alertAudioSoundTestButton">
-                <property name="icon">
-                 <iconset resource="../../../../scwx-qt.qrc">
-                  <normaloff>:/res/icons/font-awesome-6/play-solid.svg</normaloff>:/res/icons/font-awesome-6/play-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_17">
-                <property name="text">
-                 <string>Sound</string>
-                </property>
-               </widget>
-              </item>
               <item row="4" column="0">
-               <widget class="QLabel" name="label_19">
+               <widget class="QLabel" name="label_28">
                 <property name="text">
-                 <string>County</string>
+                 <string>Radius</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="1" colspan="2">
-               <widget class="QDoubleSpinBox" name="alertAudioLongitudeSpinBox">
+              <item row="4" column="1" colspan="2">
+               <widget class="QDoubleSpinBox" name="alertAudioRadiusSpinBox">
                 <property name="decimals">
                  <number>4</number>
                 </property>
                 <property name="minimum">
-                 <double>-180.000000000000000</double>
+                 <double>0.000000000000000</double>
                 </property>
                 <property name="maximum">
-                 <double>180.000000000000000</double>
+                 <double>9999999999999.000000000000000</double>
                 </property>
                 <property name="singleStep">
-                 <double>0.000100000000000</double>
+                 <double>0.010000000000000</double>
                 </property>
                </widget>
-              </item>
-              <item row="2" column="1" colspan="2">
-               <widget class="QDoubleSpinBox" name="alertAudioLatitudeSpinBox">
-                <property name="decimals">
-                 <number>4</number>
-                </property>
-                <property name="minimum">
-                 <double>-90.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>90.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.000100000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="2">
-               <widget class="QComboBox" name="alertAudioLocationMethodComboBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="2">
-               <widget class="QLineEdit" name="alertAudioSoundLineEdit"/>
               </item>
               <item row="4" column="6">
-               <widget class="QToolButton" name="resetAlertAudioCountyButton">
+               <widget class="QToolButton" name="resetAlertAudioRadiusButton">
                 <property name="text">
                  <string>...</string>
                 </property>
                 <property name="icon">
                  <iconset resource="../../../../scwx-qt.qrc">
                   <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="3">
-               <widget class="QToolButton" name="alertAudioCountySelectButton">
-                <property name="text">
-                 <string>...</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="2">
-               <widget class="QLabel" name="alertAudioCountyLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QLineEdit" name="alertAudioCountyLineEdit">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="readOnly">
-                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.cpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.cpp
@@ -55,9 +55,9 @@ bool GnomonicAreaContainsCenter(geos::geom::CoordinateSequence sequence)
          areaContainsPoint =
             geos::algorithm::PointLocation::isInRing(zero, &sequence);
       }
-      catch (const std::exception&)
+      catch (const std::exception& ex)
       {
-         logger_->trace("Invalid area sequence");
+         logger_->warn("Invalid area sequence. {}", ex.what());
       }
    }
 

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
@@ -96,6 +96,8 @@ GetDistance(double lat1, double lon1, double lat2, double lon2);
  * distance of a point. A point lying on the area boundary is considered to be
  * inside the area, and thus always in range. Any part of the area being inside
  * the radius counts as inside.
+ * This is limited to having the area be in the same hemisphere centered on
+ * the point, and radices up to a quarter of the circumference of the Earth.
  *
  * @param [in] area A vector of Coordinates representing the area
  * @param [in] point The point to check against the area

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
@@ -90,14 +90,26 @@ common::Coordinate GetCoordinate(const common::Coordinate& center,
 units::length::meters<double>
 GetDistance(double lat1, double lon1, double lat2, double lon2);
 
+/**
+ * Get the distance from an area to a point. If the area is less than a quarter
+ * radius of the Earth away, this is the closest distance between the area and
+ * the point. Otherwise it is the distance from the centroid of the area to the
+ * point. Finally, if the point is in the area, it is always 0.
+ *
+ * @param [in] area A vector of Coordinates representing the area
+ * @param [in] point The point to check against the area
+ *
+ * @return true if area is inside the radius of the point
+ */
+units::length::meters<double>
+GetDistanceAreaPoint(const std::vector<common::Coordinate>& area,
+                     const common::Coordinate&              point);
 
 /**
  * Determine if an area/ring, oriented in either direction, is within a
  * distance of a point. A point lying on the area boundary is considered to be
  * inside the area, and thus always in range. Any part of the area being inside
- * the radius counts as inside.
- * This is limited to having the area be in the same hemisphere centered on
- * the point, and radices up to a quarter of the circumference of the Earth.
+ * the radius counts as inside. Uses GetDistanceAreaPoint to get the distance.
  *
  * @param [in] area A vector of Coordinates representing the area
  * @param [in] point The point to check against the area

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
@@ -90,6 +90,23 @@ common::Coordinate GetCoordinate(const common::Coordinate& center,
 units::length::meters<double>
 GetDistance(double lat1, double lon1, double lat2, double lon2);
 
+
+/**
+ * Determine if an area/ring, oriented in either direction, is within a
+ * distance of a point. A point lying on the area boundary is considered to be
+ * inside the area, and thus always in range. Any part of the area being inside
+ * the radius counts as inside.
+ *
+ * @param [in] area A vector of Coordinates representing the area
+ * @param [in] point The point to check against the area
+ * @param [in] distance The max distance in meters
+ *
+ * @return true if area is inside the radius of the point
+ */
+bool AreaInRangeOfPoint(const std::vector<common::Coordinate>& area,
+                        const common::Coordinate&              point,
+                        const units::length::meters<double>    distance);
+
 } // namespace GeographicLib
 } // namespace util
 } // namespace qt

--- a/test/source/scwx/qt/util/geographic_lib.test.cpp
+++ b/test/source/scwx/qt/util/geographic_lib.test.cpp
@@ -1,0 +1,69 @@
+#include <scwx/qt/util/geographic_lib.hpp>
+
+#include <gtest/gtest.h>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+
+namespace scwx
+{
+namespace util
+{
+
+std::vector<common::Coordinate> area = {
+   common::Coordinate(37.0193692, -91.8778413),
+   common::Coordinate(36.9719180, -91.3006973),
+   common::Coordinate(36.7270831, -91.6815753),
+};
+
+TEST(geographic_lib, area_in_range_inside)
+{
+   auto inside = common::Coordinate(36.9241584, -91.6425933);
+   bool value;
+
+   // inside is always true
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, inside, units::length::meters<double>(0));
+   EXPECT_EQ(value, true);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, inside, units::length::meters<double>(1e6));
+   EXPECT_EQ(value, true);
+}
+
+TEST(geographic_lib, area_in_range_near)
+{
+   auto near = common::Coordinate(36.8009181, -91.3922700);
+   bool value;
+
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, near, units::length::meters<double>(9000));
+   EXPECT_EQ(value, false);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, near, units::length::meters<double>(10100));
+   EXPECT_EQ(value, true);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, near, units::length::meters<double>(1e6));
+   EXPECT_EQ(value, true);
+}
+
+TEST(geographic_lib, area_in_range_far)
+{
+   auto far = common::Coordinate(37.6481966, -94.2163834);
+   bool value;
+
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, far, units::length::meters<double>(9000));
+   EXPECT_EQ(value, false);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, far, units::length::meters<double>(10100));
+   EXPECT_EQ(value, false);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, far, units::length::meters<double>(100e3));
+   EXPECT_EQ(value, false);
+   value = scwx::qt::util::GeographicLib::AreaInRangeOfPoint(
+         area, far, units::length::meters<double>(300e3));
+   EXPECT_EQ(value, true);
+}
+
+
+} // namespace util
+} // namespace scwx

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -28,7 +28,8 @@ set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_provider.test.cpp)
 set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp)
-set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp)
+set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
+                      source/scwx/qt/util/geographic_lib.test.cpp)
 set(SRC_UTIL_TESTS source/scwx/util/float.test.cpp
                    source/scwx/util/rangebuf.test.cpp
                    source/scwx/util/streams.test.cpp


### PR DESCRIPTION
Partial implementation for issue #179

1. Adds support for Radar Site audio location method
2. Adds radius support for Fixed, Track, and Radar Site audio location methods

## I: Radar Site
1. Radar Site is selected by setting in Audio Settings, similar to the Default Radar Site
2. Has 2 additional options "default" and "follow"
3. "default" uses the Default Radar Site
4. "follow" uses the currently viewed radar site
5. "default" is the default

## II: Radius Calculations
1. The distance from the location to the alert is calculated as 
    a. 0 if the location is inside or on the edge of the alert area
    b. The distance to the nearest point on the edge of the alert, if all points of the alert fall inside the hemisphere centered on the location
    c. The distance to the centroid of the alert otherwise (edge case)
2. The distance is compared using less-than-or-equal-to the set radius
3. Setting radius to 0 is equivalent to current implementation
4. Includes tests for these calculations.

## III: Radius Settings
1. The radius setting is set in Audio Settings
2. This setting is effected by new "Distance" unit setting
3. The radius is stored in kilometers and is converted for display and setting
5. Includes a unit label
6. The unit label and input are updated correctly when the units are changed
7. Add unit logic in SettingsInterface. (SetUnit, and SetUnitLabel). Only works for doubles

## Wanted Feedback
1. Existence, naming, and selection of "default" and "follow" options. (I: 2-4)
    a. "default" may make more sense as "Default Radar Site"
    b. "follow" may make more sense as "Selected Radar Site" or "Viewing Radar Site"
    c. Should these be selected in the combo box, or added as separate settings?
2. Are the distance calculations the correct ones to be used? (II)
3. Addition of setting to "disable/enable radius". Although setting the radius to 0 should do this, should another setting be added to disable the radius in Fixed and Track modes, and use in area instead (III) 
4. The radius unit label location and formatting. It works, but does not look perfect, so if it should be changed, let me know.(III: 4)
5. I choose a random location in the great planes for my test cases, but should these be moved over water? (II: 4)
6. Any other feedback is welcome. 

## Further Work
Because this adds settings, the test/data repository will need to be updated with the new defaults. Once this gets close to being merged, I can start working on a merge request for that.