### PR TITLE
Remove additioal qt components

### DIFF
--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -21,9 +21,7 @@ find_package(Python COMPONENTS Interpreter)
 find_package(SQLite3)
 
 find_package(QT NAMES Qt6
-             COMPONENTS BuildInternals
-                        Core
-                        Gui
+             COMPONENTS Gui
                         LinguistTools
                         Multimedia
                         Network
@@ -37,9 +35,7 @@ find_package(QT NAMES Qt6
              REQUIRED)
 
 find_package(Qt${QT_VERSION_MAJOR}
-             COMPONENTS BuildInternals
-                        Core
-                        Gui
+             COMPONENTS Gui
                         LinguistTools
                         Multimedia
                         Network


### PR DESCRIPTION
Revert finding some Qt parts in cmake that appear to be causing issues with build on older versions of linux (ubuntu22.04)

If this works on its own, it may be preferable to moving the qt6ct code into the scwx repo directly.