### PR TITLE
Fix whitespace trimming

### DIFF
--- a/scwx-qt/source/scwx/qt/ui/setup/map_provider_page.cpp
+++ b/scwx-qt/source/scwx/qt/ui/setup/map_provider_page.cpp
@@ -209,9 +209,11 @@ void MapProviderPage::Impl::SetupSettingsInterface()
    mapProvider_.SetEditWidget(mapProviderComboBox_);
 
    mapboxApiKey_.SetSettingsVariable(generalSettings.mapbox_api_key());
+   mapboxApiKey_.EnableTrimming();
    mapboxApiKey_.SetEditWidget(mapboxGroup_.apiKeyEdit_);
 
    mapTilerApiKey_.SetSettingsVariable(generalSettings.maptiler_api_key());
+   mapTilerApiKey_.EnableTrimming();
    mapTilerApiKey_.SetEditWidget(maptilerGroup_.apiKeyEdit_);
 }
 

--- a/scwx-qt/source/scwx/qt/util/network.cpp
+++ b/scwx-qt/source/scwx/qt/util/network.cpp
@@ -25,7 +25,7 @@ std::string NormalizeUrl(const std::string& urlString)
    }
    else
    {
-      normalizedUrl = urlString;
+      normalizedUrl = trimmedUrlString.toStdString();
    }
 
    return normalizedUrl;

--- a/test/source/scwx/qt/util/network.test.cpp
+++ b/test/source/scwx/qt/util/network.test.cpp
@@ -12,13 +12,49 @@ namespace util
 {
 
 const std::vector<std::pair<const std::string, const std::string>> testUrls = {
-   {" https://example.com/ ", "https://example.com/"},
-   {"\thttps://example.com/\t", "https://example.com/"},
-   {"\nhttps://example.com/\n", "https://example.com/"},
-   {"\rhttps://example.com/\r", "https://example.com/"},
-   {"\r\nhttps://example.com/\r\n", "https://example.com/"},
-   {"    https://example.com/   ", "https://example.com/"},
-   {"    \nhttps://example.com/  \n ", "https://example.com/"},
+   {" https://example.com/path/to+a+test/file.txt ",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"\thttps://example.com/path/to+a+test/file.txt\t",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"\nhttps://example.com/path/to+a+test/file.txt\n",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"\rhttps://example.com/path/to+a+test/file.txt\r",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"\r\nhttps://example.com/path/to+a+test/file.txt\r\n",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"    https://example.com/path/to+a+test/file.txt   ",
+    "https://example.com/path/to+a+test/file.txt"},
+   {"    \nhttps://example.com/path/to+a+test/file.txt  \n ",
+    "https://example.com/path/to+a+test/file.txt"},
+
+   // Only tested for this OS because NormalizeUrl uses native separators
+#ifdef _WIN32
+   {" C:\\path\\to a test\\file.txt ", "C:\\path\\to a test\\file.txt"},
+   {"\tC:\\path\\to a test\\file.txt\t", "C:\\path\\to a test\\file.txt"},
+   {"\nC:\\path\\to a test\\file.txt\n", "C:\\path\\to a test\\file.txt"},
+   {"\rC:\\path\\to a test\\file.txt\r", "C:\\path\\to a test\\file.txt"},
+   {"\r\nC:\\path\\to a test\\file.txt\r\n", "C:\\path\\to a test\\file.txt"},
+   {"    C:\\path\\to a test\\file.txt   ", "C:\\path\\to a test\\file.txt"},
+   {"    \nC:\\path\\to a test\\file.txt  \n ",
+    "C:\\path\\to a test\\file.txt"},
+
+   {" C:/path/to a test/file.txt ", "C:\\path\\to a test\\file.txt"},
+   {"\tC:/path/to a test/file.txt\t", "C:\\path\\to a test\\file.txt"},
+   {"\nC:/path/to a test/file.txt\n", "C:\\path\\to a test\\file.txt"},
+   {"\rC:/path/to a test/file.txt\r", "C:\\path\\to a test\\file.txt"},
+   {"\r\nC:/path/to a test/file.txt\r\n", "C:\\path\\to a test\\file.txt"},
+   {"    C:/path/to a test/file.txt   ", "C:\\path\\to a test\\file.txt"},
+   {"    \nC:/path/to a test/file.txt  \n ", "C:\\path\\to a test\\file.txt"},
+#else
+
+   {" /path/to a test/file.txt ", "/path/to a test/file.txt"},
+   {"\t/path/to a test/file.txt\t", "/path/to a test/file.txt"},
+   {"\n/path/to a test/file.txt\n", "/path/to a test/file.txt"},
+   {"\r/path/to a test/file.txt\r", "/path/to a test/file.txt"},
+   {"\r\n/path/to a test/file.txt\r\n", "/path/to a test/file.txt"},
+   {"    /path/to a test/file.txt   ", "/path/to a test/file.txt"},
+   {"    \n/path/to a test/file.txt  \n ", "/path/to a test/file.txt"},
+#endif
 };
 
 TEST(network, NormalizeUrl)

--- a/test/source/scwx/qt/util/network.test.cpp
+++ b/test/source/scwx/qt/util/network.test.cpp
@@ -1,0 +1,40 @@
+#include <scwx/qt/util/network.hpp>
+
+#include <gtest/gtest.h>
+
+
+
+namespace scwx
+{
+namespace qt
+{
+namespace util
+{
+
+const std::vector<std::pair<const std::string, const std::string>> testUrls = {
+   {" https://example.com/ ", "https://example.com/"},
+   {"\thttps://example.com/\t", "https://example.com/"},
+   {"\nhttps://example.com/\n", "https://example.com/"},
+   {"\rhttps://example.com/\r", "https://example.com/"},
+   {"\r\nhttps://example.com/\r\n", "https://example.com/"},
+   {"    https://example.com/   ", "https://example.com/"},
+   {"    \nhttps://example.com/  \n ", "https://example.com/"},
+};
+
+TEST(network, NormalizeUrl)
+{
+   for (auto& pair : testUrls)
+   {
+      const std::string& preNormalized = pair.first;
+      const std::string& expNormalized = pair.second;
+
+      std::string normalized = network::NormalizeUrl(preNormalized);
+      EXPECT_EQ(normalized, expNormalized);
+   }
+
+}
+
+
+} // namespace util
+} // namespace qt
+} // namespace scwx

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -29,7 +29,8 @@ set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp)
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
-                      source/scwx/qt/util/geographic_lib.test.cpp)
+                      source/scwx/qt/util/geographic_lib.test.cpp
+                      source/scwx/qt/util/network.test.cpp)
 set(SRC_UTIL_TESTS source/scwx/util/float.test.cpp
                    source/scwx/util/rangebuf.test.cpp
                    source/scwx/util/streams.test.cpp


### PR DESCRIPTION
Three things:
1. White space was not being trimmed for (non local) URLs in `NormalizeUrl`
2. Added tests for `NormalizeUrl`
3. Added white space trimming for API key entries in setup dialog

Sorry I missed these in my first pull request for this.