### PR TITLE
Bump dependency Qt to 6.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             compiler: msvc
             msvc_arch: x64
             msvc_version: 2022
-            qt_version: 6.8.0
+            qt_version: 6.8.1
             qt_arch_aqt: win64_msvc2022_64
             qt_arch_dir: msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
@@ -42,7 +42,7 @@ jobs:
             env_cc: gcc-11
             env_cxx: g++-11
             compiler: gcc
-            qt_version: 6.8.0
+            qt_version: 6.8.1
             qt_arch_aqt: linux_gcc_64
             qt_arch_dir: gcc_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
@@ -57,7 +57,7 @@ jobs:
             env_cc: clang-17
             env_cxx: clang++-17
             compiler: clang
-            qt_version: 6.8.0
+            qt_version: 6.8.1
             qt_arch_aqt: linux_gcc_64
             qt_arch_dir: gcc_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
             build_type: Release
             env_cc: clang-17
             env_cxx: clang++-17
-            qt_version: 6.8.0
+            qt_version: 6.8.1
             qt_arch_aqt: linux_gcc_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''

--- a/setup-debug.bat
+++ b/setup-debug.bat
@@ -3,7 +3,7 @@ call tools\setup-common.bat
 set build_dir=build-debug
 set build_type=Debug
 set conan_profile=scwx-win64_msvc2022
-set qt_version=6.8.0
+set qt_version=6.8.1
 set qt_arch=msvc2022_64
 
 conan config install tools/conan/profiles/%conan_profile% -tf profiles

--- a/setup-debug.sh
+++ b/setup-debug.sh
@@ -4,7 +4,7 @@
 build_dir=${1:-build-debug}
 build_type=Debug
 conan_profile=${2:-scwx-linux_gcc-11}
-qt_version=6.8.0
+qt_version=6.8.1
 qt_arch=gcc_64
 script_dir="$(dirname "$(readlink -f "$0")")"
 

--- a/setup-multi.bat
+++ b/setup-multi.bat
@@ -2,7 +2,7 @@ call tools\setup-common.bat
 
 set build_dir=build
 set conan_profile=scwx-win64_msvc2022
-set qt_version=6.8.0
+set qt_version=6.8.1
 set qt_arch=msvc2022_64
 
 conan config install tools/conan/profiles/%conan_profile% -tf profiles

--- a/setup-release.bat
+++ b/setup-release.bat
@@ -3,7 +3,7 @@ call tools\setup-common.bat
 set build_dir=build-release
 set build_type=Release
 set conan_profile=scwx-win64_msvc2022
-set qt_version=6.8.0
+set qt_version=6.8.1
 set qt_arch=msvc2022_64
 
 conan config install tools/conan/profiles/%conan_profile% -tf profiles

--- a/setup-release.sh
+++ b/setup-release.sh
@@ -4,7 +4,7 @@
 build_dir=${1:-build-release}
 build_type=Release
 conan_profile=${2:-scwx-linux_gcc-11}
-qt_version=6.8.0
+qt_version=6.8.1
 qt_arch=gcc_64
 script_dir="$(dirname "$(readlink -f "$0")")"
 


### PR DESCRIPTION
Simple version bump (only tested on Linux). Up to you if you want the version bump before the release or not.