### PR TITLE
Fix location marker out of range

### DIFF
--- a/scwx-qt/source/scwx/qt/main/application.cpp
+++ b/scwx-qt/source/scwx/qt/main/application.cpp
@@ -44,6 +44,14 @@ void WaitForInitialization()
    }
 }
 
+// Only use for test cases
+void ResetInitilization()
+{
+   logger_->debug("Application initialization reset");
+   std::unique_lock lock(initializationMutex_);
+   initialized_ = false;
+}
+
 } // namespace Application
 } // namespace main
 } // namespace qt

--- a/scwx-qt/source/scwx/qt/main/application.hpp
+++ b/scwx-qt/source/scwx/qt/main/application.hpp
@@ -11,6 +11,8 @@ namespace Application
 
 void FinishInitialization();
 void WaitForInitialization();
+// Only use for test cases
+void ResetInitilization();
 
 } // namespace Application
 } // namespace main

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
@@ -36,7 +36,7 @@ public:
    explicit Impl(MarkerManager* self) : self_ {self} {}
    ~Impl() { threadPool_.join(); }
 
-   std::string                                markerSettingsPath_ {};
+   std::string                                markerSettingsPath_ {""};
    std::vector<std::shared_ptr<MarkerRecord>> markerRecords_ {};
 
    MarkerManager* self_;
@@ -176,14 +176,13 @@ MarkerManager::Impl::GetMarkerByName(const std::string& name)
 
 MarkerManager::MarkerManager() : p(std::make_unique<Impl>(this))
 {
+   p->InitializeMarkerSettings();
 
    boost::asio::post(p->threadPool_,
                      [this]()
                      {
                         try
                         {
-                           p->InitializeMarkerSettings();
-
                            // Read Marker settings on startup
                            main::Application::WaitForInitialization();
                            p->ReadMarkerSettings();
@@ -292,6 +291,13 @@ void MarkerManager::move_marker(size_t from, size_t to)
    }
    Q_EMIT MarkersUpdated();
 }
+
+// Only use for testing
+void MarkerManager::set_marker_settings_path(const std::string& path)
+{
+   p->markerSettingsPath_ = path;
+}
+
 
 std::shared_ptr<MarkerManager> MarkerManager::Instance()
 {

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
@@ -37,12 +37,31 @@ public:
    ~Impl() { threadPool_.join(); }
 
    std::string                                markerSettingsPath_ {""};
-   std::vector<std::shared_ptr<MarkerRecord>> markerRecords_ {};
 
    MarkerManager* self_;
 
    boost::asio::thread_pool threadPool_ {1u};
-   std::shared_mutex        markerRecordLock_ {};
+   /* Accessing markerRecords_
+    * For reads to markerRecords_, simply use std::shared_lock to lock
+    * markerRecordAccessMutex_
+    * For writes to markerRecords_
+    * 1. lock markerRecordModifyMutex_
+    * 2. emit start signals
+    * 3. lock (std::unique_lock) markerRecordAccessMutex_
+    * 4. Do changes
+    * 5. Unlock markerRecordAccessMutex_
+    * 6. emit end signals
+    * 7. Unlock markerRecordModifyMutex_
+    *
+    * markerRecordAccessMutex_ prevents reads during the actual right.
+    * markerRecordModifyMutex_ prevents two writes from happening.
+    * the unique_lock portion of markerRecordAccessMutex_ does not protect
+    * from 2 writes happening because reads may need to happen during
+    * signals, so they cannot be in the critical section.
+    */
+   std::shared_mutex        markerRecordAccessMutex_ {};
+   std::mutex               markerRecordModifyMutex_ {};
+   std::vector<std::shared_ptr<MarkerRecord>> markerRecords_ {};
 
    void                          InitializeMarkerSettings();
    void                          ReadMarkerSettings();
@@ -112,51 +131,53 @@ void MarkerManager::Impl::ReadMarkerSettings()
 
    boost::json::value markerJson = nullptr;
    {
-      std::unique_lock lock(markerRecordLock_);
-
-      // Determine if marker settings exists
-      if (std::filesystem::exists(markerSettingsPath_))
+      std::unique_lock modifyLock(markerRecordModifyMutex_);
       {
-         markerJson = util::json::ReadJsonFile(markerSettingsPath_);
-      }
+         std::unique_lock accessLock(markerRecordAccessMutex_);
 
-      if (markerJson != nullptr && markerJson.is_array())
-      {
-         // For each marker entry
-         auto& markerArray = markerJson.as_array();
-         markerRecords_.reserve(markerArray.size());
-         for (auto& markerEntry : markerArray)
+         // Determine if marker settings exists
+         if (std::filesystem::exists(markerSettingsPath_))
          {
-            try
-            {
-               MarkerRecord record =
-                  boost::json::value_to<MarkerRecord>(markerEntry);
-
-               if (!record.markerInfo_.name.empty())
-               {
-                  markerRecords_.emplace_back(
-                     std::make_shared<MarkerRecord>(record.markerInfo_));
-               }
-            }
-            catch (const std::exception& ex)
-            {
-               logger_->warn("Invalid location marker entry: {}", ex.what());
-            }
+            markerJson = util::json::ReadJsonFile(markerSettingsPath_);
          }
 
-         logger_->debug("{} location marker entries", markerRecords_.size());
-      }
-   }
+         if (markerJson != nullptr && markerJson.is_array())
+         {
+            // For each marker entry
+            auto& markerArray = markerJson.as_array();
+            markerRecords_.reserve(markerArray.size());
+            for (auto& markerEntry : markerArray)
+            {
+               try
+               {
+                  MarkerRecord record =
+                     boost::json::value_to<MarkerRecord>(markerEntry);
 
-   Q_EMIT self_->MarkersUpdated();
-   Q_EMIT self_->MarkersInitialized(markerRecords_.size());
+                  if (!record.markerInfo_.name.empty())
+                  {
+                     markerRecords_.emplace_back(
+                        std::make_shared<MarkerRecord>(record.markerInfo_));
+                  }
+               }
+               catch (const std::exception& ex)
+               {
+                  logger_->warn("Invalid location marker entry: {}", ex.what());
+               }
+            }
+
+            logger_->debug("{} location marker entries", markerRecords_.size());
+         }
+      }
+      Q_EMIT self_->MarkersUpdated();
+      Q_EMIT self_->MarkersInitialized(markerRecords_.size());
+   }
 }
 
 void MarkerManager::Impl::WriteMarkerSettings()
 {
    logger_->info("Saving location marker settings");
 
-   std::shared_lock lock(markerRecordLock_);
+   std::shared_lock lock(markerRecordAccessMutex_);
    auto markerJson = boost::json::value_from(markerRecords_);
    util::json::WriteJsonFile(markerSettingsPath_, markerJson);
 }
