### PR TITLE
Rework layer text

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/font_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/font_manager.cpp
@@ -71,7 +71,7 @@ public:
 
    const std::vector<char>& GetRawFontData(const std::string& filename);
 
-   static bool CheckFontFormat(const FcChar8* format);
+   static bool       CheckFontFormat(const FcChar8* format);
    static FontRecord MatchFontFile(const std::string&              family,
                                    const std::vector<std::string>& styles);
 
@@ -461,7 +461,7 @@ void FontManager::Impl::FinalizeFontconfig()
 
 bool FontManager::Impl::CheckFontFormat(const FcChar8* format)
 {
-   const std::string stdFormat = reinterpret_cast<const char *>(format);
+   const std::string stdFormat = reinterpret_cast<const char*>(format);
 
    return stdFormat == kFcTrueType_ || stdFormat == kFcOpenType_;
 }

--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -229,7 +229,10 @@ public:
 
 AlertLayer::AlertLayer(std::shared_ptr<MapContext> context,
                        awips::Phenomenon           phenomenon) :
-    DrawLayer(context), p(std::make_unique<Impl>(this, context, phenomenon))
+    DrawLayer(
+       context,
+       fmt::format("AlertLayer {}", awips::GetPhenomenonText(phenomenon))),
+    p(std::make_unique<Impl>(this, context, phenomenon))
 {
    for (auto alertActive : {false, true})
    {

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -20,11 +20,13 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class DrawLayerImpl
 {
 public:
-   explicit DrawLayerImpl(std::shared_ptr<MapContext> context) :
+   explicit DrawLayerImpl(std::shared_ptr<MapContext> context,
+                          const std::string&          imGuiContextName) :
        context_ {std::move(context)}, drawList_ {}
    {
-      static size_t currentMapId_ {0u};
-      imGuiContextName_ = fmt::format("Layer {}", ++currentMapId_);
+      static size_t currentLayerId_ {0u};
+      imGuiContextName_ =
+         fmt::format("{} {}", imGuiContextName, ++currentLayerId_);
       // This must be initialized after the last line
       // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
       imGuiContext_ =
@@ -65,8 +67,10 @@ public:
    bool          imGuiRendererInitialized_ {};
 };
 
-DrawLayer::DrawLayer(const std::shared_ptr<MapContext>& context) :
-    GenericLayer(context), p(std::make_unique<DrawLayerImpl>(context))
+DrawLayer::DrawLayer(const std::shared_ptr<MapContext>& context,
+                     const std::string&                 imGuiContextName) :
+    GenericLayer(context),
+    p(std::make_unique<DrawLayerImpl>(context, imGuiContextName))
 {
 }
 DrawLayer::~DrawLayer() = default;

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -161,8 +161,12 @@ void DrawLayer::RenderWithoutImGui(
 
    p->textureAtlasBuildCount_ = newTextureAtlasBuildCount;
 }
+void DrawLayer::ImGuiSelectContext()
+{
+   ImGui::SetCurrentContext(p->imGuiContext_);
+}
 
-   void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
+void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
    StartImGuiFrame();
    RenderWithoutImGui(params);

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -80,7 +80,7 @@ void DrawLayer::Initialize()
    ImGuiInitialize();
 }
 
-void DrawLayer::StartImGuiFrame()
+void DrawLayer::ImGuiFrameStart()
 {
    auto defaultFont = manager::FontManager::Instance().GetImGuiFont(
       types::FontCategory::Default);
@@ -95,7 +95,7 @@ void DrawLayer::StartImGuiFrame()
    ImGui::PushFont(defaultFont->font());
 }
 
-void DrawLayer::EndImGuiFrame()
+void DrawLayer::ImGuiFrameEnd()
 {
    // Pop default font
    ImGui::PopFont();
@@ -145,9 +145,9 @@ void DrawLayer::ImGuiSelectContext()
 
 void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
-   StartImGuiFrame();
+   ImGuiFrameStart();
    RenderWithoutImGui(params);
-   EndImGuiFrame();
+   ImGuiFrameEnd();
 }
 
 void DrawLayer::Deinitialize()

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -25,8 +25,7 @@ public:
    explicit DrawLayerImpl(std::shared_ptr<MapContext> context) :
        context_ {context},
        drawList_ {},
-       textureAtlas_ {GL_INVALID_INDEX},
-       imGuiRendererInitialized_ {false}
+       textureAtlas_ {GL_INVALID_INDEX}
    {
       static size_t currentMapId_ {0u};
       imGuiContextName_ = fmt::format("Layer {}", ++currentMapId_);
@@ -52,35 +51,16 @@ public:
       model::ImGuiContextModel::Instance().DestroyContext(imGuiContextName_);
    }
 
-   void ImGuiCheckFonts();
-
    std::shared_ptr<MapContext>                      context_;
    std::vector<std::shared_ptr<gl::draw::DrawItem>> drawList_;
    GLuint                                           textureAtlas_;
 
    std::uint64_t textureAtlasBuildCount_ {};
 
-   std::string imGuiContextName_;
+   std::string   imGuiContextName_;
    ImGuiContext* imGuiContext_;
-   bool          imGuiRendererInitialized_;
-   std::uint64_t imGuiFontsBuildCount_ {};
+   bool          imGuiRendererInitialized_{};
 };
-
-void DrawLayerImpl::ImGuiCheckFonts()
-{
-   // Update ImGui Fonts if required
-   std::uint64_t currentImGuiFontsBuildCount =
-      manager::FontManager::Instance().imgui_fonts_build_count();
-
-   if (imGuiFontsBuildCount_ != currentImGuiFontsBuildCount ||
-       !model::ImGuiContextModel::Instance().font_atlas()->IsBuilt())
-   {
-      ImGui_ImplOpenGL3_DestroyFontsTexture();
-      ImGui_ImplOpenGL3_CreateFontsTexture();
-   }
-
-   imGuiFontsBuildCount_ = currentImGuiFontsBuildCount;
-}
 
 DrawLayer::DrawLayer(const std::shared_ptr<MapContext>& context) :
     GenericLayer(context), p(std::make_unique<DrawLayerImpl>(context))
@@ -111,7 +91,6 @@ void DrawLayer::StartImGuiFrame()
    // Start ImGui Frame
    ImGui_ImplQt_NewFrame(p->context_->widget());
    ImGui_ImplOpenGL3_NewFrame();
-   p->ImGuiCheckFonts();
    ImGui::NewFrame();
    ImGui::PushFont(defaultFont->font());
 }
