### PR TITLE
Fix boost::containers::stable_vector memory leak in MapWidget

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1193,7 +1193,7 @@ void MapWidgetImpl::AddLayers()
    std::string before = styleLayers_.front().toStdString();
 
    // Loop through each custom layer in reverse order
-   for (const auto & customLayer : std::ranges::reverse_view(customLayers))
+   for (const auto& customLayer : std::ranges::reverse_view(customLayers))
    {
       if (customLayer.type_ == types::LayerType::Map)
       {
@@ -1214,6 +1214,8 @@ void MapWidgetImpl::AddLayers()
             break;
          }
       }
+      // id_ is always < 4, so this is safe
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
       else if (customLayer.displayed_[id_])
       {
          // If the layer is displayed for the current map, add it

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1185,6 +1185,8 @@ void MapWidgetImpl::AddLayers()
    layerList_.clear();
    genericLayers_.clear();
    placefileLayers_.clear();
+   customLayers_.clear();
+   customLayers_.shrink_to_fit();
 
    // Update custom layer list from model
    customLayers_ = model::LayerModel::Instance()->GetLayers();

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1,3 +1,4 @@
+#include <ranges>
 #include <scwx/qt/map/map_widget.hpp>
 #include <scwx/qt/gl/gl.hpp>
 #include <scwx/qt/manager/font_manager.hpp>
@@ -204,8 +205,7 @@ public:
    const std::vector<MapStyle> emptyStyles_ {};
    std::vector<MapStyle>       customStyles_ {
       MapStyle {.name_ {"Custom"}, .url_ {}, .drawBelow_ {}}};
-   QStringList        styleLayers_;
-   types::LayerVector customLayers_;
+   QStringList styleLayers_;
 
    boost::uuids::uuid customStyleUrlChangedCallbackId_ {};
    boost::uuids::uuid customStyleDrawBelowChangedCallbackId_ {};
@@ -1185,22 +1185,20 @@ void MapWidgetImpl::AddLayers()
    layerList_.clear();
    genericLayers_.clear();
    placefileLayers_.clear();
-   customLayers_.clear();
-   customLayers_.shrink_to_fit();
 
    // Update custom layer list from model
-   customLayers_ = model::LayerModel::Instance()->GetLayers();
+   types::LayerVector customLayers = model::LayerModel::Instance()->GetLayers();
 
    // Start by drawing layers before any style-defined layers
    std::string before = styleLayers_.front().toStdString();
 
    // Loop through each custom layer in reverse order
-   for (auto it = customLayers_.crbegin(); it != customLayers_.crend(); ++it)
+   for (const auto & customLayer : std::ranges::reverse_view(customLayers))
    {
-      if (it->type_ == types::LayerType::Map)
+      if (customLayer.type_ == types::LayerType::Map)
       {
          // Style-defined map layers
-         switch (std::get<types::MapLayer>(it->description_))
+         switch (std::get<types::MapLayer>(customLayer.description_))
          {
          // Subsequent layers are drawn underneath the map symbology layer
          case types::MapLayer::MapUnderlay:
@@ -1216,10 +1214,10 @@ void MapWidgetImpl::AddLayers()
             break;
          }
       }
-      else if (it->displayed_[id_])
+      else if (customLayer.displayed_[id_])
       {
          // If the layer is displayed for the current map, add it
-         AddLayer(it->type_, it->description_, before);
+         AddLayer(customLayer.type_, customLayer.description_, before);
       }
    }
 }


### PR DESCRIPTION
The move(?) assignment operator of `boost::containers::stable_vector` does not free the previously held memory, causing a memory leak when used improperly. (I think it is weird, but the comments seem to indicate it is intentional). This manually ensures the memory was freed before the assignment. 

There are a few ways this could be fixed.
1. (Current) Manually ensure the memory was freed, by clearing and shrinking `customLayers_`.
2. `customLayers_` is only used in this method, and it is assigned to before any use, so it could be changed to a local variable.
3. Use something like `std::vector`, which does free the memory in this case (unless stability is needed).
5. The new value could be assigned to a local variable, then use `customLayers_.swap` to swap the values. Then the local variable will free the memory when it is destroyed.