@@ -208,7 +229,7 @@ size_t MarkerManager::marker_count()
 
 std::optional<types::MarkerInfo> MarkerManager::get_marker(size_t index)
 {
-   std::shared_lock lock(p->markerRecordLock_);
+   std::shared_lock lock(p->markerRecordAccessMutex_);
    if (index >= p->markerRecords_.size())
    {
       return {};
@@ -221,77 +242,90 @@ std::optional<types::MarkerInfo> MarkerManager::get_marker(size_t index)
 void MarkerManager::set_marker(size_t index, const types::MarkerInfo& marker)
 {
    {
-      std::unique_lock lock(p->markerRecordLock_);
-      if (index >= p->markerRecords_.size())
+      std::unique_lock modifyLock(p->markerRecordModifyMutex_);
       {
-         return;
+         std::unique_lock accessLock(p->markerRecordAccessMutex_);
+         if (index >= p->markerRecords_.size())
+         {
+            return;
+         }
+         std::shared_ptr<MarkerManager::Impl::MarkerRecord>& markerRecord =
+            p->markerRecords_[index];
+         markerRecord->markerInfo_ = marker;
       }
-      std::shared_ptr<MarkerManager::Impl::MarkerRecord>& markerRecord =
-         p->markerRecords_[index];
-      markerRecord->markerInfo_ = marker;
+      Q_EMIT MarkerChanged(index);
+      Q_EMIT MarkersUpdated();
    }
-   Q_EMIT MarkerChanged(index);
-   Q_EMIT MarkersUpdated();
 }
 
 void MarkerManager::add_marker(const types::MarkerInfo& marker)
 {
-   Q_EMIT StartMarkerAdd(p->markerRecords_.size());
    {
-      std::unique_lock lock(p->markerRecordLock_);
-      p->markerRecords_.emplace_back(std::make_shared<Impl::MarkerRecord>(marker));
+      std::unique_lock modifyLock(p->markerRecordModifyMutex_);
+      Q_EMIT StartMarkerAdd(p->markerRecords_.size());
+      {
+         std::unique_lock accessLock(p->markerRecordAccessMutex_);
+         p->markerRecords_.emplace_back(
+            std::make_shared<Impl::MarkerRecord>(marker));
+      }
+      Q_EMIT EndMarkerAdd();
+      Q_EMIT MarkersUpdated();
    }
-   Q_EMIT EndMarkerAdd();
-   Q_EMIT MarkersUpdated();
 }
 
 void MarkerManager::remove_marker(size_t index)
 {
-   Q_EMIT StartMarkerRemove(index);
    {
-      std::unique_lock lock(p->markerRecordLock_);
-      if (index >= p->markerRecords_.size())
+      std::unique_lock modifyLock(p->markerRecordModifyMutex_);
+      Q_EMIT StartMarkerRemove(index);
       {
-         return;
+         std::unique_lock lock(p->markerRecordAccessMutex_);
+         if (index >= p->markerRecords_.size())
+         {
+            return;
+         }
+
+         p->markerRecords_.erase(std::next(p->markerRecords_.begin(), index));
       }
 
-      p->markerRecords_.erase(std::next(p->markerRecords_.begin(), index));
+      Q_EMIT EndMarkerRemove();
+      Q_EMIT MarkersUpdated();
    }
-
-   Q_EMIT EndMarkerRemove();
-   Q_EMIT MarkersUpdated();
 }
 
 void MarkerManager::move_marker(size_t from, size_t to)
 {
    {
-      std::unique_lock lock(p->markerRecordLock_);
-      if (from >= p->markerRecords_.size() || to >= p->markerRecords_.size())
+      std::unique_lock modifyLock(p->markerRecordModifyMutex_);
       {
-         return;
-      }
-      std::shared_ptr<MarkerManager::Impl::MarkerRecord>& markerRecord =
-         p->markerRecords_[from];
+         std::unique_lock accessLock(p->markerRecordAccessMutex_);
+         if (from >= p->markerRecords_.size() || to >= p->markerRecords_.size())
+         {
+            return;
+         }
+         std::shared_ptr<MarkerManager::Impl::MarkerRecord>& markerRecord =
+            p->markerRecords_[from];
 
-      if (from == to) {}
-      else if (from < to)
-      {
-         for (size_t i = from; i < to; i++)
+         if (from == to) {}
+         else if (from < to)
          {
-            p->markerRecords_[i] = p->markerRecords_[i + 1];
+            for (size_t i = from; i < to; i++)
+            {
+               p->markerRecords_[i] = p->markerRecords_[i + 1];
+            }
+            p->markerRecords_[to] = markerRecord;
          }
-         p->markerRecords_[to] = markerRecord;
-      }
-      else
-      {
-         for (size_t i = from; i > to; i--)
+         else
          {
-            p->markerRecords_[i] = p->markerRecords_[i - 1];
+            for (size_t i = from; i > to; i--)
+            {
+               p->markerRecords_[i] = p->markerRecords_[i - 1];
+            }
+            p->markerRecords_[to] = markerRecord;
          }
-         p->markerRecords_[to] = markerRecord;
       }
+      Q_EMIT MarkersUpdated();
    }
-   Q_EMIT MarkersUpdated();
 }
 
 // Only use for testing

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
@@ -149,6 +149,7 @@ void MarkerManager::Impl::ReadMarkerSettings()
    }
 
    Q_EMIT self_->MarkersUpdated();
+   Q_EMIT self_->MarkersInitialized(markerRecords_.size());
 }
 
 void MarkerManager::Impl::WriteMarkerSettings()
