### PR TITLE
Fix alert layer circular reference

### DIFF
--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -633,7 +633,7 @@ void AlertLayer::Impl::AddLine(std::shared_ptr<gl::draw::GeoLines>& geoLines,
                    std::placeholders::_1,
                    std::placeholders::_2));
 
-      std::weak_ptr<gl::draw::GeoLineDrawItem> diWeak = di;
+      const std::weak_ptr<gl::draw::GeoLineDrawItem> diWeak = di;
       gl::draw::GeoLines::RegisterEventHandler(
          di,
          std::bind(&AlertLayer::Impl::HandleGeoLinesEvent,
@@ -694,7 +694,7 @@ void AlertLayer::Impl::UpdateLines()
 void AlertLayer::Impl::HandleGeoLinesEvent(
    std::weak_ptr<gl::draw::GeoLineDrawItem>& diWeak, QEvent* ev)
 {
-   std::shared_ptr<gl::draw::GeoLineDrawItem> di = diWeak.lock();
+   const std::shared_ptr<gl::draw::GeoLineDrawItem> di = diWeak.lock();
    if (di == nullptr)
    {
       return;


### PR DESCRIPTION
In `AlertLayer::AddLine`, `di` was given a callback which had a the `shared_ptr` for `di` bound to it. This caused a circular reference and a memory leak. This was fixed by having the callback reference a `weak_ptr` instead. (Tested on Linux using address sanitation).