### PR TITLE
Speed up geolines by avoiding iterative finds

### DIFF
--- a/scwx-qt/source/scwx/qt/gl/draw/geo_lines.cpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/geo_lines.cpp
@@ -494,7 +494,7 @@ void GeoLines::Impl::UpdateModifiedLineBuffers()
    for (auto& di : dirtyLines_)
    {
       // Check if modified line is in the current list
-      if (currentLineList_.size() < di->lineIndex_ ||
+      if (di->lineIndex_ >= currentLineList_.size() ||
           currentLineList_[di->lineIndex_] != di)
       {
          continue;
@@ -799,8 +799,7 @@ bool GeoLines::RunMousePicking(
       }
       else if (it->second.di_->hoverCallback_ != nullptr)
       {
-         std::shared_ptr<GeoLineDrawItem> di = it->second.di_;
-         it->second.di_->hoverCallback_(di, mouseGlobalPos);
+         it->second.di_->hoverCallback_(it->second.di_, mouseGlobalPos);
       }
 
       if (it->second.di_->event_ != nullptr)

--- a/scwx-qt/source/scwx/qt/gl/draw/geo_lines.hpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/geo_lines.hpp
@@ -19,9 +19,8 @@ struct GeoLineDrawItem;
 class GeoLines : public DrawItem
 {
 public:
-   typedef std::function<void(const std::shared_ptr<GeoLineDrawItem>&,
-                              const QPointF&)>
-      HoverCallback;
+   using HoverCallback = std::function<void(
+      const std::shared_ptr<GeoLineDrawItem>&, const QPointF&)>;
 
    explicit GeoLines(std::shared_ptr<GlContext> context);
    ~GeoLines();

--- a/scwx-qt/source/scwx/qt/gl/draw/geo_lines.hpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/geo_lines.hpp
@@ -19,7 +19,7 @@ struct GeoLineDrawItem;
 class GeoLines : public DrawItem
 {
 public:
-   typedef std::function<void(std::shared_ptr<GeoLineDrawItem>&,
+   typedef std::function<void(const std::shared_ptr<GeoLineDrawItem>&,
                               const QPointF&)>
       HoverCallback;
 

--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -159,8 +159,9 @@ public:
    void ConnectSignals();
    void HandleGeoLinesEvent(std::weak_ptr<gl::draw::GeoLineDrawItem>& di,
                             QEvent*                                   ev);
-   void HandleGeoLinesHover(std::shared_ptr<gl::draw::GeoLineDrawItem>& di,
-                            const QPointF& mouseGlobalPos);
+   void
+   HandleGeoLinesHover(const std::shared_ptr<gl::draw::GeoLineDrawItem>& di,
+                       const QPointF& mouseGlobalPos);
    void ScheduleRefresh();
 
    LineData& GetLineData(const std::shared_ptr<const awips::Segment>& segment,
@@ -720,8 +721,8 @@ void AlertLayer::Impl::HandleGeoLinesEvent(
 }
 
 void AlertLayer::Impl::HandleGeoLinesHover(
-   std::shared_ptr<gl::draw::GeoLineDrawItem>& di,
-   const QPointF&                              mouseGlobalPos)
+   const std::shared_ptr<gl::draw::GeoLineDrawItem>& di,
+   const QPointF&                                    mouseGlobalPos)
 {
    if (di != lastHoverDi_)
    {


### PR DESCRIPTION
Speed up geolines by avoiding iterative finds. 
In several places, an iterative find was used while rendering GeoLines. Now more alerts are being created, so this is slowing down rendering (a lot for debug builds, some for release builds). Fix this by using different data structures to avoiding iterative finds. This may affect which hover is shown when lines overlap.