### PR TITLE
Change negative threshold values to act as inverted threshold

### DIFF
--- a/scwx-qt/gl/threshold.geom
+++ b/scwx-qt/gl/threshold.geom
@@ -21,7 +21,9 @@ smooth out vec4 color;
 void main()
 {
    if (gsIn[0].displayed != 0 &&
-       (gsIn[0].threshold <= 0 ||            // If Threshold: 0 was specified, no threshold
+       (gsIn[0].threshold == 0 ||            // If Threshold: 0 was specified, no threshold
+        uMapDistance == 0 ||                 // If uMapDistance is zero, threshold is disabled
+        (gsIn[0].threshold < 0 && -(gsIn[0].threshold) <= uMapDistance) || // If Threshold is negative and below current map distance
         gsIn[0].threshold >= uMapDistance || // If Threshold is above current map distance
         gsIn[0].threshold >= 999) &&         // If Threshold: 999 was specified (or greater), no threshold
        (gsIn[0].timeRange[0] == 0 ||              // If there is no start time specified

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
@@ -136,7 +136,10 @@ void PlacefileText::Impl::RenderTextDrawItem(
          std::chrono::system_clock::now() :
          selectedTime_;
 
-   if ((!thresholded_ || mapDistance_ <= di->threshold_) &&
+   const bool thresholdMet = mapDistance_ <= di->threshold_ ||
+        ((double)di->threshold_ < 0.0 && mapDistance_ >= -(di->threshold_));
+
+   if ((!thresholded_ || thresholdMet) &&
        (di->startTime_ == std::chrono::system_clock::time_point {} ||
         (di->startTime_ <= selectedTime && selectedTime < di->endTime_)))
    {

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
@@ -137,10 +137,10 @@ void PlacefileText::Impl::RenderTextDrawItem(
          selectedTime_;
 
    const bool thresholdMet =
-      mapDistance_ <= di->threshold_ ||
-      ((double) di->threshold_ < 0.0 && mapDistance_ >= -(di->threshold_));
+      !thresholded_ || mapDistance_ <= di->threshold_ ||
+      (di->threshold_.value() < 0.0 && mapDistance_ >= -(di->threshold_));
 
-   if ((!thresholded_ || thresholdMet) &&
+   if (thresholdMet &&
        (di->startTime_ == std::chrono::system_clock::time_point {} ||
         (di->startTime_ <= selectedTime && selectedTime < di->endTime_)))
    {

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_text.cpp
@@ -136,8 +136,9 @@ void PlacefileText::Impl::RenderTextDrawItem(
          std::chrono::system_clock::now() :
          selectedTime_;
 
-   const bool thresholdMet = mapDistance_ <= di->threshold_ ||
-        ((double)di->threshold_ < 0.0 && mapDistance_ >= -(di->threshold_));
+   const bool thresholdMet =
+      mapDistance_ <= di->threshold_ ||
+      ((double) di->threshold_ < 0.0 && mapDistance_ >= -(di->threshold_));
 
    if ((!thresholded_ || thresholdMet) &&
        (di->startTime_ == std::chrono::system_clock::time_point {} ||


### PR DESCRIPTION
If this is not a change you want to make, I am fine with that. It was a small change I was interested in, and I want your opinion on it. 
Inverted threshold means that once you zoom in past that threshold, it disrepair. This is useful for placefiles that give low detail, nation wide information, such as surface fronts.

Breaking Compatibility
I do not believe this will break compatibility with placefiles or other programs. If any placefile does use negative numbers to disable threshold's, the user can disable thresholds in Supercell Wx. The only case this would not work is if a placefile sometimes has thresholds, and sometimes uses negative numbers to disable thresholds. If other programs act as Supercell Wx did before this change, then any placefile with negative threshold will simply not have a threshold.