### PR TITLE
A few UI changes to location markers part2

### DIFF
--- a/scwx-qt/source/scwx/qt/ui/edit_marker_dialog.hpp
+++ b/scwx-qt/source/scwx/qt/ui/edit_marker_dialog.hpp
@@ -21,7 +21,7 @@ public:
 
    void setup();
    void setup(double latitude, double longitude);
-   void setup(types::MarkerId id);
+   void setup(types::MarkerId id, bool adding = false);
 
    [[nodiscard]] types::MarkerInfo get_marker_info() const;
 

--- a/scwx-qt/source/scwx/qt/ui/marker_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/marker_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Marker Manager</string>
+   <string>Location Marker Manager</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
# Changes
1. Location Marker Manager title from "Marker Manager" to "Location Marker Manager"
2. Edit Location Marker Dialog title switches between "Add Location Marker" and "Edit Location Marker"
3. Make Apply switch from adding to editing