### PR TITLE
Fix tooltips at high zooms

### DIFF
--- a/scwx-qt/source/scwx/qt/util/maplibre.cpp
+++ b/scwx-qt/source/scwx/qt/util/maplibre.cpp
@@ -46,6 +46,8 @@ glm::vec2 GetMapScale(const QMapLibre::CustomLayerRenderParameters& params)
 bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
                       const glm::vec2&              point)
 {
+   // All members of these unions are floats, so no type safety violation
+   // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
    bool inPolygon = true;
    bool allSame   = true;
 
@@ -80,6 +82,7 @@ bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
    }
 
    return inPolygon;
+   // NOLINTEND(cppcoreguidelines-pro-type-union-access)
 }
 
 glm::vec2 LatLongToScreenCoordinate(const QMapLibre::Coordinate& coordinate)

--- a/scwx-qt/source/scwx/qt/util/maplibre.cpp
+++ b/scwx-qt/source/scwx/qt/util/maplibre.cpp
@@ -47,7 +47,7 @@ bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
                       const glm::vec2&              point)
 {
    bool inPolygon = true;
-   bool allSame = true;
+   bool allSame   = true;
 
    // For each vertex, assume counterclockwise order
    for (std::size_t i = 0; i < vertices.size(); ++i)

--- a/scwx-qt/source/scwx/qt/util/maplibre.cpp
+++ b/scwx-qt/source/scwx/qt/util/maplibre.cpp
@@ -47,6 +47,7 @@ bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
                       const glm::vec2&              point)
 {
    bool inPolygon = true;
+   bool allSame = true;
 
    // For each vertex, assume counterclockwise order
    for (std::size_t i = 0; i < vertices.size(); ++i)
@@ -54,6 +55,8 @@ bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
       const auto& p1 = vertices[i];
       const auto& p2 =
          (i == vertices.size() - 1) ? vertices[0] : vertices[i + 1];
+
+      allSame = allSame && p1.x == p2.x && p1.y == p2.y;
 
       // Test which side of edge point lies on
       const float a = -(p2.y - p1.y);
@@ -68,6 +71,12 @@ bool IsPointInPolygon(const std::vector<glm::vec2>& vertices,
          inPolygon = false;
          break;
       }
+   }
+
+   if (allSame)
+   {
+      inPolygon = vertices.size() > 0 && vertices[0].x == point.x &&
+                  vertices[0].y == point.y;
    }
 
    return inPolygon;


### PR DESCRIPTION
Check if all points given to `scwx::qt::util::maplibre::IsPointInPolygon` are the same, and if they are, fall back to a point check, rather than a polygon check. I can think of a few other ways to fix this, but this may be the simplest. The tooltips do not fully align with the icon when zoomed in, but I think that is way better than having the tooltip always pop up.

The clang-tidy warning is all over this section of code. I think it should either be disabled, or NOLINT'ed. 