@@ -187,7 +188,6 @@ MarkerManager::MarkerManager() : p(std::make_unique<Impl>(this))
                            main::Application::WaitForInitialization();
                            p->ReadMarkerSettings();
 
-                           Q_EMIT MarkersInitialized(p->markerRecords_.size());
                         }
                         catch (const std::exception& ex)
                         {
@@ -236,16 +236,18 @@ void MarkerManager::set_marker(size_t index, const types::MarkerInfo& marker)
 
 void MarkerManager::add_marker(const types::MarkerInfo& marker)
 {
+   Q_EMIT StartMarkerAdd(p->markerRecords_.size());
    {
       std::unique_lock lock(p->markerRecordLock_);
       p->markerRecords_.emplace_back(std::make_shared<Impl::MarkerRecord>(marker));
    }
-   Q_EMIT MarkerAdded();
+   Q_EMIT EndMarkerAdd();
    Q_EMIT MarkersUpdated();
 }
 
 void MarkerManager::remove_marker(size_t index)
 {
+   Q_EMIT StartMarkerRemove(index);
    {
       std::unique_lock lock(p->markerRecordLock_);
       if (index >= p->markerRecords_.size())
@@ -256,7 +258,7 @@ void MarkerManager::remove_marker(size_t index)
       p->markerRecords_.erase(std::next(p->markerRecords_.begin(), index));
    }
 
-   Q_EMIT MarkerRemoved(index);
+   Q_EMIT EndMarkerRemove();
    Q_EMIT MarkersUpdated();
 }
 

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.hpp
@@ -20,12 +20,15 @@ public:
    explicit MarkerManager();
    ~MarkerManager();
 
-   size_t                   marker_count();
+   size_t                           marker_count();
    std::optional<types::MarkerInfo> get_marker(size_t index);
    void set_marker(size_t index, const types::MarkerInfo& marker);
    void add_marker(const types::MarkerInfo& marker);
    void remove_marker(size_t index);
    void move_marker(size_t from, size_t to);
+
+   // Only use for testing
+   void set_marker_settings_path(const std::string& path);
 
    static std::shared_ptr<MarkerManager> Instance();
 

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.hpp
@@ -33,11 +33,14 @@ public:
    static std::shared_ptr<MarkerManager> Instance();
 
 signals:
-   void MarkersInitialized(size_t count);
    void MarkersUpdated();
+
+   void MarkersInitialized(size_t count);
    void MarkerChanged(size_t index);
-   void MarkerAdded();
-   void MarkerRemoved(size_t index);
+   void StartMarkerAdd(size_t index);
+   void EndMarkerAdd();
+   void StartMarkerRemove(size_t index);
+   void EndMarkerRemove();
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/model/marker_model.cpp
+++ b/scwx-qt/source/scwx/qt/model/marker_model.cpp
@@ -254,6 +254,10 @@ bool MarkerModel::setData(const QModelIndex& index,
 
 void MarkerModel::HandleMarkersInitialized(size_t count)
 {
+   if (count == 0)
+   {
+      return;
+   }
    const int index = static_cast<int>(count - 1);
 
    beginInsertRows(QModelIndex(), 0, index);

--- a/scwx-qt/source/scwx/qt/model/marker_model.cpp
+++ b/scwx-qt/source/scwx/qt/model/marker_model.cpp
@@ -42,9 +42,14 @@ MarkerModel::MarkerModel(QObject* parent) :
          &MarkerModel::HandleMarkersInitialized);
 
    connect(p->markerManager_.get(),
-         &manager::MarkerManager::MarkerAdded,
+         &manager::MarkerManager::StartMarkerAdd,
          this,
-         &MarkerModel::HandleMarkerAdded);
+         &MarkerModel::StartMarkerAdd);
+
+   connect(p->markerManager_.get(),
+         &manager::MarkerManager::EndMarkerAdd,
+         this,
+         &MarkerModel::EndMarkerAdd);
 
    connect(p->markerManager_.get(),
          &manager::MarkerManager::MarkerChanged,
@@ -52,9 +57,14 @@ MarkerModel::MarkerModel(QObject* parent) :
          &MarkerModel::HandleMarkerChanged);
 
    connect(p->markerManager_.get(),
-         &manager::MarkerManager::MarkerRemoved,
+         &manager::MarkerManager::StartMarkerRemove,
          this,
-         &MarkerModel::HandleMarkerRemoved);
+         &MarkerModel::StartMarkerRemove);
+
+   connect(p->markerManager_.get(),
+         &manager::MarkerManager::EndMarkerRemove,
+         this,
+         &MarkerModel::EndMarkerRemove);
 }
 
 MarkerModel::~MarkerModel() = default;
