### PR TITLE
Set parameters in each layer to ensure params is set for mouse picking.

### DIFF
--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -48,6 +48,7 @@ void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
    gl::OpenGLFunctions& gl = p->context_->gl();
    p->textureAtlas_        = p->context_->GetTextureAtlas();
+   p->context_->set_render_parameters(params);
 
    // Determine if the texture atlas changed since last render
    std::uint64_t newTextureAtlasBuildCount =

--- a/scwx-qt/source/scwx/qt/map/marker_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/marker_layer.cpp
@@ -162,7 +162,6 @@ void MarkerLayer::Impl::set_icon_sheets()
 void MarkerLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
    gl::OpenGLFunctions& gl = context()->gl();
-   context()->set_render_parameters(params);
 
    DrawLayer::Render(params);
 


### PR DESCRIPTION
Currently only `OverlayLayer::Render`, `RadarSiteLayer::Render`, and `MarkerLayer::Render` set params in the context. This works fine when at least one is enabled, but if one is not, it breaks mouse picking for hover text.