### PR TITLE
Revert libcurl 8.11.1 to 8.10.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class SupercellWxConan(ConanFile):
                   "glew/2.2.0",
                   "glm/1.0.1",
                   "gtest/1.15.0",
-                  "libcurl/8.11.1",
+                  "libcurl/8.10.1",
                   "libpng/1.6.45",
                   "libxml2/2.13.4",
                   "openssl/3.3.2",


### PR DESCRIPTION
libcurl 8.11.1 has a bug with improperly closing file handles