@@ -264,11 +274,14 @@ void MarkerModel::HandleMarkersInitialized(size_t count)
    endInsertRows();
 }
 
-void MarkerModel::HandleMarkerAdded()
+void MarkerModel::StartMarkerAdd(size_t index)
 {
-   const int newIndex = static_cast<int>(p->markerManager_->marker_count() - 1);
-
+   const int newIndex = static_cast<int>(index);
    beginInsertRows(QModelIndex(), newIndex, newIndex);
+}
+
+void MarkerModel::EndMarkerAdd()
+{
    endInsertRows();
 }
 
@@ -281,11 +294,15 @@ void MarkerModel::HandleMarkerChanged(size_t index)
    Q_EMIT dataChanged(topLeft, bottomRight);
 }
 
-void MarkerModel::HandleMarkerRemoved(size_t index)
+void MarkerModel::StartMarkerRemove(size_t index)
 {
    const int removedIndex = static_cast<int>(index);
 
    beginRemoveRows(QModelIndex(), removedIndex, removedIndex);
+}
+
+void MarkerModel::EndMarkerRemove()
+{
    endRemoveRows();
 }
 

--- a/scwx-qt/source/scwx/qt/model/marker_model.hpp
+++ b/scwx-qt/source/scwx/qt/model/marker_model.hpp
@@ -40,9 +40,11 @@ public:
 
 public slots:
    void HandleMarkersInitialized(size_t count);
