### PR TITLE
Added cursor icon always on option to general settings

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1020,11 +1020,14 @@ void MapWidget::UpdateMouseCoordinate(const common::Coordinate& coordinate)
 {
    if (p->context_->mouse_coordinate() != coordinate)
    {
+      auto& generalSettings = settings::GeneralSettings::Instance();
+
       p->context_->set_mouse_coordinate(coordinate);
 
       auto keyboardModifiers = QGuiApplication::keyboardModifiers();
 
-      if (keyboardModifiers != Qt::KeyboardModifier::NoModifier ||
+      if (generalSettings.cursor_icon_always_on().GetValue() ||
+          keyboardModifiers != Qt::KeyboardModifier::NoModifier ||
           keyboardModifiers != p->lastKeyboardModifiers_)
       {
          QMetaObject::invokeMethod(

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -328,9 +328,13 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
       p->activeBoxInner_->SetBorder(1.0f * pixelRatio, {255, 255, 255, 255});
    }
 
+   auto& generalSettings = settings::GeneralSettings::Instance();
+
    // Cursor Icon
-   bool cursorIconVisible = QGuiApplication::keyboardModifiers() &
-                            Qt::KeyboardModifier::ControlModifier;
+   bool cursorIconVisible =
+      generalSettings.cursor_icon_always_on().GetValue() ||
+      (QGuiApplication::keyboardModifiers() &
+       Qt::KeyboardModifier::ControlModifier);
    p->geoIcons_->SetIconVisible(p->cursorIcon_, cursorIconVisible);
    if (cursorIconVisible)
    {
@@ -433,8 +437,6 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 
       ImGui::End();
    }
-
-   auto& generalSettings = settings::GeneralSettings::Instance();
 
    // Map Center Icon
    if (params.width != p->lastWidth_ || params.height != p->lastHeight_)

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -77,6 +77,7 @@ public:
       trackLocation_.SetDefault(false);
       updateNotificationsEnabled_.SetDefault(true);
       warningsProvider_.SetDefault(defaultWarningsProviderValue);
+      cursorIconAlwaysOn_.SetDefault(false);
 
       fontSizes_.SetElementMinimum(1);
       fontSizes_.SetElementMaximum(72);
@@ -166,6 +167,7 @@ public:
    SettingsVariable<bool>         trackLocation_ {"track_location"};
    SettingsVariable<bool> updateNotificationsEnabled_ {"update_notifications"};
    SettingsVariable<std::string> warningsProvider_ {"warnings_provider"};
+   SettingsVariable<bool>        cursorIconAlwaysOn_ {"cursor_icon_always_on"};
 };
 
 GeneralSettings::GeneralSettings() :
@@ -198,7 +200,8 @@ GeneralSettings::GeneralSettings() :
                       &p->themeFile_,
                       &p->trackLocation_,
                       &p->updateNotificationsEnabled_,
-                      &p->warningsProvider_});
+                      &p->warningsProvider_,
+                      &p->cursorIconAlwaysOn_});
    SetDefaults();
 }
 GeneralSettings::~GeneralSettings() = default;
@@ -348,6 +351,11 @@ SettingsVariable<std::string>& GeneralSettings::warnings_provider() const
    return p->warningsProvider_;
 }
 
+SettingsVariable<bool>& GeneralSettings::cursor_icon_always_on() const
+{
+   return p->cursorIconAlwaysOn_;
+}
+
 bool GeneralSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -397,7 +405,8 @@ bool operator==(const GeneralSettings& lhs, const GeneralSettings& rhs)
            lhs.p->trackLocation_ == rhs.p->trackLocation_ &&
            lhs.p->updateNotificationsEnabled_ ==
               rhs.p->updateNotificationsEnabled_ &&
-           lhs.p->warningsProvider_ == rhs.p->warningsProvider_);
+           lhs.p->warningsProvider_ == rhs.p->warningsProvider_ &&
+           lhs.p->cursorIconAlwaysOn_ == rhs.p->cursorIconAlwaysOn_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/general_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.hpp
@@ -53,6 +53,7 @@ public:
    SettingsVariable<bool>&                       track_location() const;
    SettingsVariable<bool>&        update_notifications_enabled() const;
    SettingsVariable<std::string>& warnings_provider() const;
+   SettingsVariable<bool>&        cursor_icon_always_on() const;
 
    static GeneralSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -137,6 +137,7 @@ public:
           &showMapCenter_,
           &showMapLogo_,
           &updateNotificationsEnabled_,
+          &cursorIconAlwaysOn_,
           &debugEnabled_,
           &alertAudioSoundFile_,
           &alertAudioLocationMethod_,
@@ -251,6 +252,7 @@ public:
    settings::SettingsInterface<bool>         showMapCenter_ {};
    settings::SettingsInterface<bool>         showMapLogo_ {};
    settings::SettingsInterface<bool>         updateNotificationsEnabled_ {};
+   settings::SettingsInterface<bool>         cursorIconAlwaysOn_ {};
    settings::SettingsInterface<bool>         debugEnabled_ {};
 
    std::unordered_map<std::string, settings::SettingsInterface<std::string>>
@@ -761,6 +763,10 @@ void SettingsDialogImpl::SetupGeneralTab()
       generalSettings.update_notifications_enabled());
    updateNotificationsEnabled_.SetEditWidget(
       self_->ui->enableUpdateNotificationsCheckBox);
+
+   cursorIconAlwaysOn_.SetSettingsVariable(
+      generalSettings.cursor_icon_always_on());
+   cursorIconAlwaysOn_.SetEditWidget(self_->ui->cursorIconAlwaysOnCheckBox);
 
    debugEnabled_.SetSettingsVariable(generalSettings.debug_enabled());
    debugEnabled_.SetEditWidget(self_->ui->debugEnabledCheckBox);

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -135,9 +135,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-133</y>
+                <y>-246</y>
                 <width>511</width>
-                <height>676</height>
+                <height>703</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -587,6 +587,19 @@
                 <widget class="QCheckBox" name="enableUpdateNotificationsCheckBox">
                  <property name="text">
                   <string>Update Notifications Enabled</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cursorIconAlwaysOnCheckBox">
+                 <property name="acceptDrops">
+                  <bool>false</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string/>
+                 </property>
+                 <property name="text">
+                  <string>Multi-Pane Cursor Marker Always On</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
This is going to fail some clang-tidy checks.
The checkbox text may need changing, and a tool tip could be added mentioning CTRL.