### PR TITLE
Save UI State

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -460,7 +460,25 @@ void MainWindow::showEvent(QShowEvent* event)
 {
    QMainWindow::showEvent(event);
 
-   resizeDocks({ui->radarToolboxDock}, {194}, Qt::Horizontal);
+   // restore the UI state
+   std::string uiState =
+      settings::UiSettings::Instance().main_ui_state().GetValue();
+
+   bool restored =
+      restoreState(QByteArray::fromBase64(QByteArray::fromStdString(uiState)));
+   if (!restored)
+   {
+      resizeDocks({ui->radarToolboxDock}, {194}, Qt::Horizontal);
+   }
+}
+
+void MainWindow::closeEvent(QCloseEvent* event)
+{
+   // save the UI state
+   QByteArray uiState = saveState().toBase64();
+   settings::UiSettings::Instance().main_ui_state().StageValue(uiState.data());
+
+   QMainWindow::closeEvent(event);
 }
 
 void MainWindow::on_actionOpenNexrad_triggered()

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -279,7 +279,6 @@ MainWindow::MainWindow(QWidget* parent) :
 
    // Configure Alert Dock
    p->alertDockWidget_ = new ui::AlertDockWidget(this);
-   p->alertDockWidget_->setVisible(false);
    addDockWidget(Qt::BottomDockWidgetArea, p->alertDockWidget_);
 
    // GPS Info Dialog
@@ -294,7 +293,6 @@ MainWindow::MainWindow(QWidget* parent) :
    ui->menuView->insertAction(ui->actionAlerts,
                               p->alertDockWidget_->toggleViewAction());
    p->alertDockWidget_->toggleViewAction()->setText(tr("&Alerts"));
-   ui->actionAlerts->setVisible(false);
 
    ui->menuDebug->menuAction()->setVisible(
       settings::GeneralSettings::Instance().debug_enabled().GetValue());
@@ -803,6 +801,7 @@ void MainWindowImpl::ConfigureUiSettings()
    mapSettingsGroup_->SetExpanded(
       uiSettings.map_settings_expanded().GetValue());
    timelineGroup_->SetExpanded(uiSettings.timeline_expanded().GetValue());
