### PR TITLE
Radar site threshold

### DIFF
--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -65,7 +65,9 @@ void RadarSiteLayer::Render(
    auto mapDistance = util::maplibre::GetMapDistance(params);
    auto threshold   = units::length::nautical_miles<double>(
       settings::GeneralSettings::Instance().radar_site_threshold().GetValue());
-   if (threshold.value() != 0.0 && mapDistance > threshold)
+
+   if (!(threshold.value() == 0.0 || mapDistance <= threshold ||
+         (threshold.value() < 0 && mapDistance >= -threshold)))
    {
       return;
    }

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -63,7 +63,7 @@ void RadarSiteLayer::Render(
    p->hoverText_.clear();
 
    auto mapDistance = util::maplibre::GetMapDistance(params);
-   auto threshold   = units::length::nautical_miles<double>(
+   auto threshold   = units::length::kilometers<double>(
       settings::GeneralSettings::Instance().radar_site_threshold().GetValue());
 
    if (!(threshold.value() == 0.0 || mapDistance <= threshold ||

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -1,5 +1,6 @@
 #include <scwx/qt/map/radar_site_layer.hpp>
 #include <scwx/qt/config/radar_site.hpp>
+#include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/settings/text_settings.hpp>
 #include <scwx/qt/util/maplibre.hpp>
 #include <scwx/qt/util/tooltip.hpp>
@@ -59,6 +60,16 @@ void RadarSiteLayer::Initialize()
 void RadarSiteLayer::Render(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
+   p->hoverText_.clear();
+
+   auto mapDistance = util::maplibre::GetMapDistance(params);
+   auto threshold   = units::length::nautical_miles<double>(
+      settings::GeneralSettings::Instance().radar_site_threshold().GetValue());
+   if (threshold.value() != 0.0 && mapDistance > threshold)
+   {
+      return;
+   }
+
    gl::OpenGLFunctions& gl = context()->gl();
 
    context()->set_render_parameters(params);
@@ -72,8 +83,6 @@ void RadarSiteLayer::Render(
    p->mapBearingSin_ = sinf(params.bearing * common::kDegreesToRadians);
    p->halfWidth_     = params.width * 0.5f;
    p->halfHeight_    = params.height * 0.5f;
-
-   p->hoverText_.clear();
 
    // Radar site ImGui windows shouldn't have padding
    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2 {0.0f, 0.0f});

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -97,7 +97,7 @@ public:
       nmeaBaudRate_.SetMinimum(1);
       nmeaBaudRate_.SetMaximum(999999999);
       radarSiteThreshold_.SetMinimum(-10000);
-      radarSiteThreshold_.SetMaximum( 10000);
+      radarSiteThreshold_.SetMaximum(10000);
 
       customStyleDrawLayer_.SetTransform([](const std::string& value)
                                          { return boost::trim_copy(value); });

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -96,8 +96,8 @@ public:
       loopTime_.SetMaximum(1440);
       nmeaBaudRate_.SetMinimum(1);
       nmeaBaudRate_.SetMaximum(999999999);
-      radarSiteThreshold_.SetMinimum(0);
-      radarSiteThreshold_.SetMaximum(999);
+      radarSiteThreshold_.SetMinimum(-10000);
+      radarSiteThreshold_.SetMaximum( 10000);
 
       customStyleDrawLayer_.SetTransform([](const std::string& value)
                                          { return boost::trim_copy(value); });

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -78,6 +78,7 @@ public:
       updateNotificationsEnabled_.SetDefault(true);
       warningsProvider_.SetDefault(defaultWarningsProviderValue);
       cursorIconAlwaysOn_.SetDefault(false);
+      radarSiteThreshold_.SetDefault(0.0);
 
       fontSizes_.SetElementMinimum(1);
       fontSizes_.SetElementMaximum(72);
@@ -95,6 +96,8 @@ public:
       loopTime_.SetMaximum(1440);
       nmeaBaudRate_.SetMinimum(1);
       nmeaBaudRate_.SetMaximum(999999999);
+      radarSiteThreshold_.SetMinimum(0);
+      radarSiteThreshold_.SetMaximum(999);
 
       customStyleDrawLayer_.SetTransform([](const std::string& value)
                                          { return boost::trim_copy(value); });
@@ -168,6 +171,7 @@ public:
    SettingsVariable<bool> updateNotificationsEnabled_ {"update_notifications"};
    SettingsVariable<std::string> warningsProvider_ {"warnings_provider"};
    SettingsVariable<bool>        cursorIconAlwaysOn_ {"cursor_icon_always_on"};
+   SettingsVariable<double>      radarSiteThreshold_ {"radar_site_threshold"};
 };
 
 GeneralSettings::GeneralSettings() :
@@ -201,7 +205,8 @@ GeneralSettings::GeneralSettings() :
                       &p->trackLocation_,
                       &p->updateNotificationsEnabled_,
                       &p->warningsProvider_,
-                      &p->cursorIconAlwaysOn_});
+                      &p->cursorIconAlwaysOn_,
+                      &p->radarSiteThreshold_});
    SetDefaults();
 }
 GeneralSettings::~GeneralSettings() = default;