@@ -131,8 +110,6 @@ void DrawLayer::ImGuiInitialize()
    ImGui::SetCurrentContext(p->imGuiContext_);
    ImGui_ImplQt_RegisterWidget(p->context_->widget());
    ImGui_ImplOpenGL3_Init();
-   p->imGuiFontsBuildCount_ =
-      manager::FontManager::Instance().imgui_fonts_build_count();
    p->imGuiRendererInitialized_ = true;
 }
 

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -32,6 +32,11 @@ public:
 
 protected:
    void AddDrawItem(const std::shared_ptr<gl::draw::DrawItem>& drawItem);
+   void StartImGuiFrame();
+   void EndImGuiFrame();
+   void ImGuiInitialize();
+   void
+   RenderWithoutImGui(const QMapLibre::CustomLayerRenderParameters& params);
 
 private:
    std::unique_ptr<DrawLayerImpl> p;

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -15,7 +15,8 @@ class DrawLayerImpl;
 class DrawLayer : public GenericLayer
 {
 public:
-   explicit DrawLayer(const std::shared_ptr<MapContext>& context);
+   explicit DrawLayer(const std::shared_ptr<MapContext>& context,
+                      const std::string&                 imGuiContextName);
    virtual ~DrawLayer();
 
    virtual void Initialize() override;

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -32,8 +32,8 @@ public:
 
 protected:
    void AddDrawItem(const std::shared_ptr<gl::draw::DrawItem>& drawItem);
-   void StartImGuiFrame();
-   void EndImGuiFrame();
+   void ImGuiFrameStart();
+   void ImGuiFrameEnd();
    void ImGuiInitialize();
    void
    RenderWithoutImGui(const QMapLibre::CustomLayerRenderParameters& params);

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -37,6 +37,7 @@ protected:
    void ImGuiInitialize();
    void
    RenderWithoutImGui(const QMapLibre::CustomLayerRenderParameters& params);
+   void ImGuiSelectContext();
 
 private:
    std::unique_ptr<DrawLayerImpl> p;

--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -36,6 +36,8 @@ public:
 
    std::shared_ptr<view::OverlayProductView> overlayProductView_ {nullptr};
    std::shared_ptr<view::RadarProductView>   radarProductView_;
+
+   QWidget* widget_;
 };
 
 MapContext::MapContext(
@@ -109,6 +111,19 @@ int16_t MapContext::radar_product_code() const
    return p->radarProductCode_;
 }
 
