### PR TITLE
Radar Product Manager rare crash when changing radar sites

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -794,7 +794,7 @@ void RadarProductManagerImpl::RefreshDataSync(
       interval = kSlowRetryInterval_;
    }
 
-   std::unique_lock lock(providerManager->refreshTimerMutex_);
+   std::unique_lock const lock(providerManager->refreshTimerMutex_);
 
    if (providerManager->refreshEnabled_)
    {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -794,10 +794,10 @@ void RadarProductManagerImpl::RefreshDataSync(
       interval = kSlowRetryInterval_;
    }
 
+   std::unique_lock lock(providerManager->refreshTimerMutex_);
+
    if (providerManager->refreshEnabled_)
    {
-      std::unique_lock lock(providerManager->refreshTimerMutex_);
-
       logger_->debug(
          "[{}] Scheduled refresh in {:%M:%S}",
          providerManager->name(),


### PR DESCRIPTION
Fix destructor race condition by taking refresh mutex prior to checking refresh enabled status