### PR TITLE
Revert to using ubuntu-22.04 for GCC build to ensure support for older GLibc versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             conan_compiler_runtime: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
             artifact_suffix: linux-x64
-            packages: ''
+            compiler_packages: ''
           - name: linux64_clang
             os: ubuntu-24.04
             build_type: Release
@@ -77,7 +77,7 @@ jobs:
             conan_compiler_runtime: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
             artifact_suffix: linux-clang-x64
-            packages: clang-17
+            compiler_packages: clang-17
     name: ${{ matrix.name }}
     env:
       CC: ${{ matrix.env_cc }}
@@ -117,7 +117,7 @@ jobs:
         sudo apt-get install doxygen \
                              libfuse2 \
                              ninja-build \
-                             ${{ matrix.packages }}
+                             ${{ matrix.compiler_packages }}
 
     - name: Setup Python Environment
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             conan_package_manager: ''
             artifact_suffix: windows-x64
           - name: linux64_gcc
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             build_type: Release
             env_cc: gcc-11
             env_cxx: g++-11
@@ -58,6 +58,7 @@ jobs:
             conan_compiler_runtime: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
             artifact_suffix: linux-x64
+            packages: ''
           - name: linux64_clang
             os: ubuntu-24.04
             build_type: Release
@@ -76,6 +77,7 @@ jobs:
             conan_compiler_runtime: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
             artifact_suffix: linux-clang-x64
+            packages: clang-17
     name: ${{ matrix.name }}
     env:
       CC: ${{ matrix.env_cc }}
@@ -86,7 +88,7 @@ jobs:
     steps:
     - name: Setup
       run: git config --global core.longpaths true
-      
+
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -109,15 +111,13 @@ jobs:
         vsversion: ${{ matrix.msvc_version }}
 
     - name: Setup Ubuntu Environment
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       shell: bash
       run: |
         sudo apt-get install doxygen \
                              libfuse2 \
                              ninja-build \
-                             clang-17 \
-                             gcc-11 \
-                             g++-11
+                             ${{ matrix.packages }}
 
     - name: Setup Python Environment
       shell: pwsh
@@ -153,7 +153,7 @@ jobs:
         ninja supercell-wx wxtest
 
     - name: Separate Debug Symbols (Linux)
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       shell: bash
       run: |
         cd build/
@@ -172,7 +172,7 @@ jobs:
         cmake --install . --component supercell-wx
 
     - name: Collect Artifacts
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       shell: bash
       run: |
         pushd supercell-wx/
@@ -204,14 +204,14 @@ jobs:
         path: ${{ github.workspace }}/build/bin/*.pdb
 
     - name: Upload Artifacts (Linux)
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       uses: actions/upload-artifact@v4
       with:
         name: supercell-wx-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/supercell-wx-${{ matrix.artifact_suffix }}.tar.gz
 
     - name: Upload Debug Artifacts (Linux)
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       uses: actions/upload-artifact@v4
       with:
         name: supercell-wx-debug-${{ matrix.artifact_suffix }}
@@ -234,7 +234,7 @@ jobs:
         path: ${{ github.workspace }}/build/supercell-wx-*.msi*
 
     - name: Build AppImage (Linux)
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       env:
         APPIMAGE_DIR: ${{ github.workspace }}/supercell-wx/
         LDAI_UPDATE_INFORMATION: gh-releases-zsync|dpaulat|supercell-wx|latest|*x86_64.AppImage.zsync
@@ -258,7 +258,7 @@ jobs:
         rm -f linuxdeploy-x86_64.AppImage
 
     - name: Upload AppImage (Linux)
-      if: matrix.os == 'ubuntu-24.04'
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       uses: actions/upload-artifact@v4
       with:
         name: supercell-wx-appimage-${{ matrix.artifact_suffix }}


### PR DESCRIPTION
Upgrading Ubuntu to 24.04 meant that CI was building against a newer version of GLibc which is not supported on Debian, and AppImage does not package GLibc. This pull request reverts the GCC build back to ubuntu-22.04 to avoid this. Clang-17 is not supported on ubuntu-22.04, so ubuntu-24.04 is still used. 

Sorry about this. I definitely should have tested this before making that pull request.