+<<<<<<< HEAD
+=======
+QMapLibre::CustomLayerRenderParameters MapContext::render_parameters() const
+{
+   return p->renderParameters_;
+}
+
+QWidget* MapContext::widget() const
+{
+   return p->widget_;
+}
+
+>>>>>>> 513a41d3 (Inital code for per map layer ImGui contexts)
 void MapContext::set_map(const std::shared_ptr<QMapLibre::Map>& map)
 {
    p->map_ = map;
@@ -165,6 +180,11 @@ void MapContext::set_radar_product(const std::string& radarProduct)
 void MapContext::set_radar_product_code(int16_t radarProductCode)
 {
    p->radarProductCode_ = radarProductCode;
+}
+
+void MapContext::set_widget(QWidget* widget)
+{
+   p->widget_ = widget;
 }
 
 } // namespace map

--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -111,19 +111,11 @@ int16_t MapContext::radar_product_code() const
    return p->radarProductCode_;
 }
 
-<<<<<<< HEAD
-=======
-QMapLibre::CustomLayerRenderParameters MapContext::render_parameters() const
-{
-   return p->renderParameters_;
-}
-
 QWidget* MapContext::widget() const
 {
    return p->widget_;
 }
 
->>>>>>> 513a41d3 (Inital code for per map layer ImGui contexts)
 void MapContext::set_map(const std::shared_ptr<QMapLibre::Map>& map)
 {
    p->map_ = map;

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -50,7 +50,7 @@ public:
    common::RadarProductGroup                 radar_product_group() const;
    std::string                               radar_product() const;
    int16_t                                   radar_product_code() const;
-   QWidget*                                  widget() const;
+   [[nodiscard]] QWidget*                    widget() const;
 
    void set_map(const std::shared_ptr<QMapLibre::Map>& map);
    void set_map_copyrights(const std::string& copyrights);

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -50,6 +50,7 @@ public:
    common::RadarProductGroup                 radar_product_group() const;
    std::string                               radar_product() const;
    int16_t                                   radar_product_code() const;
+   QWidget*                                  widget() const;
 
    void set_map(const std::shared_ptr<QMapLibre::Map>& map);
    void set_map_copyrights(const std::string& copyrights);
@@ -64,6 +65,7 @@ public:
    void set_radar_product_group(common::RadarProductGroup radarProductGroup);
    void set_radar_product(const std::string& radarProduct);
    void set_radar_product_code(int16_t radarProductCode);
+   void set_widget(QWidget* widget);
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -38,19 +38,21 @@ public:
    MapContext(MapContext&&) noexcept;
    MapContext& operator=(MapContext&&) noexcept;
 
-   std::weak_ptr<QMapLibre::Map>             map() const;
-   std::string                               map_copyrights() const;
-   MapProvider                               map_provider() const;
-   MapSettings&                              settings();
-   QMargins                                  color_table_margins() const;
-   float                                     pixel_ratio() const;
-   common::Coordinate                        mouse_coordinate() const;
-   std::shared_ptr<view::OverlayProductView> overlay_product_view() const;
-   std::shared_ptr<view::RadarProductView>   radar_product_view() const;
-   common::RadarProductGroup                 radar_product_group() const;
-   std::string                               radar_product() const;
-   int16_t                                   radar_product_code() const;
-   [[nodiscard]] QWidget*                    widget() const;
+   [[nodiscard]] std::weak_ptr<QMapLibre::Map> map() const;
+   [[nodiscard]] std::string                   map_copyrights() const;
+   [[nodiscard]] MapProvider                   map_provider() const;
+   [[nodiscard]] MapSettings&                  settings();
+   [[nodiscard]] QMargins                      color_table_margins() const;
+   [[nodiscard]] float                         pixel_ratio() const;
+   [[nodiscard]] common::Coordinate            mouse_coordinate() const;
+   [[nodiscard]] std::shared_ptr<view::OverlayProductView>
+   overlay_product_view() const;
+   [[nodiscard]] std::shared_ptr<view::RadarProductView>
+                                           radar_product_view() const;
+   [[nodiscard]] common::RadarProductGroup radar_product_group() const;
+   [[nodiscard]] std::string               radar_product() const;
+   [[nodiscard]] int16_t                   radar_product_code() const;
+   [[nodiscard]] QWidget*                  widget() const;
 
    void set_map(const std::shared_ptr<QMapLibre::Map>& map);
    void set_map_copyrights(const std::string& copyrights);

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1576,6 +1576,9 @@ void MapWidget::paintGL()
    std::shared_lock imguiFontAtlasLock {
       manager::FontManager::Instance().imgui_font_atlas_mutex()};
 
+   // Check ImGui fonts
+   ImGui::SetCurrentContext(p->imGuiContext_);
+   p->ImGuiCheckFonts();
 
    // Update pixel ratio
    p->context_->set_pixel_ratio(pixelRatio());
@@ -1593,7 +1596,6 @@ void MapWidget::paintGL()
    // Start ImGui Frame
    ImGui_ImplQt_NewFrame(this);
    ImGui_ImplOpenGL3_NewFrame();
-   p->ImGuiCheckFonts();
    ImGui::NewFrame();
 
    // Set default font

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -114,6 +114,7 @@ public:
       context_->set_map_provider(
          GetMapProvider(generalSettings.map_provider().GetValue()));
       context_->set_overlay_product_view(overlayProductView);
+      context_->set_widget(widget);
 
       // Initialize map data
       SetRadarSite(generalSettings.default_radar_site().GetValue());
@@ -1571,21 +1572,10 @@ void MapWidget::paintGL()
    // Handle hotkey updates
    p->HandleHotkeyUpdates();
 
-   // Setup ImGui Frame
-   ImGui::SetCurrentContext(p->imGuiContext_);
-
    // Lock ImGui font atlas prior to new ImGui frame
    std::shared_lock imguiFontAtlasLock {
       manager::FontManager::Instance().imgui_font_atlas_mutex()};
 
-   // Start ImGui Frame
-   ImGui_ImplQt_NewFrame(this);
-   ImGui_ImplOpenGL3_NewFrame();
-   p->ImGuiCheckFonts();
-   ImGui::NewFrame();
-
-   // Set default font
-   ImGui::PushFont(defaultFont->font());
 
    // Update pixel ratio
    p->context_->set_pixel_ratio(pixelRatio());
@@ -1595,6 +1585,19 @@ void MapWidget::paintGL()
    p->map_->setOpenGLFramebufferObject(defaultFramebufferObject(),
                                        size() * pixelRatio());
    p->map_->render();
+
+   // ImGui tool tip code
+   // Setup ImGui Frame
+   ImGui::SetCurrentContext(p->imGuiContext_);
+
+   // Start ImGui Frame
+   ImGui_ImplQt_NewFrame(this);
+   ImGui_ImplOpenGL3_NewFrame();
+   p->ImGuiCheckFonts();
+   ImGui::NewFrame();
+
+   // Set default font
+   ImGui::PushFont(defaultFont->font());
 
    // Perform mouse picking
    if (p->hasMouse_)

--- a/scwx-qt/source/scwx/qt/map/marker_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/marker_layer.cpp
@@ -129,7 +129,8 @@ void MarkerLayer::Impl::ReloadMarkers()
 }
 
 MarkerLayer::MarkerLayer(const std::shared_ptr<MapContext>& context) :
