### PR TITLE
Qt6.7.2 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             compiler: msvc
             msvc_arch: x64
             msvc_version: 2022
-            qt_version: 6.7.1
+            qt_version: 6.7.2
             qt_arch_aqt: win64_msvc2019_64
             qt_arch_dir: msvc2019_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
@@ -45,7 +45,7 @@ jobs:
             env_cc: gcc-11
             env_cxx: g++-11
             compiler: gcc
-            qt_version: 6.7.1
+            qt_version: 6.7.2
             qt_arch_aqt: linux_gcc_64
             qt_arch_dir: gcc_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -43,6 +43,7 @@ find_package(Qt${QT_VERSION_MAJOR}
                         SerialPort
                         Svg
                         Widgets
+                        Sql
              REQUIRED)
 
 set(SRC_EXE_MAIN source/scwx/qt/main/main.cpp)

--- a/setup-debug.bat
+++ b/setup-debug.bat
@@ -2,7 +2,7 @@ call tools\setup-common.bat
 
 set build_dir=build-debug
 set build_type=Debug
-set qt_version=6.7.1
+set qt_version=6.7.2
 
 mkdir %build_dir%
 cmake -B %build_dir% -S . ^

--- a/setup-debug.sh
+++ b/setup-debug.sh
@@ -3,7 +3,7 @@
 
 build_dir=${1:-build-debug}
 build_type=Debug
-qt_version=6.7.1
+qt_version=6.7.2
 script_dir="$(dirname "$(readlink -f "$0")")"
 
 mkdir -p ${build_dir}

--- a/setup-release.bat
+++ b/setup-release.bat
@@ -2,7 +2,7 @@ call tools\setup-common.bat
 
 set build_dir=build-release
 set build_type=Release
-set qt_version=6.7.1
+set qt_version=6.7.2
 
 mkdir %build_dir%
 cmake -B %build_dir% -S . ^

--- a/setup-release.sh
+++ b/setup-release.sh
@@ -3,7 +3,7 @@
 
 build_dir=${1:-build-release}
 build_type=Release
-qt_version=6.7.1
+qt_version=6.7.2
 script_dir="$(dirname "$(readlink -f "$0")")"
 
 mkdir -p ${build_dir}


### PR DESCRIPTION
Resolved issues with Qt6.7.2 on Linux.

I added `Sql` to the `find_package(Qt ...)`. I am not sure why this is needed, or if it is a bug, but it seems to have fixed the issue on Linux. Bellow is an issue on a different project I found that may be related. It looks like changes to `QtPublicWalkLibsHelpers.cmake` may be to blame. A different solution may work better. 

https://github.com/stachenov/quazip/issues/197 