+   alertDockWidget_->setVisible(uiSettings.alert_dock_visible().GetValue());
 
    connect(level2ProductsGroup_,
            &ui::CollapsibleGroup::StateChanged,

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -443,10 +443,15 @@ void MainWindow::keyReleaseEvent(QKeyEvent* ev)
 void MainWindow::showEvent(QShowEvent* event)
 {
    QMainWindow::showEvent(event);
+   auto& uiSettings = settings::UiSettings::Instance();
+
+   // restore the geometry state
+   std::string uiGeometry = uiSettings.main_ui_geometry().GetValue();
+   restoreGeometry(
+      QByteArray::fromBase64(QByteArray::fromStdString(uiGeometry)));
 
    // restore the UI state
-   std::string uiState =
-      settings::UiSettings::Instance().main_ui_state().GetValue();
+   std::string uiState = uiSettings.main_ui_state().GetValue();
 
    bool restored =
       restoreState(QByteArray::fromBase64(QByteArray::fromStdString(uiState)));
@@ -458,9 +463,15 @@ void MainWindow::showEvent(QShowEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+   auto& uiSettings = settings::UiSettings::Instance();
+
+   // save the UI geometry
+   QByteArray uiGeometry = saveGeometry().toBase64();
+   uiSettings.main_ui_geometry().StageValue(uiGeometry.data());
+
    // save the UI state
    QByteArray uiState = saveState().toBase64();
-   settings::UiSettings::Instance().main_ui_state().StageValue(uiState.data());
+   uiSettings.main_ui_state().StageValue(uiState.data());
 
    QMainWindow::closeEvent(event);
 }

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -820,7 +820,6 @@ void MainWindowImpl::ConfigureUiSettings()
    mapSettingsGroup_->SetExpanded(
       uiSettings.map_settings_expanded().GetValue());
    timelineGroup_->SetExpanded(uiSettings.timeline_expanded().GetValue());
-   alertDockWidget_->setVisible(uiSettings.alert_dock_visible().GetValue());
 
    connect(level2ProductsGroup_,
            &ui::CollapsibleGroup::StateChanged,

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -277,13 +277,10 @@ MainWindow::MainWindow(QWidget* parent) :
 
    ui->radarSitePresetsButton->setVisible(!radarSitePresets.empty());
 
-   auto& uiSettings = settings::UiSettings::Instance();
    // Configure Alert Dock
-   bool alertDockVisible_ = uiSettings.alert_dock_visible().GetValue();
    p->alertDockWidget_ = new ui::AlertDockWidget(this);
    p->alertDockWidget_->setVisible(false);
    addDockWidget(Qt::BottomDockWidgetArea, p->alertDockWidget_);
-   p->alertDockWidget_->setVisible(alertDockVisible_);
 
    // GPS Info Dialog
    p->gpsInfoDialog_ = new ui::GpsInfoDialog(this);
@@ -293,24 +290,10 @@ MainWindow::MainWindow(QWidget* parent) :
                               ui->radarToolboxDock->toggleViewAction());
    ui->radarToolboxDock->toggleViewAction()->setText(tr("Radar &Toolbox"));
    ui->actionRadarToolbox->setVisible(false);
-   ui->radarToolboxDock->setVisible(
-      uiSettings.radar_toolbox_dock_visible().GetValue());
-
-   // Update dock setting on visiblity change.
-   connect(ui->radarToolboxDock->toggleViewAction(),
-           &QAction::triggered,
-           this,
-           [](bool checked)
-           {
-              settings::UiSettings::Instance()
-                 .radar_toolbox_dock_visible()
-                 .StageValue(checked);
-           });
 
    ui->menuView->insertAction(ui->actionAlerts,
                               p->alertDockWidget_->toggleViewAction());
    p->alertDockWidget_->toggleViewAction()->setText(tr("&Alerts"));
-   ui->actionAlerts->setVisible(false);
 
    ui->menuDebug->menuAction()->setVisible(
       settings::GeneralSettings::Instance().debug_enabled().GetValue());
@@ -837,6 +820,7 @@ void MainWindowImpl::ConfigureUiSettings()
    mapSettingsGroup_->SetExpanded(
       uiSettings.map_settings_expanded().GetValue());
    timelineGroup_->SetExpanded(uiSettings.timeline_expanded().GetValue());
+   alertDockWidget_->setVisible(uiSettings.alert_dock_visible().GetValue());
 
    connect(level2ProductsGroup_,
            &ui::CollapsibleGroup::StateChanged,

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -281,6 +281,7 @@ MainWindow::MainWindow(QWidget* parent) :
    // Configure Alert Dock
    bool alertDockVisible_ = uiSettings.alert_dock_visible().GetValue();
    p->alertDockWidget_ = new ui::AlertDockWidget(this);
+   p->alertDockWidget_->setVisible(false);
    addDockWidget(Qt::BottomDockWidgetArea, p->alertDockWidget_);
    p->alertDockWidget_->setVisible(alertDockVisible_);
 

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -279,7 +279,6 @@ MainWindow::MainWindow(QWidget* parent) :
 
    // Configure Alert Dock
    p->alertDockWidget_ = new ui::AlertDockWidget(this);
-   p->alertDockWidget_->setVisible(false);
    addDockWidget(Qt::BottomDockWidgetArea, p->alertDockWidget_);
 
    // GPS Info Dialog
@@ -294,6 +293,7 @@ MainWindow::MainWindow(QWidget* parent) :
    ui->menuView->insertAction(ui->actionAlerts,
                               p->alertDockWidget_->toggleViewAction());
    p->alertDockWidget_->toggleViewAction()->setText(tr("&Alerts"));
+   ui->actionAlerts->setVisible(false);
 
    ui->menuDebug->menuAction()->setVisible(
       settings::GeneralSettings::Instance().debug_enabled().GetValue());

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -277,9 +277,12 @@ MainWindow::MainWindow(QWidget* parent) :
 
    ui->radarSitePresetsButton->setVisible(!radarSitePresets.empty());
 
+   auto& uiSettings = settings::UiSettings::Instance();
    // Configure Alert Dock
+   bool alertDockVisible_ = uiSettings.alert_dock_visible().GetValue();
    p->alertDockWidget_ = new ui::AlertDockWidget(this);
    addDockWidget(Qt::BottomDockWidgetArea, p->alertDockWidget_);
+   p->alertDockWidget_->setVisible(alertDockVisible_);
 
    // GPS Info Dialog
    p->gpsInfoDialog_ = new ui::GpsInfoDialog(this);
@@ -289,10 +292,24 @@ MainWindow::MainWindow(QWidget* parent) :
                               ui->radarToolboxDock->toggleViewAction());
    ui->radarToolboxDock->toggleViewAction()->setText(tr("Radar &Toolbox"));
    ui->actionRadarToolbox->setVisible(false);
+   ui->radarToolboxDock->setVisible(
+      uiSettings.radar_toolbox_dock_visible().GetValue());
+
+   // Update dock setting on visiblity change.
+   connect(ui->radarToolboxDock->toggleViewAction(),
+           &QAction::triggered,
+           this,
+           [](bool checked)
+           {
+              settings::UiSettings::Instance()
+                 .radar_toolbox_dock_visible()
+                 .StageValue(checked);
+           });
 
    ui->menuView->insertAction(ui->actionAlerts,
                               p->alertDockWidget_->toggleViewAction());
    p->alertDockWidget_->toggleViewAction()->setText(tr("&Alerts"));
+   ui->actionAlerts->setVisible(false);
 
    ui->menuDebug->menuAction()->setVisible(
       settings::GeneralSettings::Instance().debug_enabled().GetValue());
@@ -801,7 +818,6 @@ void MainWindowImpl::ConfigureUiSettings()
    mapSettingsGroup_->SetExpanded(
       uiSettings.map_settings_expanded().GetValue());
    timelineGroup_->SetExpanded(uiSettings.timeline_expanded().GetValue());
-   alertDockWidget_->setVisible(uiSettings.alert_dock_visible().GetValue());
 
    connect(level2ProductsGroup_,
            &ui::CollapsibleGroup::StateChanged,

--- a/scwx-qt/source/scwx/qt/main/main_window.hpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.hpp
@@ -29,6 +29,7 @@ public:
    void keyPressEvent(QKeyEvent* ev) override final;
    void keyReleaseEvent(QKeyEvent* ev) override final;
    void showEvent(QShowEvent* event) override;
+   void closeEvent(QCloseEvent *event) override;
 
 signals:
    void ActiveMapMoved(double latitude, double longitude);

--- a/scwx-qt/source/scwx/qt/settings/settings_variable.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_variable.hpp
@@ -91,7 +91,7 @@ public:
     * @return true if the staged value was committed, false if no staged value
     * is present.
     */
-   bool Commit();
+   bool Commit() override;
 
    /**
     * Clears the staged value of the settings variable.

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -20,6 +20,7 @@ public:
       mapSettingsExpanded_.SetDefault(true);
       timelineExpanded_.SetDefault(true);
       mainUIState_.SetDefault("");
+      mainUIGeometry_.SetDefault("");
    }
 
    ~UiSettingsImpl() {}
@@ -30,6 +31,7 @@ public:
    SettingsVariable<bool> mapSettingsExpanded_ {"map_settings_expanded"};
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
    SettingsVariable<std::string> mainUIState_ {"main_ui_state"};
+   SettingsVariable<std::string> mainUIGeometry_ {"main_ui_geometry"};
 };
 
 UiSettings::UiSettings() :
@@ -40,7 +42,8 @@ UiSettings::UiSettings() :
                       &p->level3ProductsExpanded_,
                       &p->mapSettingsExpanded_,
                       &p->timelineExpanded_,
-                      &p->mainUIState_});
+                      &p->mainUIState_,
+                      &p->mainUIGeometry_});
    SetDefaults();
 }
 UiSettings::~UiSettings() = default;
@@ -78,6 +81,11 @@ SettingsVariable<std::string>& UiSettings::main_ui_state() const
    return p->mainUIState_;
 }
 
+SettingsVariable<std::string>& UiSettings::main_ui_geometry() const
+{
+   return p->mainUIGeometry_;
+}
+
 bool UiSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -89,6 +97,7 @@ bool UiSettings::Shutdown()
    dataChanged |= p->mapSettingsExpanded_.Commit();
    dataChanged |= p->timelineExpanded_.Commit();
    dataChanged |= p->mainUIState_.Commit();
+   dataChanged |= p->mainUIGeometry_.Commit();
 
    return dataChanged;
 }
@@ -106,7 +115,8 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->level3ProductsExpanded_ == rhs.p->level3ProductsExpanded_ &&
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
            lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
-           lhs.p->mainUIState_ == rhs.p->mainUIState_);
+           lhs.p->mainUIState_ == rhs.p->mainUIState_ &&
+           lhs.p->mainUIGeometry_ == rhs.p->mainUIGeometry_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -19,6 +19,7 @@ public:
       level3ProductsExpanded_.SetDefault(true);
       mapSettingsExpanded_.SetDefault(true);
       timelineExpanded_.SetDefault(true);
+      alertDockVisible_.SetDefault(false);
    }
 
    ~UiSettingsImpl() {}
@@ -28,6 +29,7 @@ public:
    SettingsVariable<bool> level3ProductsExpanded_ {"level3_products_expanded"};
    SettingsVariable<bool> mapSettingsExpanded_ {"map_settings_expanded"};
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
+   SettingsVariable<bool> alertDockVisible_ {"alert_dock_visible"};
 };
 
 UiSettings::UiSettings() :
@@ -37,7 +39,8 @@ UiSettings::UiSettings() :
                       &p->level2SettingsExpanded_,
                       &p->level3ProductsExpanded_,
                       &p->mapSettingsExpanded_,
-                      &p->timelineExpanded_});
+                      &p->timelineExpanded_,
+                      &p->alertDockVisible_});
    SetDefaults();
 }
 UiSettings::~UiSettings() = default;
@@ -70,6 +73,11 @@ SettingsVariable<bool>& UiSettings::timeline_expanded() const
    return p->timelineExpanded_;
 }
 
+SettingsVariable<bool>& UiSettings::alert_dock_visible() const
+{
+   return p->alertDockVisible_;
+}
+
 bool UiSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -80,6 +88,7 @@ bool UiSettings::Shutdown()
    dataChanged |= p->level3ProductsExpanded_.Commit();
    dataChanged |= p->mapSettingsExpanded_.Commit();
    dataChanged |= p->timelineExpanded_.Commit();
+   dataChanged |= p->alertDockVisible_.Commit();
 
    return dataChanged;
 }
@@ -96,7 +105,8 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->level2SettingsExpanded_ == rhs.p->level2SettingsExpanded_ &&
            lhs.p->level3ProductsExpanded_ == rhs.p->level3ProductsExpanded_ &&
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
-           lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_);
+           lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
+           lhs.p->alertDockVisible_ == rhs.p->alertDockVisible_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -19,7 +19,6 @@ public:
       level3ProductsExpanded_.SetDefault(true);
       mapSettingsExpanded_.SetDefault(true);
       timelineExpanded_.SetDefault(true);
-      alertDockVisible_.SetDefault(false);
       radarToolboxDockVisible_.SetDefault(true);
       mainUIState_.SetDefault("");
    }
@@ -31,7 +30,6 @@ public:
    SettingsVariable<bool> level3ProductsExpanded_ {"level3_products_expanded"};
    SettingsVariable<bool> mapSettingsExpanded_ {"map_settings_expanded"};
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
-   SettingsVariable<bool> alertDockVisible_ {"alert_dock_visible"};
    SettingsVariable<bool> radarToolboxDockVisible_ {"radar_toolbox_dock_visible"};
    SettingsVariable<std::string> mainUIState_ {"main_ui_state"};
 };
@@ -44,7 +42,6 @@ UiSettings::UiSettings() :
                       &p->level3ProductsExpanded_,
                       &p->mapSettingsExpanded_,
                       &p->timelineExpanded_,
-                      &p->alertDockVisible_,
                       &p->radarToolboxDockVisible_,
                       &p->mainUIState_});
    SetDefaults();
@@ -79,10 +76,6 @@ SettingsVariable<bool>& UiSettings::timeline_expanded() const
    return p->timelineExpanded_;
 }
 
-SettingsVariable<bool>& UiSettings::alert_dock_visible() const
-{
-   return p->alertDockVisible_;
-}
 
 SettingsVariable<bool>& UiSettings::radar_toolbox_dock_visible() const
 {
@@ -105,7 +98,6 @@ bool UiSettings::Shutdown()
    dataChanged |= p->level3ProductsExpanded_.Commit();
    dataChanged |= p->mapSettingsExpanded_.Commit();
    dataChanged |= p->timelineExpanded_.Commit();
-   dataChanged |= p->alertDockVisible_.Commit();
    dataChanged |= p->radarToolboxDockVisible_.Commit();
    dataChanged |= p->mainUIState_.Commit();
 
@@ -125,7 +117,6 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->level3ProductsExpanded_ == rhs.p->level3ProductsExpanded_ &&
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
            lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
-           lhs.p->alertDockVisible_ == rhs.p->alertDockVisible_ &&
            lhs.p->radarToolboxDockVisible_ == rhs.p->radarToolboxDockVisible_ &&
            lhs.p->mainUIState_ == rhs.p->mainUIState_);
 }

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -20,6 +20,7 @@ public:
       mapSettingsExpanded_.SetDefault(true);
       timelineExpanded_.SetDefault(true);
       alertDockVisible_.SetDefault(false);
+      radarToolboxDockVisible_.SetDefault(true);
    }
 
    ~UiSettingsImpl() {}
@@ -30,6 +31,7 @@ public:
    SettingsVariable<bool> mapSettingsExpanded_ {"map_settings_expanded"};
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
    SettingsVariable<bool> alertDockVisible_ {"alert_dock_visible"};
+   SettingsVariable<bool> radarToolboxDockVisible_ {"radar_toolbox_dock_visible"};
 };
 
 UiSettings::UiSettings() :
@@ -40,7 +42,8 @@ UiSettings::UiSettings() :
                       &p->level3ProductsExpanded_,
                       &p->mapSettingsExpanded_,
                       &p->timelineExpanded_,
-                      &p->alertDockVisible_});
+                      &p->alertDockVisible_,
+                      &p->radarToolboxDockVisible_});
    SetDefaults();
 }
 UiSettings::~UiSettings() = default;
@@ -78,6 +81,12 @@ SettingsVariable<bool>& UiSettings::alert_dock_visible() const
    return p->alertDockVisible_;
 }
 
+SettingsVariable<bool>& UiSettings::radar_toolbox_dock_visible() const
+{
+   return p->radarToolboxDockVisible_;
+}
+
+
 bool UiSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -89,6 +98,7 @@ bool UiSettings::Shutdown()
    dataChanged |= p->mapSettingsExpanded_.Commit();
    dataChanged |= p->timelineExpanded_.Commit();
    dataChanged |= p->alertDockVisible_.Commit();
+   dataChanged |= p->radarToolboxDockVisible_.Commit();
 
    return dataChanged;
 }
@@ -106,7 +116,8 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->level3ProductsExpanded_ == rhs.p->level3ProductsExpanded_ &&
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
            lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
-           lhs.p->alertDockVisible_ == rhs.p->alertDockVisible_);
+           lhs.p->alertDockVisible_ == rhs.p->alertDockVisible_ &&
+           lhs.p->radarToolboxDockVisible_ == rhs.p->radarToolboxDockVisible_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -19,7 +19,6 @@ public:
       level3ProductsExpanded_.SetDefault(true);
       mapSettingsExpanded_.SetDefault(true);
       timelineExpanded_.SetDefault(true);
-      radarToolboxDockVisible_.SetDefault(true);
       mainUIState_.SetDefault("");
    }
 
@@ -30,7 +29,6 @@ public:
    SettingsVariable<bool> level3ProductsExpanded_ {"level3_products_expanded"};
    SettingsVariable<bool> mapSettingsExpanded_ {"map_settings_expanded"};
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
-   SettingsVariable<bool> radarToolboxDockVisible_ {"radar_toolbox_dock_visible"};
    SettingsVariable<std::string> mainUIState_ {"main_ui_state"};
 };
 
@@ -42,7 +40,6 @@ UiSettings::UiSettings() :
                       &p->level3ProductsExpanded_,
                       &p->mapSettingsExpanded_,
                       &p->timelineExpanded_,
-                      &p->radarToolboxDockVisible_,
                       &p->mainUIState_});
    SetDefaults();
 }
@@ -76,17 +73,10 @@ SettingsVariable<bool>& UiSettings::timeline_expanded() const
    return p->timelineExpanded_;
 }
 
-
-SettingsVariable<bool>& UiSettings::radar_toolbox_dock_visible() const
-{
-   return p->radarToolboxDockVisible_;
-}
-
 SettingsVariable<std::string>& UiSettings::main_ui_state() const
 {
    return p->mainUIState_;
 }
-
 
 bool UiSettings::Shutdown()
 {
@@ -98,7 +88,6 @@ bool UiSettings::Shutdown()
    dataChanged |= p->level3ProductsExpanded_.Commit();
    dataChanged |= p->mapSettingsExpanded_.Commit();
    dataChanged |= p->timelineExpanded_.Commit();
-   dataChanged |= p->radarToolboxDockVisible_.Commit();
    dataChanged |= p->mainUIState_.Commit();
 
    return dataChanged;
@@ -117,7 +106,6 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->level3ProductsExpanded_ == rhs.p->level3ProductsExpanded_ &&
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
            lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
-           lhs.p->radarToolboxDockVisible_ == rhs.p->radarToolboxDockVisible_ &&
            lhs.p->mainUIState_ == rhs.p->mainUIState_);
 }
 

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.cpp
@@ -21,6 +21,7 @@ public:
       timelineExpanded_.SetDefault(true);
       alertDockVisible_.SetDefault(false);
       radarToolboxDockVisible_.SetDefault(true);
+      mainUIState_.SetDefault("");
    }
 
    ~UiSettingsImpl() {}
@@ -32,6 +33,7 @@ public:
    SettingsVariable<bool> timelineExpanded_ {"timeline_expanded"};
    SettingsVariable<bool> alertDockVisible_ {"alert_dock_visible"};
    SettingsVariable<bool> radarToolboxDockVisible_ {"radar_toolbox_dock_visible"};
+   SettingsVariable<std::string> mainUIState_ {"main_ui_state"};
 };
 
 UiSettings::UiSettings() :
@@ -43,7 +45,8 @@ UiSettings::UiSettings() :
                       &p->mapSettingsExpanded_,
                       &p->timelineExpanded_,
                       &p->alertDockVisible_,
-                      &p->radarToolboxDockVisible_});
+                      &p->radarToolboxDockVisible_,
+                      &p->mainUIState_});
    SetDefaults();
 }
 UiSettings::~UiSettings() = default;
@@ -86,6 +89,11 @@ SettingsVariable<bool>& UiSettings::radar_toolbox_dock_visible() const
    return p->radarToolboxDockVisible_;
 }
 
+SettingsVariable<std::string>& UiSettings::main_ui_state() const
+{
+   return p->mainUIState_;
+}
+
 
 bool UiSettings::Shutdown()
 {
@@ -99,6 +107,7 @@ bool UiSettings::Shutdown()
    dataChanged |= p->timelineExpanded_.Commit();
    dataChanged |= p->alertDockVisible_.Commit();
    dataChanged |= p->radarToolboxDockVisible_.Commit();
+   dataChanged |= p->mainUIState_.Commit();
 
    return dataChanged;
 }
@@ -117,7 +126,8 @@ bool operator==(const UiSettings& lhs, const UiSettings& rhs)
            lhs.p->mapSettingsExpanded_ == rhs.p->mapSettingsExpanded_ &&
            lhs.p->timelineExpanded_ == rhs.p->timelineExpanded_ &&
            lhs.p->alertDockVisible_ == rhs.p->alertDockVisible_ &&
-           lhs.p->radarToolboxDockVisible_ == rhs.p->radarToolboxDockVisible_);
+           lhs.p->radarToolboxDockVisible_ == rhs.p->radarToolboxDockVisible_ &&
+           lhs.p->mainUIState_ == rhs.p->mainUIState_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -33,6 +33,7 @@ public:
    SettingsVariable<bool>& map_settings_expanded() const;
    SettingsVariable<bool>& timeline_expanded() const;
    SettingsVariable<bool>& alert_dock_visible() const;
+   SettingsVariable<bool>& radar_toolbox_dock_visible() const;
 
    bool Shutdown();
 

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -32,7 +32,6 @@ public:
    SettingsVariable<bool>& level3_products_expanded() const;
    SettingsVariable<bool>& map_settings_expanded() const;
    SettingsVariable<bool>& timeline_expanded() const;
-   SettingsVariable<bool>& radar_toolbox_dock_visible() const;
    SettingsVariable<std::string>& main_ui_state() const;
 
    bool Shutdown();

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -34,6 +34,7 @@ public:
    SettingsVariable<bool>& timeline_expanded() const;
    SettingsVariable<bool>& alert_dock_visible() const;
    SettingsVariable<bool>& radar_toolbox_dock_visible() const;
+   SettingsVariable<std::string>& main_ui_state() const;
 
    bool Shutdown();
 

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -33,6 +33,7 @@ public:
    SettingsVariable<bool>& map_settings_expanded() const;
    SettingsVariable<bool>& timeline_expanded() const;
    SettingsVariable<std::string>& main_ui_state() const;
+   SettingsVariable<std::string>& main_ui_geometry() const;
 
    bool Shutdown();
 

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -32,7 +32,6 @@ public:
    SettingsVariable<bool>& level3_products_expanded() const;
    SettingsVariable<bool>& map_settings_expanded() const;
    SettingsVariable<bool>& timeline_expanded() const;
-   SettingsVariable<bool>& alert_dock_visible() const;
    SettingsVariable<bool>& radar_toolbox_dock_visible() const;
    SettingsVariable<std::string>& main_ui_state() const;
 

--- a/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/ui_settings.hpp
@@ -32,6 +32,7 @@ public:
    SettingsVariable<bool>& level3_products_expanded() const;
    SettingsVariable<bool>& map_settings_expanded() const;
    SettingsVariable<bool>& timeline_expanded() const;
+   SettingsVariable<bool>& alert_dock_visible() const;
 
    bool Shutdown();
 

--- a/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
@@ -5,6 +5,7 @@
 #include <scwx/qt/model/alert_model.hpp>
 #include <scwx/qt/model/alert_proxy_model.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
+#include <scwx/qt/settings/ui_settings.hpp>
 #include <scwx/qt/types/alert_types.hpp>
 #include <scwx/qt/types/qt_types.hpp>
 #include <scwx/qt/ui/alert_dialog.hpp>
@@ -81,6 +82,15 @@ AlertDockWidget::AlertDockWidget(QWidget* parent) :
 
    // Check Active Alerts and trigger signal
    ui->actionActiveAlerts->setChecked(true);
+
+   // Update setting on visiblity change.
+   connect(toggleViewAction(),
+           &QAction::triggered,
+           this,
+           [](bool checked) {
+              settings::UiSettings::Instance().alert_dock_visible().StageValue(
+                 checked);
+           });
 }
 
 AlertDockWidget::~AlertDockWidget()

--- a/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
@@ -5,7 +5,6 @@
 #include <scwx/qt/model/alert_model.hpp>
 #include <scwx/qt/model/alert_proxy_model.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
-#include <scwx/qt/settings/ui_settings.hpp>
 #include <scwx/qt/types/alert_types.hpp>
 #include <scwx/qt/types/qt_types.hpp>
 #include <scwx/qt/ui/alert_dialog.hpp>
@@ -82,15 +81,6 @@ AlertDockWidget::AlertDockWidget(QWidget* parent) :
 
    // Check Active Alerts and trigger signal
    ui->actionActiveAlerts->setChecked(true);
-
-   // Update setting on visiblity change.
-   connect(toggleViewAction(),
-           &QAction::triggered,
-           this,
-           [](bool checked) {
-              settings::UiSettings::Instance().alert_dock_visible().StageValue(
-                 checked);
-           });
 }
 
 AlertDockWidget::~AlertDockWidget()


### PR DESCRIPTION
Implementation for #73.
Saves and restores
- Displayed docks
- Dock positions
- Dock sizes
- Possibly other state (The documentation is a bit vague)

Uses `QMainWindow::saveState` and `QMainWindow::restoreState` to save the state of the UI. It looks like this is the only official way to save the sizes of the docks. Unfortunately, this saves the state in an opaque binary format. I convert this to base64 and save it in the UI settings.

Is this method of saving the state OK?
Should a setting be added to disable the restoring of UI state on startup (to keep current behavior)?

I will make the `test/data` pull request.