-    DrawLayer(context), p(std::make_unique<MarkerLayer::Impl>(this, context))
+    DrawLayer(context, "MarkerLayer"),
+    p(std::make_unique<MarkerLayer::Impl>(this, context))
 {
    AddDrawItem(p->geoIcons_);
 }

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -292,7 +292,7 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    auto&                settings         = context()->settings();
    const float          pixelRatio       = context()->pixel_ratio();
 
-   StartImGuiFrame();
+   ImGuiFrameStart();
 
    p->sweepTimePicked_ = false;
 
@@ -493,7 +493,7 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    p->lastFontSize_          = ImGui::GetFontSize();
    p->lastColorTableMargins_ = colorTableMargins;
 
-   EndImGuiFrame();
+   ImGuiFrameEnd();
 
    SCWX_GL_CHECK_ERROR();
 }

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -143,7 +143,8 @@ public:
 };
 
 OverlayLayer::OverlayLayer(std::shared_ptr<MapContext> context) :
-    DrawLayer(context), p(std::make_unique<OverlayLayerImpl>(this, context))
+    DrawLayer(context, "OverlayLayer"),
+    p(std::make_unique<OverlayLayerImpl>(this, context))
 {
    AddDrawItem(p->activeBoxOuter_);
    AddDrawItem(p->activeBoxInner_);

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -292,6 +292,8 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    auto&                settings         = context()->settings();
    const float          pixelRatio       = context()->pixel_ratio();
 
+   StartImGuiFrame();
+
    p->sweepTimePicked_ = false;
 
    if (radarProductView != nullptr)
@@ -457,7 +459,7 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    p->icons_->SetIconVisible(p->mapLogoIcon_,
                              generalSettings.show_map_logo().GetValue());
 
-   DrawLayer::Render(params);
+   DrawLayer::RenderWithoutImGui(params);
 
    auto mapCopyrights = context()->map_copyrights();
    if (mapCopyrights.length() > 0 &&
@@ -490,6 +492,8 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    p->lastBearing_           = params.bearing;
    p->lastFontSize_          = ImGui::GetFontSize();
    p->lastColorTableMargins_ = colorTableMargins;
+
+   EndImGuiFrame();
 
    SCWX_GL_CHECK_ERROR();
 }

--- a/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
@@ -109,7 +109,8 @@ public:
 };
 
 OverlayProductLayer::OverlayProductLayer(std::shared_ptr<MapContext> context) :