@@ -356,6 +361,11 @@ SettingsVariable<bool>& GeneralSettings::cursor_icon_always_on() const
    return p->cursorIconAlwaysOn_;
 }
 
+SettingsVariable<double>& GeneralSettings::radar_site_threshold() const
+{
+   return p->radarSiteThreshold_;
+}
+
 bool GeneralSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -406,7 +416,8 @@ bool operator==(const GeneralSettings& lhs, const GeneralSettings& rhs)
            lhs.p->updateNotificationsEnabled_ ==
               rhs.p->updateNotificationsEnabled_ &&
            lhs.p->warningsProvider_ == rhs.p->warningsProvider_ &&
-           lhs.p->cursorIconAlwaysOn_ == rhs.p->cursorIconAlwaysOn_);
+           lhs.p->cursorIconAlwaysOn_ == rhs.p->cursorIconAlwaysOn_ &&
+           lhs.p->radarSiteThreshold_ == rhs.p->radarSiteThreshold_);
 }
 
 } // namespace settings

--- a/scwx-qt/source/scwx/qt/settings/general_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.hpp
@@ -54,6 +54,7 @@ public:
    SettingsVariable<bool>&        update_notifications_enabled() const;
    SettingsVariable<std::string>& warnings_provider() const;
    SettingsVariable<bool>&        cursor_icon_always_on() const;
+   SettingsVariable<double>&      radar_site_threshold() const;
 
    static GeneralSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -753,8 +753,7 @@ void SettingsDialogImpl::SetupGeneralTab()
 
    radarSiteThreshold_.SetSettingsVariable(
       generalSettings.radar_site_threshold());
-   radarSiteThreshold_.SetEditWidget(
-      self_->ui->radarSiteThresholdSpinBox);
+   radarSiteThreshold_.SetEditWidget(self_->ui->radarSiteThresholdSpinBox);
    radarSiteThreshold_.SetResetButton(self_->ui->resetRadarSiteThresholdButton);
 
    antiAliasingEnabled_.SetSettingsVariable(

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -755,6 +755,22 @@ void SettingsDialogImpl::SetupGeneralTab()
       generalSettings.radar_site_threshold());
    radarSiteThreshold_.SetEditWidget(self_->ui->radarSiteThresholdSpinBox);
    radarSiteThreshold_.SetResetButton(self_->ui->resetRadarSiteThresholdButton);
