### PR TITLE
Color palette fallback

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1865,56 +1865,49 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
 void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
-   boost::asio::post(threadPool_,
-                     [colorPalette, this]()
-                     {
-                        try
-                        {
-                           auto radarProductView =
-                              context_->radar_product_view();
+   boost::asio::post(
+      threadPool_,
+      [colorPalette, this]()
+      {
+         try
+         {
+            auto radarProductView = context_->radar_product_view();
 
-                           auto& paletteSetting =
-                              settings::PaletteSettings::Instance().palette(
-                                 colorPalette);
+            auto& paletteSetting =
+               settings::PaletteSettings::Instance().palette(colorPalette);
 
-                           std::string colorTableFile =
-                              paletteSetting.GetValue();
-                           if (colorTableFile.empty())
-                           {
-                              colorTableFile = paletteSetting.GetDefault();
-                           }
+            std::string colorTableFile = paletteSetting.GetValue();
+            if (colorTableFile.empty())
+            {
+               colorTableFile = paletteSetting.GetDefault();
+            }
 
-                           std::unique_ptr<std::istream> colorTableStream =
-                              util::OpenFile(colorTableFile);
-                           if (colorTableStream->fail())
-                           {
-                              logger_->warn("Could not open color table {}",
-                                            colorTableFile);
-                              colorTableStream =
-                                 util::OpenFile(paletteSetting.GetDefault());
-                           }
+            std::unique_ptr<std::istream> colorTableStream =
+               util::OpenFile(colorTableFile);
+            if (colorTableStream->fail())
+            {
+               logger_->warn("Could not open color table {}", colorTableFile);
+               colorTableStream = util::OpenFile(paletteSetting.GetDefault());
+            }
 
-                           std::shared_ptr<common::ColorTable> colorTable =
-                              common::ColorTable::Load(*colorTableStream);
-                           if (!colorTable->IsValid())
-                           {
-                              logger_->warn("Could not load color table {}",
-                                            colorTableFile);
-                              colorTableStream =
-                                 util::OpenFile(paletteSetting.GetDefault());
-                              colorTable =
-                                 common::ColorTable::Load(*colorTableStream);
-                           }
+            std::shared_ptr<common::ColorTable> colorTable =
+               common::ColorTable::Load(*colorTableStream);
+            if (!colorTable->IsValid())
+            {
+               logger_->warn("Could not load color table {}", colorTableFile);
+               colorTableStream = util::OpenFile(paletteSetting.GetDefault());
+               colorTable       = common::ColorTable::Load(*colorTableStream);
+            }
 
-                           radarProductView->LoadColorTable(colorTable);
+            radarProductView->LoadColorTable(colorTable);
 
-                           radarProductView->Initialize();
-                        }
-                        catch (const std::exception& ex)
-                        {
-                           logger_->error(ex.what());
-                        }
-                     });
+            radarProductView->Initialize();
+         }
+         catch (const std::exception& ex)
+         {
+            logger_->error(ex.what());
+         }
+      });
 
    if (map_ != nullptr)
    {

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1866,25 +1866,47 @@ void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
    boost::asio::post(threadPool_,
-                     [=, this]()
+                     [colorPalette, this]()
                      {
                         try
                         {
                            auto radarProductView =
                               context_->radar_product_view();
 
+                           auto& paletteSetting =
+                              settings::PaletteSettings::Instance().palette(
+                                 colorPalette);
+
                            std::string colorTableFile =
-                              settings::PaletteSettings::Instance()
-                                 .palette(colorPalette)
-                                 .GetValue();
-                           if (!colorTableFile.empty())
+                              paletteSetting.GetValue();
+                           if (colorTableFile.empty())
                            {
-                              std::unique_ptr<std::istream> colorTableStream =
-                                 util::OpenFile(colorTableFile);
-                              std::shared_ptr<common::ColorTable> colorTable =
-                                 common::ColorTable::Load(*colorTableStream);
-                              radarProductView->LoadColorTable(colorTable);
+                              colorTableFile = paletteSetting.GetDefault();
                            }
+
+                           std::unique_ptr<std::istream> colorTableStream =
+                              util::OpenFile(colorTableFile);
+                           if (colorTableStream->fail())
+                           {
+                              logger_->warn("Could not open color table {}",
+                                            colorTableFile);
+                              colorTableStream =
+                                 util::OpenFile(paletteSetting.GetDefault());
+                           }
+
+                           std::shared_ptr<common::ColorTable> colorTable =
+                              common::ColorTable::Load(*colorTableStream);
+                           if (!colorTable->IsValid())
+                           {
+                              logger_->warn("Could not load color table {}",
+                                            colorTableFile);
+                              colorTableStream =
+                                 util::OpenFile(paletteSetting.GetDefault());
+                              colorTable =
+                                 common::ColorTable::Load(*colorTableStream);
+                           }
+
+                           radarProductView->LoadColorTable(colorTable);
 
                            radarProductView->Initialize();
                         }


### PR DESCRIPTION
Fall back to the default color palettes if a color palette could not be loaded.
Fix for #376.
I think this makes it clearer to the user that something is wrong with their color palettes rather than with retrieving the radar when it fails to load the color palette. In the color palettes settings, the label does not appear when it cannot be loaded, so I think that is good there. I also added logging, so it should be easier to provide support in the future. I did not add a message box, but it would be easy enough to add in the same locations as the logging if desired.