-    DrawLayer(context), p(std::make_unique<Impl>(this, context))
+    DrawLayer(context, "OverlayProductLayer"),
+    p(std::make_unique<Impl>(this, context))
 {
    auto overlayProductView = context->overlay_product_view();
    connect(overlayProductView.get(),

--- a/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
@@ -66,7 +66,7 @@ public:
 
 PlacefileLayer::PlacefileLayer(const std::shared_ptr<MapContext>& context,
                                const std::string& placefileName) :
-    DrawLayer(context),
+    DrawLayer(context, fmt::format("PlacefileLayer {}", placefileName)),
     p(std::make_unique<PlacefileLayer::Impl>(this, context, placefileName))
 {
    AddDrawItem(p->placefileImages_);

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -55,6 +55,8 @@ void RadarSiteLayer::Initialize()
    logger_->debug("Initialize()");
 
    p->radarSites_ = config::RadarSite::GetAll();
+
+   ImGuiInitialize();
 }
 
 void RadarSiteLayer::Render(
@@ -84,6 +86,7 @@ void RadarSiteLayer::Render(
    p->halfWidth_     = params.width * 0.5f;
    p->halfHeight_    = params.height * 0.5f;
 
+   StartImGuiFrame();
    // Radar site ImGui windows shouldn't have padding
    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2 {0.0f, 0.0f});
 
@@ -93,6 +96,7 @@ void RadarSiteLayer::Render(
    }
 
    ImGui::PopStyleVar();
+   EndImGuiFrame();
 
    SCWX_GL_CHECK_ERROR();
 }

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -140,6 +140,7 @@ void RadarSiteLayer::Impl::RenderRadarSite(
       if (ImGui::Button(radarSite->id().c_str()))
       {
          Q_EMIT self_->RadarSiteSelected(radarSite->id());
+         self_->ImGuiSelectContext();
       }
 
       // Store hover text for mouse picking pass

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -86,7 +86,7 @@ void RadarSiteLayer::Render(
    p->halfWidth_     = params.width * 0.5f;
    p->halfHeight_    = params.height * 0.5f;
 
-   StartImGuiFrame();
+   ImGuiFrameStart();
    // Radar site ImGui windows shouldn't have padding
    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2 {0.0f, 0.0f});
 
@@ -96,7 +96,7 @@ void RadarSiteLayer::Render(
    }
 
    ImGui::PopStyleVar();
-   EndImGuiFrame();
+   ImGuiFrameEnd();
 
    SCWX_GL_CHECK_ERROR();
 }

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -44,7 +44,7 @@ public:
 };
 
 RadarSiteLayer::RadarSiteLayer(std::shared_ptr<MapContext> context) :
-    DrawLayer(context), p(std::make_unique<Impl>(this))
+    DrawLayer(context, "RadarSiteLayer"), p(std::make_unique<Impl>(this))
 {
 }
 


### PR DESCRIPTION
A few fixes for layer text.
1. Ensure text is rendered on the correct layer
2. Enable support for (most) OpenType font faces in layer text
3. Some clang tidy fixes

# Text rendering
Text is rendered on there layer by using an ImGui context for each layer. A separate context is used in `MapWidget` to render tooltips and to ensure that all fonts are loaded.
This works because MapLibre mostly renders layers from bottom to top. It does also use `GL_DEPTH_TEST`. ImGui's OpenGL backend explicitly disables this, so rendering is not perfect. In particular, the opaque layers of the map underlay are always rendered first, so putting a layer under this keeps the text on top of it. This is still much better than what we had before.

# OpenType
I added OpenType CFF fonts for ImGui. This seems to be the most common OpenType format. This should enable the usage of most fonts on Linux systems.

# RFC's
1. Not checking the font format (TrueType vs CFF etc) also seems to work fine, but I have not tested it thoroughly. ImGui uses FreeType, which supports most common font formats, so this check may be unnecessary.
2. I had to add a pointer to the `MapWidget` to `MapContext` in order for `imgui_impl_qt` to work. I think this is mostly inevitable, but maybe it should be done in a different way. (I am mostly worried about race conditions when shutting down).
3. Some layers needed to initialize and use the ImGui context when running their own rendering code. I split up the ImGui code in such a way that it can be used successfully, but requires being somewhat careful when writing Render functions.