### PR TITLE
Fix Tooltips Without Info Layers 2

### DIFF
--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -48,7 +48,6 @@ void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
    gl::OpenGLFunctions& gl = p->context_->gl();
    p->textureAtlas_        = p->context_->GetTextureAtlas();
-   p->context_->set_render_parameters(params);
 
    // Determine if the texture atlas changed since last render
    std::uint64_t newTextureAtlasBuildCount =

--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -27,7 +27,6 @@ public:
       common::RadarProductGroup::Unknown};
    std::string                            radarProduct_ {"???"};
    int16_t                                radarProductCode_ {0};
-   QMapLibre::CustomLayerRenderParameters renderParameters_ {};
 
    MapProvider mapProvider_ {MapProvider::Unknown};
    std::string mapCopyrights_ {};
@@ -110,11 +109,6 @@ int16_t MapContext::radar_product_code() const
    return p->radarProductCode_;
 }
 
-QMapLibre::CustomLayerRenderParameters MapContext::render_parameters() const
-{
-   return p->renderParameters_;
-}
-
 void MapContext::set_map(const std::shared_ptr<QMapLibre::Map>& map)
 {
    p->map_ = map;
@@ -171,12 +165,6 @@ void MapContext::set_radar_product(const std::string& radarProduct)
 void MapContext::set_radar_product_code(int16_t radarProductCode)
 {
    p->radarProductCode_ = radarProductCode;
-}
-
-void MapContext::set_render_parameters(
-   const QMapLibre::CustomLayerRenderParameters& params)
-{
-   p->renderParameters_ = params;
 }
 
 } // namespace map

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -50,7 +50,6 @@ public:
    common::RadarProductGroup                 radar_product_group() const;
    std::string                               radar_product() const;
    int16_t                                   radar_product_code() const;
-   QMapLibre::CustomLayerRenderParameters    render_parameters() const;
 
    void set_map(const std::shared_ptr<QMapLibre::Map>& map);
    void set_map_copyrights(const std::string& copyrights);
@@ -65,8 +64,6 @@ public:
    void set_radar_product_group(common::RadarProductGroup radarProductGroup);
    void set_radar_product(const std::string& radarProduct);
    void set_radar_product_code(int16_t radarProductCode);
-   void
-   set_render_parameters(const QMapLibre::CustomLayerRenderParameters& params);
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1649,8 +1649,15 @@ void MapWidgetImpl::ImGuiCheckFonts()
 
 void MapWidgetImpl::RunMousePicking()
 {
-   const QMapLibre::CustomLayerRenderParameters params =
-      context_->render_parameters();
+   const QMapLibre::CustomLayerRenderParameters params = {
+      .width       = static_cast<double>(widget_->size().width()),
+      .height      = static_cast<double>(widget_->size().height()),
+      .latitude    = map_->coordinate().first,
+      .longitude   = map_->coordinate().second,
+      .zoom        = map_->zoom(),
+      .bearing     = map_->bearing(),
+      .pitch       = map_->pitch(),
+      .fieldOfView = 0};
 
    auto coordinate = map_->coordinateForPixel(lastPos_);
    auto mouseScreenCoordinate =

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -292,8 +292,6 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    auto&                settings         = context()->settings();
    const float          pixelRatio       = context()->pixel_ratio();
 
-   context()->set_render_parameters(params);
-
    p->sweepTimePicked_ = false;
 
    if (radarProductView != nullptr)

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -74,8 +74,6 @@ void RadarSiteLayer::Render(
 
    gl::OpenGLFunctions& gl = context()->gl();
 
-   context()->set_render_parameters(params);
-
    // Update map screen coordinate and scale information
    p->mapScreenCoordLocation_ = util::maplibre::LatLongToScreenCoordinate(
       {params.latitude, params.longitude});


### PR DESCRIPTION
Rewrite of #356.

Use information available during `DoMousePicking` instead of params from last render in `MapWidget`. Constructs a `CustomLayerRenderParameters` to pass to other mouse picking methods. I was not sure what `fieldOfView` was, and it was not used, so I did not set it. Maybe a different method of passing this information should be used, but that would require rewriting a bunch of functions, and possibly code outside of mouse picking. I was also able to fully remove the parameters from the map context.