+   radarSiteThreshold_.SetUnitLabel(self_->ui->radarSiteThresholdUnitLabel);
+   auto radarSiteThresholdUpdateUnits = [this](const std::string& newValue)
+   {
+      types::DistanceUnits radiusUnits =
+         types::GetDistanceUnitsFromName(newValue);
+      double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
+      std::string abbreviation =
+         types::GetDistanceUnitsAbbreviation(radiusUnits);
+
+      radarSiteThreshold_.SetUnit(radiusScale, abbreviation);
+   };
+   settings::UnitSettings::Instance()
+      .distance_units()
+      .RegisterValueStagedCallback(radarSiteThresholdUpdateUnits);
+   radarSiteThresholdUpdateUnits(
+      settings::UnitSettings::Instance().distance_units().GetValue());
 
    antiAliasingEnabled_.SetSettingsVariable(
       generalSettings.anti_aliasing_enabled());

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -758,10 +758,10 @@ void SettingsDialogImpl::SetupGeneralTab()
    radarSiteThreshold_.SetUnitLabel(self_->ui->radarSiteThresholdUnitLabel);
    auto radarSiteThresholdUpdateUnits = [this](const std::string& newValue)
    {
-      types::DistanceUnits radiusUnits =
+      const types::DistanceUnits radiusUnits =
          types::GetDistanceUnitsFromName(newValue);
-      double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
-      std::string abbreviation =
+      const double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
+      const std::string abbreviation =
          types::GetDistanceUnitsAbbreviation(radiusUnits);
 
       radarSiteThreshold_.SetUnit(radiusScale, abbreviation);
@@ -1082,10 +1082,10 @@ void SettingsDialogImpl::SetupAudioTab()
    alertAudioRadius_.SetUnitLabel(self_->ui->alertAudioRadiusUnitsLabel);
    auto alertAudioRadiusUpdateUnits = [this](const std::string& newValue)
    {
-      types::DistanceUnits radiusUnits =
+      const types::DistanceUnits radiusUnits =
          types::GetDistanceUnitsFromName(newValue);
-      double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
-      std::string abbreviation =
+      const double      radiusScale = types::GetDistanceUnitsScale(radiusUnits);
+      const std::string abbreviation =
          types::GetDistanceUnitsAbbreviation(radiusUnits);
 
       alertAudioRadius_.SetUnit(radiusScale, abbreviation);

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -133,6 +133,7 @@ public:
           &nmeaBaudRate_,
           &nmeaSource_,
           &warningsProvider_,
+          &radarSiteThreshold_,
           &antiAliasingEnabled_,
           &showMapAttribution_,
           &showMapCenter_,
@@ -249,6 +250,7 @@ public:
    settings::SettingsInterface<std::string>  theme_ {};
    settings::SettingsInterface<std::string>  themeFile_ {};
    settings::SettingsInterface<std::string>  warningsProvider_ {};
+   settings::SettingsInterface<double>       radarSiteThreshold_ {};
    settings::SettingsInterface<bool>         antiAliasingEnabled_ {};
    settings::SettingsInterface<bool>         showMapAttribution_ {};
    settings::SettingsInterface<bool>         showMapCenter_ {};
@@ -748,6 +750,12 @@ void SettingsDialogImpl::SetupGeneralTab()
    warningsProvider_.SetEditWidget(self_->ui->warningsProviderLineEdit);
    warningsProvider_.SetResetButton(self_->ui->resetWarningsProviderButton);
    warningsProvider_.EnableTrimming();
+
+   radarSiteThreshold_.SetSettingsVariable(
+      generalSettings.radar_site_threshold());
+   radarSiteThreshold_.SetEditWidget(
+      self_->ui->radarSiteThresholdSpinBox);
+   radarSiteThreshold_.SetResetButton(self_->ui->resetRadarSiteThresholdButton);
 
    antiAliasingEnabled_.SetSettingsVariable(
       generalSettings.anti_aliasing_enabled());

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -122,7 +122,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -572,8 +572,17 @@
                   </item>
                   <item row="23" column="2">
                    <widget class="QDoubleSpinBox" name="radarSiteThresholdSpinBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                     <string>Set to 0 to disable</string>
+                    </property>
                     <property name="suffix">
-                     <string>NM</string>
+                     <string/>
                     </property>
                     <property name="decimals">
                      <number>0</number>
@@ -586,6 +595,16 @@
                     </property>
                     <property name="stepType">
                      <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="23" column="3">
+                   <widget class="QLabel" name="radarSiteThresholdUnitLabel">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="text">
+                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -822,6 +841,9 @@
               </item>
               <item row="5" column="1" colspan="2">
                <widget class="QDoubleSpinBox" name="alertAudioRadiusSpinBox">
+                <property name="toolTip">
+                 <string>Set to 0 to disable</string>
+                </property>
                 <property name="decimals">
                  <number>2</number>
                 </property>

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -572,6 +572,9 @@
                   </item>
                   <item row="23" column="2">
                    <widget class="QDoubleSpinBox" name="radarSiteThresholdSpinBox">
+                    <property name="suffix">
+                     <string>NM</string>
+                    </property>
                     <property name="decimals">
                      <number>0</number>
                     </property>

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -135,9 +135,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-272</y>
-                <width>513</width>
-                <height>702</height>
+                <y>-302</y>
+                <width>511</width>
+                <height>733</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -159,155 +159,15 @@
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item row="3" column="3">
-                   <widget class="QToolButton" name="radarSiteSelectButton">
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_2">
                     <property name="text">
-                     <string>...</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="0">
-                   <widget class="QLabel" name="label_4">
-                    <property name="text">
-                     <string>Mapbox API Key</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="0">
-                   <widget class="QLabel" name="label_27">
-                    <property name="text">
-                     <string>Custom Map Layer</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="2">
-                   <widget class="QComboBox" name="radarSiteComboBox"/>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="label_23">
-                    <property name="text">
-                     <string>GPS Plugin</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="4">
-                   <widget class="QToolButton" name="resetNmeaSourceButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="2">
-                   <widget class="QComboBox" name="mapProviderComboBox"/>
-                  </item>
-                  <item row="14" column="2">
-                   <widget class="QLineEdit" name="customMapUrlLineEdit"/>
-                  </item>
-                  <item row="9" column="3">
-                   <widget class="QToolButton" name="gpsSourceSelectButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="4">
-                   <widget class="QToolButton" name="resetCustomMapLayerButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="2">
-                   <widget class="QComboBox" name="defaultTimeZoneComboBox"/>
-                  </item>
-                  <item row="6" column="2">
-                   <widget class="QSpinBox" name="gridHeightSpinBox"/>
-                  </item>
-                  <item row="11" column="4">
-                   <widget class="QToolButton" name="resetMapProviderButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="4">
-                   <widget class="QToolButton" name="resetCustomMapUrlButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="18" column="4">
-                   <widget class="QToolButton" name="resetThemeButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                     <string>Grid Width</string>
                     </property>
                    </widget>
                   </item>
                   <item row="18" column="2">
                    <widget class="QComboBox" name="themeComboBox"/>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_25">
-                    <property name="text">
-                     <string>GPS Source</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="22" column="2">
-                   <widget class="QLineEdit" name="warningsProviderLineEdit"/>
-                  </item>
-                  <item row="22" column="0">
-                   <widget class="QLabel" name="label_22">
-                    <property name="text">
-                     <string>Warnings Provider</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label">
-                    <property name="text">
-                     <string>Default Radar Site</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="4">
-                   <widget class="QToolButton" name="resetRadarSiteButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="label_3">
-                    <property name="text">
-                     <string>Grid Height</string>
-                    </property>
-                   </widget>
                   </item>
                   <item row="13" column="4">
                    <widget class="QToolButton" name="resetMapTilerApiKeyButton">
@@ -320,20 +180,31 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="10" column="2">
-                   <widget class="QSpinBox" name="nmeaBaudRateSpinBox">
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                    <property name="maximum">
-                     <number>999999999</number>
+                  <item row="9" column="3">
+                   <widget class="QToolButton" name="gpsSourceSelectButton">
+                    <property name="text">
+                     <string>...</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="12" column="2">
-                   <widget class="QLineEdit" name="mapboxApiKeyLineEdit">
-                    <property name="echoMode">
-                     <enum>QLineEdit::EchoMode::Password</enum>
+                  <item row="10" column="4">
+                   <widget class="QToolButton" name="resetNmeaBaudRateButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="clockFormatComboBox"/>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_4">
+                    <property name="text">
+                     <string>Mapbox API Key</string>
                     </property>
                    </widget>
                   </item>
@@ -348,110 +219,8 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="2">
-                   <widget class="QLineEdit" name="nmeaSourceLineEdit"/>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QLabel" name="label_24">
-                    <property name="text">
-                     <string>GPS Baud Rate</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="4">
-                   <widget class="QToolButton" name="resetGridHeightButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="4">
-                   <widget class="QToolButton" name="resetMapboxApiKeyButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="4">
-                   <widget class="QToolButton" name="resetGridWidthButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="4">
-                   <widget class="QToolButton" name="resetDefaultTimeZoneButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="label_7">
-                    <property name="text">
-                     <string>Map Provider</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="2">
-                   <widget class="QSpinBox" name="gridWidthSpinBox"/>
-                  </item>
-                  <item row="18" column="0">
-                   <widget class="QLabel" name="label_5">
-                    <property name="text">
-                     <string>Theme</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="0">
-                   <widget class="QLabel" name="label_6">
-                    <property name="text">
-                     <string>MapTiler API Key</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="4">
-                   <widget class="QToolButton" name="resetClockFormatButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="2">
-                   <widget class="QLineEdit" name="customMapLayerLineEdit"/>
-                  </item>
-                  <item row="14" column="0">
-                   <widget class="QLabel" name="label_26">
-                    <property name="text">
-                     <string>Custom Map URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QComboBox" name="defaultAlertActionComboBox"/>
-                  </item>
-                  <item row="10" column="4">
-                   <widget class="QToolButton" name="resetNmeaBaudRateButton">
+                  <item row="19" column="4">
+                   <widget class="QToolButton" name="resetThemeFileButton">
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -468,33 +237,8 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="4">
-                   <widget class="QToolButton" name="resetDefaultAlertActionButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="label_2">
-                    <property name="text">
-                     <string>Grid Width</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="2">
-                   <widget class="QLineEdit" name="mapTilerApiKeyLineEdit">
-                    <property name="echoMode">
-                     <enum>QLineEdit::EchoMode::Password</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="4">
-                   <widget class="QToolButton" name="resetPositioningPluginButton">
+                  <item row="9" column="4">
+                   <widget class="QToolButton" name="resetNmeaSourceButton">
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -511,18 +255,33 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="defaultAlertActionLabel">
-                    <property name="text">
-                     <string>Default Alert Action</string>
+                  <item row="13" column="2">
+                   <widget class="QLineEdit" name="mapTilerApiKeyLineEdit">
+                    <property name="echoMode">
+                     <enum>QLineEdit::EchoMode::Password</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="2">
+                   <widget class="QLineEdit" name="mapboxApiKeyLineEdit">
+                    <property name="echoMode">
+                     <enum>QLineEdit::EchoMode::Password</enum>
                     </property>
                    </widget>
                   </item>
                   <item row="8" column="2">
                    <widget class="QComboBox" name="positioningPluginComboBox"/>
                   </item>
-                  <item row="1" column="2">
-                   <widget class="QComboBox" name="clockFormatComboBox"/>
+                  <item row="18" column="4">
+                   <widget class="QToolButton" name="resetThemeButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
                   </item>
                   <item row="19" column="0">
                    <widget class="QLabel" name="label_30">
@@ -531,8 +290,72 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="19" column="2">
-                   <widget class="QLineEdit" name="themeFileLineEdit"/>
+                  <item row="5" column="2">
+                   <widget class="QSpinBox" name="gridWidthSpinBox"/>
+                  </item>
+                  <item row="6" column="4">
+                   <widget class="QToolButton" name="resetGridHeightButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="4">
+                   <widget class="QToolButton" name="resetRadarSiteButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="2">
+                   <widget class="QComboBox" name="defaultTimeZoneComboBox"/>
+                  </item>
+                  <item row="5" column="4">
+                   <widget class="QToolButton" name="resetGridWidthButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="2">
+                   <widget class="QLineEdit" name="customMapUrlLineEdit"/>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="defaultAlertActionLabel">
+                    <property name="text">
+                     <string>Default Alert Action</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string>MapTiler API Key</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="4">
+                   <widget class="QToolButton" name="resetMapProviderButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
                   </item>
                   <item row="19" column="3">
                    <widget class="QToolButton" name="themeFileSelectButton">
@@ -541,14 +364,222 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="19" column="4">
-                   <widget class="QToolButton" name="resetThemeFileButton">
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_25">
+                    <property name="text">
+                     <string>GPS Source</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="2">
+                   <widget class="QLineEdit" name="customMapLayerLineEdit"/>
+                  </item>
+                  <item row="14" column="0">
+                   <widget class="QLabel" name="label_26">
+                    <property name="text">
+                     <string>Custom Map URL</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="2">
+                   <widget class="QSpinBox" name="nmeaBaudRateSpinBox">
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>999999999</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="2">
+                   <widget class="QComboBox" name="mapProviderComboBox"/>
+                  </item>
+                  <item row="19" column="2">
+                   <widget class="QLineEdit" name="themeFileLineEdit"/>
+                  </item>
+                  <item row="2" column="4">
+                   <widget class="QToolButton" name="resetDefaultAlertActionButton">
                     <property name="text">
                      <string>...</string>
                     </property>
                     <property name="icon">
                      <iconset resource="../../../../scwx-qt.qrc">
                       <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="4">
+                   <widget class="QToolButton" name="resetCustomMapLayerButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="2">
+                   <widget class="QLineEdit" name="nmeaSourceLineEdit"/>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_7">
+                    <property name="text">
+                     <string>Map Provider</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="0">
+                   <widget class="QLabel" name="label_5">
+                    <property name="text">
+                     <string>Theme</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="4">
+                   <widget class="QToolButton" name="resetDefaultTimeZoneButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="22" column="0">
+                   <widget class="QLabel" name="label_22">
+                    <property name="text">
+                     <string>Warnings Provider</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label">
+                    <property name="text">
+                     <string>Default Radar Site</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="4">
+                   <widget class="QToolButton" name="resetCustomMapUrlButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_24">
+                    <property name="text">
+                     <string>GPS Baud Rate</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_27">
+                    <property name="text">
+                     <string>Custom Map Layer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="2">
+                   <widget class="QSpinBox" name="gridHeightSpinBox"/>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QComboBox" name="defaultAlertActionComboBox"/>
+                  </item>
+                  <item row="12" column="4">
+                   <widget class="QToolButton" name="resetMapboxApiKeyButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="22" column="2">
+                   <widget class="QLineEdit" name="warningsProviderLineEdit"/>
+                  </item>
+                  <item row="8" column="4">
+                   <widget class="QToolButton" name="resetPositioningPluginButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="3">
+                   <widget class="QToolButton" name="radarSiteSelectButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0">
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Grid Height</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="4">
+                   <widget class="QToolButton" name="resetClockFormatButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_23">
+                    <property name="text">
+                     <string>GPS Plugin</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="2">
+                   <widget class="QComboBox" name="radarSiteComboBox"/>
+                  </item>
+                  <item row="23" column="0">
+                   <widget class="QLabel" name="label_31">
+                    <property name="text">
+                     <string>Radar Site Threshold</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="23" column="4">
+                   <widget class="QToolButton" name="resetRadarSiteThresholdButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="23" column="2">
+                   <widget class="QDoubleSpinBox" name="radarSiteThresholdSpinBox">
+                    <property name="decimals">
+                     <number>0</number>
+                    </property>
+                    <property name="maximum">
+                     <double>999.000000000000000</double>
+                    </property>
+                    <property name="stepType">
+                     <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
                     </property>
                    </widget>
                   </item>

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -135,7 +135,7 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-302</y>
+                <y>-303</y>
                 <width>511</width>
                 <height>733</height>
                </rect>
@@ -575,8 +575,11 @@
                     <property name="decimals">
                      <number>0</number>
                     </property>
+                    <property name="minimum">
+                     <double>-10000.000000000000000</double>
+                    </property>
                     <property name="maximum">
-                     <double>999.000000000000000</double>
+                     <double>10000.000000000000000</double>
                     </property>
                     <property name="stepType">
                      <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>


### PR DESCRIPTION
Another quality of life feature for looking at nationwide radar/placefiles.

## Settings
1. Setting to zero disables threshold, but maybe a checkbox or tooltip should be added to make that clear.
2. Units. Currently uses nautical miles for constancy with placefiles. Could be changed to following distance units settings like alert radius.

## Linting
1. Magic numbers for settings default/min/max. I think adding constants for each would generally decrease readability. I think we should add `NOLINTBEGIN(readability-magic-numbers)`/`NOLINTEND` + comment to avoid this in the future if you agree.
2. `[[nodiscard]]`. This should probably be fixed for all settings in one pull or commit.
I can make a separate pull request for these if you think that would be best. 