-   void HandleMarkerAdded();
+   void StartMarkerAdd(size_t index);
+   void EndMarkerAdd();
    void HandleMarkerChanged(size_t index);
-   void HandleMarkerRemoved(size_t index);
+   void StartMarkerRemove(size_t index);
+   void EndMarkerRemove();
 
 private:
    class Impl;

--- a/test/source/scwx/qt/model/marker_model.test.cpp
+++ b/test/source/scwx/qt/model/marker_model.test.cpp
@@ -1,0 +1,201 @@
+#include <scwx/qt/model/marker_model.hpp>
+#include <scwx/qt/manager/marker_manager.hpp>
+#include <scwx/qt/main/application.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <QObject>
+
+#include <condition_variable>
+#include <gtest/gtest.h>
+
+
+namespace scwx
+{
+namespace qt
+{
+namespace model
+{
+
+static const std::string EMPTY_MARKERS_FILE =
+   std::string(SCWX_TEST_DATA_DIR) + "/json/markers/markers-empty.json";
+static const std::string TEMP_MARKERS_FILE =
+   std::string(SCWX_TEST_DATA_DIR) + "/json/markers/markers-temp.json";
+static const std::string ONE_MARKERS_FILE =
+   std::string(SCWX_TEST_DATA_DIR) + "/json/markers/markers-one.json";
+static const std::string FIVE_MARKERS_FILE =
+   std::string(SCWX_TEST_DATA_DIR) + "/json/markers/markers-five.json";
+
+static std::mutex              initializedMutex {};
+static std::condition_variable initializedCond {};
+static bool                    initialized;
+
+void CompareFiles(const std::string& file1, const std::string& file2)
+{
+   std::ifstream     ifs1 {file1};
+   std::stringstream buffer1;
+   buffer1 << ifs1.rdbuf();
+
+   std::ifstream     ifs2 {file2};
+   std::stringstream buffer2;
+   buffer2 << ifs2.rdbuf();
+
+   EXPECT_EQ(buffer1.str(), buffer2.str());
+}
+
+void CopyFile(const std::string& from, const std::string& to)
+{
+   std::filesystem::copy_file(from, to);
+   CompareFiles(from, to);
+}
+
+typedef void TestFunction(std::shared_ptr<manager::MarkerManager> manager,
+                          MarkerModel&                            model);
+
+void RunTest(const std::string& filename, TestFunction testFunction)
+{
+   {
+      main::Application::ResetInitilization();
+      MarkerModel                             model = MarkerModel();
+      std::shared_ptr<manager::MarkerManager> manager =
+         manager::MarkerManager::Instance();
+
+      manager->set_marker_settings_path(TEMP_MARKERS_FILE);
+
+      initialized = false;
+      QObject::connect(manager.get(),
+                       &manager::MarkerManager::MarkersInitialized,
+                       []()
+                       {
+                          std::unique_lock lock(initializedMutex);
+                          initialized = true;
+                          initializedCond.notify_all();
+                       });
+
+      main::Application::FinishInitialization();
+
+      std::unique_lock lock(initializedMutex);
+      while (!initialized)
+      {
+         initializedCond.wait(lock);
+      }
+
+      testFunction(manager, model);
+   }
+
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), true);
+
+   CompareFiles(TEMP_MARKERS_FILE, filename);
+}
+
+TEST(MarkerModelTest, CreateJson)
+{
+   // Verify file doesn't exist prior to test start
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+
+   RunTest(EMPTY_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager>, MarkerModel&) {});
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, LoadEmpty)
+{
+   CopyFile(EMPTY_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(EMPTY_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager>, MarkerModel&) {});
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, AddRemove)
+{
+   CopyFile(EMPTY_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(ONE_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           { manager->add_marker(types::MarkerInfo("Null", 0, 0)); });
+   RunTest(EMPTY_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           { manager->remove_marker(0); });
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, AddFive)
+{
+   CopyFile(EMPTY_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(FIVE_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           {
+              manager->add_marker(types::MarkerInfo("Null", 0, 0));
+              manager->add_marker(types::MarkerInfo("North", 90, 0));
+              manager->add_marker(types::MarkerInfo("South", -90, 0));
+              manager->add_marker(types::MarkerInfo("East", 0, 90));
+              manager->add_marker(types::MarkerInfo("West", 0, -90));
+           });
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, AddFour)
+{
+   CopyFile(ONE_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(FIVE_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           {
+              manager->add_marker(types::MarkerInfo("North", 90, 0));
+              manager->add_marker(types::MarkerInfo("South", -90, 0));
+              manager->add_marker(types::MarkerInfo("East", 0, 90));
+              manager->add_marker(types::MarkerInfo("West", 0, -90));
+           });
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, RemoveFive)
+{
+   CopyFile(FIVE_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(EMPTY_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           {
+              manager->remove_marker(4);
+              manager->remove_marker(3);
+              manager->remove_marker(2);
+              manager->remove_marker(1);
+              manager->remove_marker(0);
+           });
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+TEST(MarkerModelTest, RemoveFour)
+{
+   CopyFile(FIVE_MARKERS_FILE, TEMP_MARKERS_FILE);
+
+   RunTest(ONE_MARKERS_FILE,
+           [](std::shared_ptr<manager::MarkerManager> manager, MarkerModel&)
+           {
+              manager->remove_marker(4);
+              manager->remove_marker(3);
+              manager->remove_marker(2);
+              manager->remove_marker(1);
+           });
+
+   std::filesystem::remove(TEMP_MARKERS_FILE);
+   EXPECT_EQ(std::filesystem::exists(TEMP_MARKERS_FILE), false);
+}
+
+} // namespace model
+} // namespace qt
+} // namespace scwx

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -25,7 +25,8 @@ set(SRC_QT_CONFIG_TESTS source/scwx/qt/config/county_database.test.cpp
 set(SRC_QT_MANAGER_TESTS source/scwx/qt/manager/settings_manager.test.cpp
                          source/scwx/qt/manager/update_manager.test.cpp)
 set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_provider.test.cpp)
-set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp)
+set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp
+                       source/scwx/qt/model/marker_model.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp)
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp


### PR DESCRIPTION
The fix itself is really simple, although I am not able to replicate the assertion failure on Linux, so that should be double checked (although the tests should catch it)
The test cases are a bit complex because of threading. If they are too complex, then they can be removed, or moved to a separate pull request.