### PR TITLE
Trim white space from inputs

### DIFF
--- a/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.cpp
@@ -56,6 +56,8 @@ public:
    double                     unitScale_ {1};
    std::optional<std::string> unitAbbreviation_ {};
    bool                       unitEnabled_ {false};
+
+   bool trimmingEnabled_ {false};
 };
 
 template<class T>
@@ -191,8 +193,11 @@ void SettingsInterface<T>::SetEditWidget(QWidget* widget)
                           p->context_.get(),
                           [this](const QString& text)
                           {
+                             QString trimmedText =
+                                p->trimmingEnabled_ ? text.trimmed() : text;
+
                              // Map to value if required
-                             std::string value {text.toStdString()};
+                             std::string value {trimmedText.toStdString()};
                              if (p->mapToValue_ != nullptr)
                              {
                                 value = p->mapToValue_(value);
@@ -486,6 +491,12 @@ void SettingsInterface<T>::SetUnit(const double&      scale,
    p->unitEnabled_      = true;
    p->UpdateEditWidget();
    p->UpdateUnitLabel();
+}
+
+template<class T>
+void SettingsInterface<T>::EnableTrimming(bool trimmingEnabled)
+{
+   p->trimmingEnabled_ = trimmingEnabled;
 }
 
 template<class T>

--- a/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
@@ -121,8 +121,8 @@ public:
    /**
     * Sets the unit to be used by this setting.
     *
-    * @param scale The radio of the current unit to the base unit
-    * @param abbreviation The abreviation to be displayed
+    * @param scale The ratio of the current unit to the base unit
+    * @param abbreviation The abbreviation to be displayed
     */
    void SetUnit(const double& scale, const std::string& abbreviation);
 

--- a/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_interface.hpp
@@ -126,6 +126,15 @@ public:
     */
    void SetUnit(const double& scale, const std::string& abbreviation);
 
+   /**
+    * Enables or disables whitespace trimming of text input.
+    * Removes whitespace ('\t', '\n', '\v', '\f', '\r', and ' ') at the
+    * beginning and end of the string from a QLineEdit.
+    *
+    * @param trimmingEnabled If trimming should be enabled.
+    */
+   void EnableTrimming(bool trimmingEnabled = true);
+
 private:
    class Impl;
    std::unique_ptr<Impl> p;

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -675,6 +675,7 @@ void SettingsDialogImpl::SetupGeneralTab()
    nmeaSource_.SetSettingsVariable(generalSettings.nmea_source());
    nmeaSource_.SetEditWidget(self_->ui->nmeaSourceLineEdit);
    nmeaSource_.SetResetButton(self_->ui->resetNmeaSourceButton);
+   nmeaSource_.EnableTrimming();
 
    warningsProvider_.SetSettingsVariable(generalSettings.warnings_provider());
    warningsProvider_.SetEditWidget(self_->ui->warningsProviderLineEdit);
@@ -754,6 +755,7 @@ void SettingsDialogImpl::SetupPalettesColorTablesTab()
       colorTable.SetSettingsVariable(colorTableVariable);
       colorTable.SetEditWidget(lineEdit);
       colorTable.SetResetButton(resetButton);
+      colorTable.EnableTrimming();
 
       colorTableVariable.RegisterValueStagedCallback(
          [colorTableType, imageLabel](const std::string& value)
@@ -877,6 +879,7 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioSoundFile_.SetSettingsVariable(audioSettings.alert_sound_file());
    alertAudioSoundFile_.SetEditWidget(self_->ui->alertAudioSoundLineEdit);
    alertAudioSoundFile_.SetResetButton(self_->ui->resetAlertAudioSoundButton);
+   alertAudioSoundFile_.EnableTrimming();
 
    QObject::connect(
       self_->ui->alertAudioSoundSelectButton,
@@ -1089,6 +1092,7 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioCounty_.SetSettingsVariable(audioSettings.alert_county());
    alertAudioCounty_.SetEditWidget(self_->ui->alertAudioCountyLineEdit);
    alertAudioCounty_.SetResetButton(self_->ui->resetAlertAudioCountyButton);
+   alertAudioCounty_.EnableTrimming();
 
    QObject::connect(self_->ui->alertAudioWFOSelectButton,
                     &QAbstractButton::clicked,
@@ -1121,6 +1125,7 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioWFO_.SetSettingsVariable(audioSettings.alert_wfo());
    alertAudioWFO_.SetEditWidget(self_->ui->alertAudioWFOLineEdit);
    alertAudioWFO_.SetResetButton(self_->ui->resetAlertAudioWFOButton);
+   alertAudioWFO_.EnableTrimming();
 }
 
 void SettingsDialogImpl::SetupTextTab()

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -603,14 +603,17 @@ void SettingsDialogImpl::SetupGeneralTab()
    mapboxApiKey_.SetSettingsVariable(generalSettings.mapbox_api_key());
    mapboxApiKey_.SetEditWidget(self_->ui->mapboxApiKeyLineEdit);
    mapboxApiKey_.SetResetButton(self_->ui->resetMapboxApiKeyButton);
+   mapboxApiKey_.EnableTrimming();
 
    mapTilerApiKey_.SetSettingsVariable(generalSettings.maptiler_api_key());
    mapTilerApiKey_.SetEditWidget(self_->ui->mapTilerApiKeyLineEdit);
    mapTilerApiKey_.SetResetButton(self_->ui->resetMapTilerApiKeyButton);
+   mapTilerApiKey_.EnableTrimming();
 
    customStyleUrl_.SetSettingsVariable(generalSettings.custom_style_url());
    customStyleUrl_.SetEditWidget(self_->ui->customMapUrlLineEdit);
    customStyleUrl_.SetResetButton(self_->ui->resetCustomMapUrlButton);
+   customStyleUrl_.EnableTrimming();
 
    customStyleDrawLayer_.SetSettingsVariable(
       generalSettings.custom_style_draw_layer());
@@ -676,6 +679,7 @@ void SettingsDialogImpl::SetupGeneralTab()
    warningsProvider_.SetSettingsVariable(generalSettings.warnings_provider());
    warningsProvider_.SetEditWidget(self_->ui->warningsProviderLineEdit);
    warningsProvider_.SetResetButton(self_->ui->resetWarningsProviderButton);
+   warningsProvider_.EnableTrimming();
 
    antiAliasingEnabled_.SetSettingsVariable(
       generalSettings.anti_aliasing_enabled());

--- a/scwx-qt/source/scwx/qt/util/network.cpp
+++ b/scwx-qt/source/scwx/qt/util/network.cpp
@@ -17,7 +17,8 @@ std::string NormalizeUrl(const std::string& urlString)
    std::string normalizedUrl;
 
    // Normalize URL string
-   QUrl url = QUrl::fromUserInput(QString::fromStdString(urlString));
+   QString trimmedUrlString = QString::fromStdString(urlString).trimmed();
+   QUrl url = QUrl::fromUserInput(trimmedUrlString);
    if (url.isLocalFile())
    {
       normalizedUrl = QDir::toNativeSeparators(url.toLocalFile()).toStdString();


### PR DESCRIPTION
Adds white space trimming for the following user inputs:
1. Placefile URL in placefile manager.
2. MapBox API Key
3. MapTiler API Key
4. Custom Style URL
5. NMEA Source
6. Warnings Provider URL
7. Color Table Files
8. Alert Audio Sound File
9. Alert Audio County
10. Alert Audio WFO

Notes:
1. I did not trim the Custom Style Draw Layer, because it is possible to have a layer that starts or ends with a space.
2. It is valid to use spaces in file names, including at the beginning or end of the file, but I doubt this will be an issue.