### PR TITLE
Level 2 chunks

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -963,6 +963,13 @@ void MainWindowImpl::ConnectMapSignals()
             }
          },
          Qt::QueuedConnection);
+      connect(
+         mapWidget,
+         &map::MapWidget::IncomingLevel2ElevationChanged,
+         this,
+         [this](float incomingElevation)
+         { level2SettingsWidget_->UpdateIncomingElevation(incomingElevation); },
+         Qt::QueuedConnection);
    }
 }
 

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -967,8 +967,7 @@ void MainWindowImpl::ConnectMapSignals()
          mapWidget,
          &map::MapWidget::IncomingLevel2ElevationChanged,
          this,
-         [this](float incomingElevation)
-         { level2SettingsWidget_->UpdateIncomingElevation(incomingElevation); },
+         [this](float) { level2SettingsWidget_->UpdateSettings(activeMap_); },
          Qt::QueuedConnection);
    }
 }

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -967,7 +967,8 @@ void MainWindowImpl::ConnectMapSignals()
          mapWidget,
          &map::MapWidget::IncomingLevel2ElevationChanged,
          this,
-         [this](float) { level2SettingsWidget_->UpdateSettings(activeMap_); },
+         [this](std::optional<float>)
+         { level2SettingsWidget_->UpdateSettings(activeMap_); },
          Qt::QueuedConnection);
    }
 }

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -769,9 +769,7 @@ void RadarProductManagerImpl::RefreshDataSync(
 
    if (totalObjects > 0)
    {
-      std::string key = providerManager->provider_->FindLatestKey();
-      auto latestTime = providerManager->provider_->GetTimePointByKey(key);
-
+      auto latestTime        = providerManager->provider_->FindLatestTime();
       auto updatePeriod      = providerManager->provider_->update_period();
       auto lastModified      = providerManager->provider_->last_modified();
       auto sinceLastModified = std::chrono::system_clock::now() - lastModified;
@@ -951,13 +949,8 @@ void RadarProductManagerImpl::LoadProviderData(
 
          if (existingRecord == nullptr)
          {
-            std::string key = providerManager->provider_->FindKey(time);
-
-            if (!key.empty())
-            {
-               nexradFile = providerManager->provider_->LoadObjectByKey(key);
-            }
-            else
+            nexradFile = providerManager->provider_->LoadObjectByTime(time);
+            if (nexradFile == nullptr)
             {
                logger_->warn("Attempting to load object without key: {}",
                              scwx::util::TimeString(time));

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -151,6 +151,16 @@ public:
       level2ChunksProviderManager_->provider_ =
          provider::NexradDataProviderFactory::CreateLevel2ChunksDataProvider(
             radarId);
+
+      auto level2ChunksProvider =
+         std::dynamic_pointer_cast<provider::AwsLevel2ChunksDataProvider>(
+            level2ChunksProviderManager_->provider_);
+      if (level2ChunksProvider != nullptr)
+      {
+         level2ChunksProvider->SetLevel2DataProvider(
+            std::dynamic_pointer_cast<provider::AwsLevel2DataProvider>(
+               level2ProviderManager_->provider_));
+      }
    }
    ~RadarProductManagerImpl()
    {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -645,7 +645,7 @@ void RadarProductManager::EnableRefresh(common::RadarProductGroup group,
 {
    if (group == common::RadarProductGroup::Level2)
    {
-      p->EnableRefresh(uuid, p->level2ProviderManager_, enabled);
+      //p->EnableRefresh(uuid, p->level2ProviderManager_, enabled);
       p->EnableRefresh(uuid, p->level2ChunksProviderManager_, enabled);
    }
    else

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1520,87 +1520,17 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
    std::vector<float>                          elevationCuts {};
    std::chrono::system_clock::time_point       foundTime {};
 
-   auto records = p->GetLevel2ProductRecords(time);
-
    //TODO decide when to use chunked vs archived data.
-   if (true)
+   if constexpr (true)
    {
       auto currentFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
          p->level2ChunksProviderManager_->provider_->LoadLatestObject());
-      auto lastFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
-         p->level2ChunksProviderManager_->provider_->LoadSecondLatestObject());
-      auto radarFile =
-         std::make_shared<wsr88d::Ar2vFile>(currentFile, lastFile);
       std::tie(radarData, elevationCut, elevationCuts) =
-         radarFile->GetElevationScan(dataBlockType, elevation, time);
-
-      /*
-      auto currentFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
-         p->level2ChunksProviderManager_->provider_->LoadLatestObject());
-      std::shared_ptr<wsr88d::rda::ElevationScan> currentRadarData = nullptr;
-      float                                       currentElevationCut = 0.0f;
-      std::vector<float>                          currentElevationCuts;
-      if (currentFile != nullptr)
-      {
-         std::tie(currentRadarData, currentElevationCut, currentElevationCuts) =
-            currentFile->GetElevationScan(dataBlockType, elevation, time);
-      }
-
-      std::shared_ptr<wsr88d::rda::ElevationScan> lastRadarData = nullptr;
-      float                                       lastElevationCut = 0.0f;
-      std::vector<float>                          lastElevationCuts;
-      auto lastFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
-         p->level2ChunksProviderManager_->provider_->LoadSecondLatestObject());
-      if (lastFile != nullptr)
-      {
-         std::tie(lastRadarData, lastElevationCut, lastElevationCuts) =
-               lastFile->GetElevationScan(dataBlockType, elevation, time);
-      }
-
-      if (currentRadarData != nullptr)
-      {
-         if (lastRadarData != nullptr)
-         {
-            auto& radarData0     = (*currentRadarData)[0];
-            auto  collectionTime = std::chrono::floor<std::chrono::seconds>(
-                  scwx::util::TimePoint(radarData0->modified_julian_date(),
-                     radarData0->collection_time()));
-
-            // TODO merge data
-            radarData     = currentRadarData;
-            elevationCut  = currentElevationCut;
-            elevationCuts = std::move(currentElevationCuts);
-            foundTime     = collectionTime;
-         }
-         else
-         {
-            auto& radarData0     = (*currentRadarData)[0];
-            auto  collectionTime = std::chrono::floor<std::chrono::seconds>(
-                  scwx::util::TimePoint(radarData0->modified_julian_date(),
-                     radarData0->collection_time()));
-
-            radarData     = currentRadarData;
-            elevationCut  = currentElevationCut;
-            elevationCuts = std::move(currentElevationCuts);
-            foundTime     = collectionTime;
-         }
-      }
-      else if (lastRadarData != nullptr)
-      {
-         auto& radarData0     = (*lastRadarData)[0];
-         auto  collectionTime = std::chrono::floor<std::chrono::seconds>(
-               scwx::util::TimePoint(radarData0->modified_julian_date(),
-                  radarData0->collection_time()));
-
-         radarData     = lastRadarData;
-         elevationCut  = lastElevationCut;
-         elevationCuts = std::move(lastElevationCuts);
-         foundTime     = collectionTime;
-      }
-      */
+         currentFile->GetElevationScan(dataBlockType, elevation, time);
    }
    else
    {
+      auto records = p->GetLevel2ProductRecords(time);
       for (auto& recordPair : records)
       {
          auto& record = recordPair.second;

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -766,7 +766,7 @@ void RadarProductManagerImpl::EnableRefresh(
 void RadarProductManagerImpl::RefreshData(
    std::shared_ptr<ProviderManager> providerManager)
 {
-   logger_->debug("RefreshData: {}", providerManager->name());
+   // logger_->debug("RefreshData: {}", providerManager->name());
 
    {
       std::unique_lock lock(providerManager->refreshTimerMutex_);
@@ -846,10 +846,12 @@ void RadarProductManagerImpl::RefreshDataSync(
 
    if (providerManager->refreshEnabled_)
    {
+      /*
       logger_->debug(
          "[{}] Scheduled refresh in {:%M:%S}",
          providerManager->name(),
          std::chrono::duration_cast<std::chrono::seconds>(interval));
+         */
 
       {
          providerManager->refreshTimer_.expires_after(interval);
@@ -960,9 +962,9 @@ void RadarProductManagerImpl::LoadProviderData(
    std::mutex&                                        loadDataMutex,
    const std::shared_ptr<request::NexradFileRequest>& request)
 {
-   logger_->debug("LoadProviderData: {}, {}",
+   /*logger_->debug("LoadProviderData: {}, {}",
                   providerManager->name(),
-                  scwx::util::TimeString(time));
+                  scwx::util::TimeString(time));*/
 
    LoadNexradFileAsync(
       [=, &recordMap, &recordMutex]() -> std::shared_ptr<wsr88d::NexradFile>
@@ -1013,7 +1015,7 @@ void RadarProductManager::LoadLevel2Data(
    std::chrono::system_clock::time_point              time,
    const std::shared_ptr<request::NexradFileRequest>& request)
 {
-   logger_->debug("LoadLevel2Data: {}", scwx::util::TimeString(time));
+   // logger_->debug("LoadLevel2Data: {}", scwx::util::TimeString(time));
 
    p->LoadProviderData(time,
                        p->level2ProviderManager_,

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1548,8 +1548,8 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
    std::vector<float>                          elevationCuts {};
    std::chrono::system_clock::time_point       foundTime {};
 
-   const bool isEpox = time == std::chrono::system_clock::time_point{};
-   bool needArchive = true;
+   const bool        isEpox = time == std::chrono::system_clock::time_point {};
+   bool              needArchive   = true;
    static const auto maxChunkDelay = std::chrono::minutes(10);
    const std::chrono::system_clock::time_point firstValidChunkTime =
       (isEpox ? std::chrono::system_clock::now() : time) - maxChunkDelay;

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -272,8 +272,7 @@ public:
    common::Level3ProductCategoryMap availableCategoryMap_ {};
    std::shared_mutex                availableCategoryMutex_ {};
 
-   float incomingLevel2Elevation_ {
-      provider::AwsLevel2ChunksDataProvider::INVALID_ELEVATION};
+   std::optional<float> incomingLevel2Elevation_ {};
 
    std::unordered_map<boost::uuids::uuid,
                       std::shared_ptr<ProviderManager>,
@@ -454,7 +453,7 @@ float RadarProductManager::gate_size() const
    return (is_tdwr()) ? 150.0f : 250.0f;
 }
 
-float RadarProductManager::incoming_level_2_elevation() const
+std::optional<float> RadarProductManager::incoming_level_2_elevation() const
 {
    return p->incomingLevel2Elevation_;
 }
@@ -1552,7 +1551,7 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
             scwx::util::TimePoint(radarData0->modified_julian_date(),
                                   radarData0->collection_time()));
 
-         const float incomingElevation =
+         const std::optional<float> incomingElevation =
             std::dynamic_pointer_cast<provider::AwsLevel2ChunksDataProvider>(
                p->level2ChunksProviderManager_->provider_)
                ->GetCurrentElevation();
@@ -1597,14 +1596,11 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
                   elevationCuts = std::move(recordElevationCuts);
                   foundTime     = collectionTime;
 
-                  if (p->incomingLevel2Elevation_ !=
-                      provider::AwsLevel2ChunksDataProvider::INVALID_ELEVATION)
+                  if (!p->incomingLevel2Elevation_.has_value())
                   {
-                     p->incomingLevel2Elevation_ = provider::
-                        AwsLevel2ChunksDataProvider::INVALID_ELEVATION;
+                     p->incomingLevel2Elevation_ = {};
                      Q_EMIT IncomingLevel2ElevationChanged(
-                        provider::AwsLevel2ChunksDataProvider::
-                           INVALID_ELEVATION);
+                        p->incomingLevel2Elevation_);
                   }
                }
             }

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -766,7 +766,7 @@ void RadarProductManagerImpl::EnableRefresh(
 void RadarProductManagerImpl::RefreshData(
    std::shared_ptr<ProviderManager> providerManager)
 {
-   // logger_->debug("RefreshData: {}", providerManager->name());
+   logger_->trace("RefreshData: {}", providerManager->name());
 
    {
       std::unique_lock lock(providerManager->refreshTimerMutex_);
@@ -846,12 +846,10 @@ void RadarProductManagerImpl::RefreshDataSync(
 
    if (providerManager->refreshEnabled_)
    {
-      /*
-      logger_->debug(
+      logger_->trace(
          "[{}] Scheduled refresh in {:%M:%S}",
          providerManager->name(),
          std::chrono::duration_cast<std::chrono::seconds>(interval));
-         */
 
       {
          providerManager->refreshTimer_.expires_after(interval);
@@ -962,9 +960,9 @@ void RadarProductManagerImpl::LoadProviderData(
    std::mutex&                                        loadDataMutex,
    const std::shared_ptr<request::NexradFileRequest>& request)
 {
-   /*logger_->debug("LoadProviderData: {}, {}",
+   logger_->trace("LoadProviderData: {}, {}",
                   providerManager->name(),
-                  scwx::util::TimeString(time));*/
+                  scwx::util::TimeString(time));
 
    LoadNexradFileAsync(
       [=, &recordMap, &recordMutex]() -> std::shared_ptr<wsr88d::NexradFile>
@@ -980,13 +978,11 @@ void RadarProductManagerImpl::LoadProviderData(
             {
                existingRecord = it->second.lock();
 
-               /*
                if (existingRecord != nullptr)
                {
-                  logger_->debug(
+                  logger_->trace(
                      "Data previously loaded, loading from data cache");
                }
-               */
             }
          }
 
@@ -1015,7 +1011,7 @@ void RadarProductManager::LoadLevel2Data(
    std::chrono::system_clock::time_point              time,
    const std::shared_ptr<request::NexradFileRequest>& request)
 {
-   // logger_->debug("LoadLevel2Data: {}", scwx::util::TimeString(time));
+   logger_->trace("LoadLevel2Data: {}", scwx::util::TimeString(time));
 
    p->LoadProviderData(time,
                        p->level2ProviderManager_,
@@ -1445,7 +1441,7 @@ std::shared_ptr<types::RadarProductRecord>
 RadarProductManagerImpl::StoreRadarProductRecord(
    std::shared_ptr<types::RadarProductRecord> record)
 {
-   // logger_->debug("StoreRadarProductRecord()");
+   logger_->trace("StoreRadarProductRecord()");
 
    std::shared_ptr<types::RadarProductRecord> storedRecord = nullptr;
 
@@ -1462,12 +1458,11 @@ RadarProductManagerImpl::StoreRadarProductRecord(
       {
          storedRecord = it->second.lock();
 
-         /*
          if (storedRecord != nullptr)
          {
-            logger_->debug(
+            logger_->trace(
                "Level 2 product previously loaded, loading from cache");
-         }*/
+         }
       }
 
       if (storedRecord == nullptr)

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -272,7 +272,8 @@ public:
    common::Level3ProductCategoryMap availableCategoryMap_ {};
    std::shared_mutex                availableCategoryMutex_ {};
 
-   float incomingLevel2Elevation_ {-90};
+   float incomingLevel2Elevation_ {
+      provider::AwsLevel2ChunksDataProvider::INVALID_ELEVATION};
 
    std::unordered_map<boost::uuids::uuid,
                       std::shared_ptr<ProviderManager>,
@@ -654,7 +655,7 @@ void RadarProductManager::EnableRefresh(common::RadarProductGroup group,
 {
    if (group == common::RadarProductGroup::Level2)
    {
-      //p->EnableRefresh(uuid, p->level2ProviderManager_, enabled);
+      // p->EnableRefresh(uuid, p->level2ProviderManager_, enabled);
       p->EnableRefresh(uuid, p->level2ChunksProviderManager_, enabled);
    }
    else
@@ -1431,7 +1432,7 @@ std::shared_ptr<types::RadarProductRecord>
 RadarProductManagerImpl::StoreRadarProductRecord(
    std::shared_ptr<types::RadarProductRecord> record)
 {
-   //logger_->debug("StoreRadarProductRecord()");
+   // logger_->debug("StoreRadarProductRecord()");
 
    std::shared_ptr<types::RadarProductRecord> storedRecord = nullptr;
 
@@ -1571,9 +1572,10 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
 
          if (record != nullptr)
          {
-            std::shared_ptr<wsr88d::rda::ElevationScan> recordRadarData = nullptr;
-            float                                       recordElevationCut = 0.0f;
-            std::vector<float>                          recordElevationCuts;
+            std::shared_ptr<wsr88d::rda::ElevationScan> recordRadarData =
+               nullptr;
+            float              recordElevationCut = 0.0f;
+            std::vector<float> recordElevationCuts;
 
             std::tie(recordRadarData, recordElevationCut, recordElevationCuts) =
                record->level2_file()->GetElevationScan(
@@ -1595,10 +1597,14 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
                   elevationCuts = std::move(recordElevationCuts);
                   foundTime     = collectionTime;
 
-                  if (p->incomingLevel2Elevation_ != -90)
+                  if (p->incomingLevel2Elevation_ !=
+                      provider::AwsLevel2ChunksDataProvider::INVALID_ELEVATION)
                   {
-                     p->incomingLevel2Elevation_ = -90;
-                     Q_EMIT IncomingLevel2ElevationChanged(-90);
+                     p->incomingLevel2Elevation_ = provider::
+                        AwsLevel2ChunksDataProvider::INVALID_ELEVATION;
+                     Q_EMIT IncomingLevel2ElevationChanged(
+                        provider::AwsLevel2ChunksDataProvider::
+                           INVALID_ELEVATION);
                   }
                }
             }

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1527,6 +1527,16 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
    {
       auto currentFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
          p->level2ChunksProviderManager_->provider_->LoadLatestObject());
+      auto lastFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
+         p->level2ChunksProviderManager_->provider_->LoadSecondLatestObject());
+      auto radarFile =
+         std::make_shared<wsr88d::Ar2vFile>(currentFile, lastFile);
+      std::tie(radarData, elevationCut, elevationCuts) =
+         radarFile->GetElevationScan(dataBlockType, elevation, time);
+
+      /*
+      auto currentFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
+         p->level2ChunksProviderManager_->provider_->LoadLatestObject());
       std::shared_ptr<wsr88d::rda::ElevationScan> currentRadarData = nullptr;
       float                                       currentElevationCut = 0.0f;
       std::vector<float>                          currentElevationCuts;
@@ -1587,6 +1597,7 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
          elevationCuts = std::move(lastElevationCuts);
          foundTime     = collectionTime;
       }
+      */
    }
    else
    {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
@@ -45,9 +45,9 @@ public:
    coordinates(common::RadialSize radialSize, bool smoothingEnabled) const;
    [[nodiscard]] const scwx::util::time_zone* default_time_zone() const;
    [[nodiscard]] float                        gate_size() const;
-   [[nodiscard]] float       incoming_level_2_elevation() const;
-   [[nodiscard]] bool        is_tdwr() const;
-   [[nodiscard]] std::string radar_id() const;
+   [[nodiscard]] std::optional<float> incoming_level_2_elevation() const;
+   [[nodiscard]] bool                 is_tdwr() const;
+   [[nodiscard]] std::string          radar_id() const;
    [[nodiscard]] std::shared_ptr<config::RadarSite> radar_site() const;
 
    void Initialize();
@@ -149,7 +149,7 @@ signals:
    void NewDataAvailable(common::RadarProductGroup             group,
                          const std::string&                    product,
                          std::chrono::system_clock::time_point latestTime);
-   void IncomingLevel2ElevationChanged(float incomingElevation);
+   void IncomingLevel2ElevationChanged(std::optional<float> incomingElevation);
 
 private:
    std::unique_ptr<RadarProductManagerImpl> p;

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
@@ -148,6 +148,7 @@ signals:
    void Level3ProductsChanged();
    void NewDataAvailable(common::RadarProductGroup             group,
                          const std::string&                    product,
+                         bool                                  isChunks,
                          std::chrono::system_clock::time_point latestTime);
    void IncomingLevel2ElevationChanged(std::optional<float> incomingElevation);
 

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
@@ -43,10 +43,11 @@ public:
 
    [[nodiscard]] const std::vector<float>&
    coordinates(common::RadialSize radialSize, bool smoothingEnabled) const;
-   [[nodiscard]] const scwx::util::time_zone*       default_time_zone() const;
-   [[nodiscard]] bool                               is_tdwr() const;
-   [[nodiscard]] float                              gate_size() const;
-   [[nodiscard]] std::string                        radar_id() const;
+   [[nodiscard]] const scwx::util::time_zone* default_time_zone() const;
+   [[nodiscard]] float                        gate_size() const;
+   [[nodiscard]] float       incoming_level_2_elevation() const;
+   [[nodiscard]] bool        is_tdwr() const;
+   [[nodiscard]] std::string radar_id() const;
    [[nodiscard]] std::shared_ptr<config::RadarSite> radar_site() const;
 
    void Initialize();
@@ -148,6 +149,7 @@ signals:
    void NewDataAvailable(common::RadarProductGroup             group,
                          const std::string&                    product,
                          std::chrono::system_clock::time_point latestTime);
+   void IncomingLevel2ElevationChanged(float incomingElevation);
 
 private:
    std::unique_ptr<RadarProductManagerImpl> p;

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -656,6 +656,12 @@ std::vector<float> MapWidget::GetElevationCuts() const
    }
 }
 
+float MapWidget::GetIncomingLevel2Elevation() const
+{
+   return p->radarProductManager_->incoming_level_2_elevation();
+}
+
+
 common::Level2Product
 MapWidgetImpl::GetLevel2ProductOrDefault(const std::string& productName) const
 {
@@ -1797,6 +1803,14 @@ void MapWidgetImpl::RadarProductManagerConnect()
    if (radarProductManager_ != nullptr)
    {
       connect(radarProductManager_.get(),
+              &manager::RadarProductManager::IncomingLevel2ElevationChanged,
+              this,
+              [this](float incomingElevation)
+              {
+                 Q_EMIT widget_->IncomingLevel2ElevationChanged(
+                    incomingElevation);
+              });
+      connect(radarProductManager_.get(),
               &manager::RadarProductManager::Level3ProductsChanged,
               this,
               [this]()
@@ -1914,6 +1928,10 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
    {
       disconnect(radarProductManager_.get(),
                  &manager::RadarProductManager::NewDataAvailable,
+                 this,
+                 nullptr);
+      disconnect(radarProductManager_.get(),
+                 &manager::RadarProductManager::IncomingLevel2ElevationChanged,
                  this,
                  nullptr);
    }

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -656,7 +656,7 @@ std::vector<float> MapWidget::GetElevationCuts() const
    }
 }
 
-float MapWidget::GetIncomingLevel2Elevation() const
+std::optional<float> MapWidget::GetIncomingLevel2Elevation() const
 {
    return p->radarProductManager_->incoming_level_2_elevation();
 }
@@ -1804,7 +1804,7 @@ void MapWidgetImpl::RadarProductManagerConnect()
       connect(radarProductManager_.get(),
               &manager::RadarProductManager::IncomingLevel2ElevationChanged,
               this,
-              [this](float incomingElevation)
+              [this](std::optional<float> incomingElevation)
               {
                  Q_EMIT widget_->IncomingLevel2ElevationChanged(
                     incomingElevation);

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1843,6 +1843,7 @@ void MapWidgetImpl::RadarProductManagerConnect()
          this,
          [this](common::RadarProductGroup             group,
                 const std::string&                    product,
+                bool                                  isChunks,
                 std::chrono::system_clock::time_point latestTime)
          {
             if (autoRefreshEnabled_ &&
@@ -1850,71 +1851,81 @@ void MapWidgetImpl::RadarProductManagerConnect()
                 (group == common::RadarProductGroup::Level2 ||
                  context_->radar_product() == product))
             {
-               // Create file request
-               std::shared_ptr<request::NexradFileRequest> request =
-                  std::make_shared<request::NexradFileRequest>(
-                     radarProductManager_->radar_id());
-
-               // File request callback
-               if (autoUpdateEnabled_)
+               if (isChunks && autoUpdateEnabled_)
                {
-                  connect(
-                     request.get(),
-                     &request::NexradFileRequest::RequestComplete,
-                     this,
-                     [=,
-                      this](std::shared_ptr<request::NexradFileRequest> request)
-                     {
-                        // Select loaded record
-                        auto record = request->radar_product_record();
+                  // Level 2 products may have multiple time points,
+                  // ensure the latest is selected
+                  widget_->SelectRadarProduct(group, product);
+               }
+               else
+               {
+                  // Create file request
+                  const std::shared_ptr<request::NexradFileRequest> request =
+                     std::make_shared<request::NexradFileRequest>(
+                        radarProductManager_->radar_id());
 
-                        // Validate record, and verify current map context
-                        // still displays site and product
-                        if (record != nullptr &&
-                            radarProductManager_ != nullptr &&
-                            radarProductManager_->radar_id() ==
-                               request->current_radar_site() &&
-                            context_->radar_product_group() == group &&
-                            (group == common::RadarProductGroup::Level2 ||
-                             context_->radar_product() == product))
+                  // File request callback
+                  if (autoUpdateEnabled_)
+                  {
+                     connect(
+                        request.get(),
+                        &request::NexradFileRequest::RequestComplete,
+                        this,
+                        [group, product, this](
+                           const std::shared_ptr<request::NexradFileRequest>&
+                              request)
+                        {
+                           // Select loaded record
+                           auto record = request->radar_product_record();
+
+                           // Validate record, and verify current map context
+                           // still displays site and product
+                           if (record != nullptr &&
+                               radarProductManager_ != nullptr &&
+                               radarProductManager_->radar_id() ==
+                                  request->current_radar_site() &&
+                               context_->radar_product_group() == group &&
+                               (group == common::RadarProductGroup::Level2 ||
+                                context_->radar_product() == product))
+                           {
+                              if (group == common::RadarProductGroup::Level2)
+                              {
+                                 // Level 2 products may have multiple time
+                                 // points, ensure the latest is selected
+                                 widget_->SelectRadarProduct(group, product);
+                              }
+                              else
+                              {
+                                 widget_->SelectRadarProduct(record);
+                              }
+                           }
+                        });
+                  }
+
+                  // Load file
+                  boost::asio::post(
+                     threadPool_,
+                     [group, latestTime, request, product, this]()
+                     {
+                        try
                         {
                            if (group == common::RadarProductGroup::Level2)
                            {
-                              // Level 2 products may have multiple time points,
-                              // ensure the latest is selected
-                              widget_->SelectRadarProduct(group, product);
+                              radarProductManager_->LoadLevel2Data(latestTime,
+                                                                   request);
                            }
                            else
                            {
-                              widget_->SelectRadarProduct(record);
+                              radarProductManager_->LoadLevel3Data(
+                                 product, latestTime, request);
                            }
+                        }
+                        catch (const std::exception& ex)
+                        {
+                           logger_->error(ex.what());
                         }
                      });
                }
-
-               // Load file
-               boost::asio::post(
-                  threadPool_,
-                  [=, this]()
-                  {
-                     try
-                     {
-                        if (group == common::RadarProductGroup::Level2)
-                        {
-                           radarProductManager_->LoadLevel2Data(latestTime,
-                                                                request);
-                        }
-                        else
-                        {
-                           radarProductManager_->LoadLevel3Data(
-                              product, latestTime, request);
-                        }
-                     }
-                     catch (const std::exception& ex)
-                     {
-                        logger_->error(ex.what());
-                     }
-                  });
             }
          },
          Qt::QueuedConnection);

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -661,7 +661,6 @@ float MapWidget::GetIncomingLevel2Elevation() const
    return p->radarProductManager_->incoming_level_2_elevation();
 }
 
-
 common::Level2Product
 MapWidgetImpl::GetLevel2ProductOrDefault(const std::string& productName) const
 {

--- a/scwx-qt/source/scwx/qt/map/map_widget.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.hpp
@@ -45,6 +45,7 @@ public:
                                            GetAvailableLevel3Categories();
    [[nodiscard]] std::optional<float>      GetElevation() const;
    [[nodiscard]] std::vector<float>        GetElevationCuts() const;
+   [[nodiscard]] float                     GetIncomingLevel2Elevation() const;
    [[nodiscard]] std::vector<std::string>  GetLevel3Products();
    [[nodiscard]] std::string               GetMapStyle() const;
    [[nodiscard]] common::RadarProductGroup GetRadarProductGroup() const;
@@ -184,6 +185,7 @@ signals:
    void RadarSweepUpdated();
    void RadarSweepNotUpdated(types::NoUpdateReason reason);
    void WidgetPainted();
+   void IncomingLevel2ElevationChanged(float incomingElevation);
 };
 
 } // namespace map

--- a/scwx-qt/source/scwx/qt/map/map_widget.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.hpp
@@ -45,7 +45,7 @@ public:
                                            GetAvailableLevel3Categories();
    [[nodiscard]] std::optional<float>      GetElevation() const;
    [[nodiscard]] std::vector<float>        GetElevationCuts() const;
-   [[nodiscard]] float                     GetIncomingLevel2Elevation() const;
+   [[nodiscard]] std::optional<float>      GetIncomingLevel2Elevation() const;
    [[nodiscard]] std::vector<std::string>  GetLevel3Products();
    [[nodiscard]] std::string               GetMapStyle() const;
    [[nodiscard]] common::RadarProductGroup GetRadarProductGroup() const;
@@ -185,7 +185,7 @@ signals:
    void RadarSweepUpdated();
    void RadarSweepNotUpdated(types::NoUpdateReason reason);
    void WidgetPainted();
-   void IncomingLevel2ElevationChanged(float incomingElevation);
+   void IncomingLevel2ElevationChanged(std::optional<float> incomingElevation);
 };
 
 } // namespace map

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -170,7 +170,7 @@ void RadarProductLayer::UpdateSweep()
                               std::try_to_lock);
    if (!sweepLock.owns_lock())
    {
-      //logger_->debug("Sweep locked, deferring update");
+      // logger_->debug("Sweep locked, deferring update");
       return;
    }
    logger_->debug("UpdateSweep()");

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -170,7 +170,7 @@ void RadarProductLayer::UpdateSweep()
                               std::try_to_lock);
    if (!sweepLock.owns_lock())
    {
-      // logger_->debug("Sweep locked, deferring update");
+      logger_->trace("Sweep locked, deferring update");
       return;
    }
    logger_->debug("UpdateSweep()");

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -159,8 +159,6 @@ void RadarProductLayer::Initialize()
 
 void RadarProductLayer::UpdateSweep()
 {
-   logger_->debug("UpdateSweep()");
-
    gl::OpenGLFunctions& gl = context()->gl();
 
    boost::timer::cpu_timer timer;
@@ -172,9 +170,10 @@ void RadarProductLayer::UpdateSweep()
                               std::try_to_lock);
    if (!sweepLock.owns_lock())
    {
-      logger_->debug("Sweep locked, deferring update");
+      //logger_->debug("Sweep locked, deferring update");
       return;
    }
+   logger_->debug("UpdateSweep()");
 
    p->sweepNeedsUpdate_ = false;
 

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -242,11 +242,19 @@ void Level2SettingsWidget::UpdateElevationSelection(float elevation)
    p->currentElevationButton_ = newElevationButton;
 }
 
-void Level2SettingsWidget::UpdateIncomingElevation(float incomingElevation)
+void Level2SettingsWidget::UpdateIncomingElevation(
+   std::optional<float> incomingElevation)
 {
-   p->incomingElevationLabel_->setText(
-      "Incoming Elevation: " + QString::number(incomingElevation, 'f', 1) +
-      common::Characters::DEGREE);
+   if (incomingElevation.has_value())
+   {
+      p->incomingElevationLabel_->setText(
+         "Incoming Elevation: " + QString::number(*incomingElevation, 'f', 1) +
+         common::Characters::DEGREE);
+   }
+   else
+   {
+      p->incomingElevationLabel_->setText("Incoming Elevation: None");
+   }
 }
 
 void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
@@ -254,8 +262,9 @@ void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
    std::optional<float> currentElevationOption = activeMap->GetElevation();
    const float          currentElevation =
       currentElevationOption.has_value() ? *currentElevationOption : 0.0f;
-   const std::vector<float> elevationCuts = activeMap->GetElevationCuts();
-   const float incomingElevation = activeMap->GetIncomingLevel2Elevation();
+   const std::vector<float>   elevationCuts = activeMap->GetElevationCuts();
+   const std::optional<float> incomingElevation =
+      activeMap->GetIncomingLevel2Elevation();
 
    if (p->elevationCuts_ != elevationCuts)
    {

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -1,3 +1,4 @@
+#include <qlabel.h>
 #include <scwx/qt/ui/level2_settings_widget.hpp>
 #include <scwx/qt/ui/flow_layout.hpp>
 #include <scwx/qt/manager/hotkey_manager.hpp>
@@ -30,6 +31,7 @@ public:
        self_ {self},
        layout_ {new QVBoxLayout(self)},
        elevationGroupBox_ {},
+       incomingElevationLabel_ {},
        elevationButtons_ {},
        elevationCuts_ {},
        elevationButtonsChanged_ {false},
@@ -39,9 +41,13 @@ public:
    {
       layout_->setContentsMargins(0, 0, 0, 0);
 
+      incomingElevationLabel_ = new QLabel("", self);
+      layout_->addWidget(incomingElevationLabel_);
+
       elevationGroupBox_ = new QGroupBox(tr("Elevation"), self);
       new ui::FlowLayout(elevationGroupBox_);
       layout_->addWidget(elevationGroupBox_);
+
 
       settingsGroupBox_       = new QGroupBox(tr("Settings"), self);
       QLayout* settingsLayout = new QVBoxLayout(settingsGroupBox_);
@@ -67,6 +73,7 @@ public:
    QLayout*              layout_;
 
    QGroupBox*              elevationGroupBox_;
+   QLabel*                 incomingElevationLabel_;
    std::list<QToolButton*> elevationButtons_;
    std::vector<float>      elevationCuts_;
    bool                    elevationButtonsChanged_;
@@ -240,12 +247,19 @@ void Level2SettingsWidget::UpdateElevationSelection(float elevation)
    p->currentElevationButton_ = newElevationButton;
 }
 
+void Level2SettingsWidget::UpdateIncomingElevation(float incomingElevation)
+{
+   p->incomingElevationLabel_->setText("Incoming Elevation: " +
+      QString::number(incomingElevation, 'f', 1) + common::Characters::DEGREE);
+}
+
 void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
 {
    std::optional<float> currentElevationOption = activeMap->GetElevation();
    const float          currentElevation =
       currentElevationOption.has_value() ? *currentElevationOption : 0.0f;
    std::vector<float> elevationCuts    = activeMap->GetElevationCuts();
+   float incomingElevation = activeMap->GetIncomingLevel2Elevation();
 
    if (p->elevationCuts_ != elevationCuts)
    {
@@ -279,6 +293,7 @@ void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
    }
 
    UpdateElevationSelection(currentElevation);
+   UpdateIncomingElevation(incomingElevation);
 }
 
 } // namespace ui

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -254,8 +254,8 @@ void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
    std::optional<float> currentElevationOption = activeMap->GetElevation();
    const float          currentElevation =
       currentElevationOption.has_value() ? *currentElevationOption : 0.0f;
-   std::vector<float> elevationCuts = activeMap->GetElevationCuts();
-   const float incomingElevation    = activeMap->GetIncomingLevel2Elevation();
+   const std::vector<float> elevationCuts = activeMap->GetElevationCuts();
+   const float incomingElevation = activeMap->GetIncomingLevel2Elevation();
 
    if (p->elevationCuts_ != elevationCuts)
    {

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -30,15 +30,10 @@ public:
    explicit Level2SettingsWidgetImpl(Level2SettingsWidget* self) :
        self_ {self},
        layout_ {new QVBoxLayout(self)},
-       elevationGroupBox_ {},
-       incomingElevationLabel_ {},
        elevationButtons_ {},
-       elevationCuts_ {},
-       elevationButtonsChanged_ {false},
-       resizeElevationButtons_ {false},
-       settingsGroupBox_ {},
-       declutterCheckBox_ {}
+       elevationCuts_ {}
    {
+      // NOLINTBEGIN(cppcoreguidelines-owning-memory) Qt takes care of this
       layout_->setContentsMargins(0, 0, 0, 0);
 
       incomingElevationLabel_ = new QLabel("", self);
@@ -48,7 +43,6 @@ public:
       new ui::FlowLayout(elevationGroupBox_);
       layout_->addWidget(elevationGroupBox_);
 
-
       settingsGroupBox_       = new QGroupBox(tr("Settings"), self);
       QLayout* settingsLayout = new QVBoxLayout(settingsGroupBox_);
       layout_->addWidget(settingsGroupBox_);
@@ -57,6 +51,7 @@ public:
       settingsLayout->addWidget(declutterCheckBox_);
 
       settingsGroupBox_->setVisible(false);
+      // NOLINTEND(cppcoreguidelines-owning-memory) Qt takes care of this
 
       QObject::connect(hotkeyManager_.get(),
                        &manager::HotkeyManager::HotkeyPressed,
@@ -72,15 +67,15 @@ public:
    Level2SettingsWidget* self_;
    QLayout*              layout_;
 
-   QGroupBox*              elevationGroupBox_;
-   QLabel*                 incomingElevationLabel_;
+   QGroupBox*              elevationGroupBox_ {};
+   QLabel*                 incomingElevationLabel_ {};
    std::list<QToolButton*> elevationButtons_;
    std::vector<float>      elevationCuts_;
-   bool                    elevationButtonsChanged_;
-   bool                    resizeElevationButtons_;
+   bool                    elevationButtonsChanged_ {};
+   bool                    resizeElevationButtons_ {};
 
-   QGroupBox* settingsGroupBox_;
-   QCheckBox* declutterCheckBox_;
+   QGroupBox* settingsGroupBox_ {};
+   QCheckBox* declutterCheckBox_ {};
 
    float        currentElevation_ {};
    QToolButton* currentElevationButton_ {nullptr};
@@ -249,8 +244,9 @@ void Level2SettingsWidget::UpdateElevationSelection(float elevation)
 
 void Level2SettingsWidget::UpdateIncomingElevation(float incomingElevation)
 {
-   p->incomingElevationLabel_->setText("Incoming Elevation: " +
-      QString::number(incomingElevation, 'f', 1) + common::Characters::DEGREE);
+   p->incomingElevationLabel_->setText(
+      "Incoming Elevation: " + QString::number(incomingElevation, 'f', 1) +
+      common::Characters::DEGREE);
 }
 
 void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
@@ -258,8 +254,8 @@ void Level2SettingsWidget::UpdateSettings(map::MapWidget* activeMap)
    std::optional<float> currentElevationOption = activeMap->GetElevation();
    const float          currentElevation =
       currentElevationOption.has_value() ? *currentElevationOption : 0.0f;
-   std::vector<float> elevationCuts    = activeMap->GetElevationCuts();
-   float incomingElevation = activeMap->GetIncomingLevel2Elevation();
+   std::vector<float> elevationCuts = activeMap->GetElevationCuts();
+   const float incomingElevation    = activeMap->GetIncomingLevel2Elevation();
 
    if (p->elevationCuts_ != elevationCuts)
    {

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.hpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.hpp
@@ -23,6 +23,7 @@ public:
    void showEvent(QShowEvent* event) override;
 
    void UpdateElevationSelection(float elevation);
+   void UpdateIncomingElevation(float incomingElevation);
    void UpdateSettings(map::MapWidget* activeMap);
 
 signals:

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.hpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.hpp
@@ -2,6 +2,8 @@
 
 #include <scwx/qt/map/map_widget.hpp>
 
+#include <optional>
+
 namespace scwx
 {
 namespace qt
@@ -23,7 +25,7 @@ public:
    void showEvent(QShowEvent* event) override;
 
    void UpdateElevationSelection(float elevation);
-   void UpdateIncomingElevation(float incomingElevation);
+   void UpdateIncomingElevation(std::optional<float> incomingElevation);
    void UpdateSettings(map::MapWidget* activeMap);
 
 signals:

--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -561,7 +561,8 @@ void Level2ProductView::ComputeSweep()
       Q_EMIT SweepNotComputed(types::NoUpdateReason::NotLoaded);
       return;
    }
-   if (radarData == p->elevationScan_ &&
+   // TODO do not do this when updating from live data
+   if (false && (radarData == p->elevationScan_) &&
        smoothingEnabled == p->lastSmoothingEnabled_ &&
        (showSmoothedRangeFolding == p->lastShowSmoothedRangeFolding_ ||
         !smoothingEnabled))

--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -561,8 +561,7 @@ void Level2ProductView::ComputeSweep()
       Q_EMIT SweepNotComputed(types::NoUpdateReason::NotLoaded);
       return;
    }
-   // TODO do not do this when updating from live data
-   if (false && (radarData == p->elevationScan_) &&
+   if ((radarData == p->elevationScan_) &&
        smoothingEnabled == p->lastSmoothingEnabled_ &&
        (showSmoothedRangeFolding == p->lastShowSmoothedRangeFolding_ ||
         !smoothingEnabled))

--- a/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
@@ -116,8 +116,9 @@ void OverlayProductView::Impl::ConnectRadarProductManager()
       radarProductManager_.get(),
       &manager::RadarProductManager::NewDataAvailable,
       self_,
-      [this](common::RadarProductGroup             group,
-             const std::string&                    product,
+      [this](common::RadarProductGroup group,
+             const std::string&        product,
+             bool /*isChunks*/,
              std::chrono::system_clock::time_point latestTime)
       {
          if (autoRefreshEnabled_ &&

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -53,9 +53,7 @@ public:
    LoadObjectByKey(const std::string& key) override;
    std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByTime(std::chrono::system_clock::time_point time) override;
-   std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
-   std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() override;
-   std::pair<size_t, size_t>           Refresh() override;
+   std::pair<size_t, size_t> Refresh() override;
 
    void                     RequestAvailableProducts() override;
    std::vector<std::string> GetAvailableProducts() override;

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -2,6 +2,8 @@
 
 #include <scwx/provider/nexrad_data_provider.hpp>
 
+#include <optional>
+
 namespace Aws::S3
 {
 class S3Client;
@@ -16,7 +18,6 @@ namespace scwx::provider
 class AwsLevel2ChunksDataProvider : public NexradDataProvider
 {
 public:
-   constexpr static const float INVALID_ELEVATION = -90.0;
    explicit AwsLevel2ChunksDataProvider(const std::string& radarSite);
    explicit AwsLevel2ChunksDataProvider(const std::string& radarSite,
                                         const std::string& bucketName,
@@ -58,7 +59,7 @@ public:
    void                     RequestAvailableProducts() override;
    std::vector<std::string> GetAvailableProducts() override;
 
-   float GetCurrentElevation();
+   std::optional<float> GetCurrentElevation();
 
 private:
    class Impl;

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -16,6 +16,7 @@ namespace scwx::provider
 class AwsLevel2ChunksDataProvider : public NexradDataProvider
 {
 public:
+   constexpr static const float INVALID_ELEVATION = -90.0;
    explicit AwsLevel2ChunksDataProvider(const std::string& radarSite);
    explicit AwsLevel2ChunksDataProvider(const std::string& radarSite,
                                         const std::string& bucketName,

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <scwx/provider/nexrad_data_provider.hpp>
+
+namespace Aws::S3
+{
+class S3Client;
+} // namespace Aws::S3
+
+namespace scwx::provider
+{
+
+/**
+ * @brief AWS Level 2 Data Provider
+ */
+class AwsLevel2ChunksDataProvider : public NexradDataProvider
+{
+public:
+   explicit AwsLevel2ChunksDataProvider(const std::string& radarSite);
+   explicit AwsLevel2ChunksDataProvider(const std::string& radarSite,
+                                        const std::string& bucketName,
+                                        const std::string& region);
+   ~AwsLevel2ChunksDataProvider() override;
+
+   AwsLevel2ChunksDataProvider(const AwsLevel2ChunksDataProvider&) = delete;
+   AwsLevel2ChunksDataProvider& operator=(const AwsLevel2ChunksDataProvider&) = delete;
+
+   AwsLevel2ChunksDataProvider(AwsLevel2ChunksDataProvider&&) noexcept;
+   AwsLevel2ChunksDataProvider& operator=(AwsLevel2ChunksDataProvider&&) noexcept;
+
+   [[nodiscard]] std::chrono::system_clock::time_point
+   GetTimePointByKey(const std::string& key) const override;
+
+   [[nodiscard]] size_t cache_size() const override;
+
+   [[nodiscard]] std::chrono::system_clock::time_point
+                                      last_modified() const override;
+   [[nodiscard]] std::chrono::seconds update_period() const override;
+
+   std::string FindKey(std::chrono::system_clock::time_point time) override;
+   std::string FindLatestKey() override;
+   std::chrono::system_clock::time_point FindLatestTime() override;
+   std::vector<std::chrono::system_clock::time_point>
+   GetTimePointsByDate(std::chrono::system_clock::time_point date) override;
+   std::tuple<bool, size_t, size_t>
+   ListObjects(std::chrono::system_clock::time_point date) override;
+   std::shared_ptr<wsr88d::NexradFile>
+                             LoadObjectByKey(const std::string& key) override;
+   std::shared_ptr<wsr88d::NexradFile>
+   LoadObjectByTime(std::chrono::system_clock::time_point time) override;
+   std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
+   std::pair<size_t, size_t> Refresh() override;
+
+   void RequestAvailableProducts() override;
+   std::vector<std::string> GetAvailableProducts() override;
+
+private:
+   class Impl;
+   std::unique_ptr<Impl> p;
+};
+
+} // namespace scwx::provider

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -23,10 +23,12 @@ public:
    ~AwsLevel2ChunksDataProvider() override;
 
    AwsLevel2ChunksDataProvider(const AwsLevel2ChunksDataProvider&) = delete;
-   AwsLevel2ChunksDataProvider& operator=(const AwsLevel2ChunksDataProvider&) = delete;
+   AwsLevel2ChunksDataProvider&
+   operator=(const AwsLevel2ChunksDataProvider&) = delete;
 
    AwsLevel2ChunksDataProvider(AwsLevel2ChunksDataProvider&&) noexcept;
-   AwsLevel2ChunksDataProvider& operator=(AwsLevel2ChunksDataProvider&&) noexcept;
+   AwsLevel2ChunksDataProvider&
+   operator=(AwsLevel2ChunksDataProvider&&) noexcept;
 
    [[nodiscard]] std::chrono::system_clock::time_point
    GetTimePointByKey(const std::string& key) const override;
@@ -45,13 +47,13 @@ public:
    std::tuple<bool, size_t, size_t>
    ListObjects(std::chrono::system_clock::time_point date) override;
    std::shared_ptr<wsr88d::NexradFile>
-                             LoadObjectByKey(const std::string& key) override;
+   LoadObjectByKey(const std::string& key) override;
    std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByTime(std::chrono::system_clock::time_point time) override;
    std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
-   std::pair<size_t, size_t> Refresh() override;
+   std::pair<size_t, size_t>           Refresh() override;
 
-   void RequestAvailableProducts() override;
+   void                     RequestAvailableProducts() override;
    std::vector<std::string> GetAvailableProducts() override;
 
 private:

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -57,6 +57,8 @@ public:
    void                     RequestAvailableProducts() override;
    std::vector<std::string> GetAvailableProducts() override;
 
+   float GetCurrentElevation();
+
 private:
    class Impl;
    std::unique_ptr<Impl> p;

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <scwx/provider/nexrad_data_provider.hpp>
+#include <scwx/provider/aws_level2_data_provider.hpp>
 
 #include <optional>
 
@@ -60,6 +61,9 @@ public:
    std::vector<std::string> GetAvailableProducts() override;
 
    std::optional<float> GetCurrentElevation();
+
+   void SetLevel2DataProvider(
+      const std::shared_ptr<AwsLevel2DataProvider>& provider);
 
 private:
    class Impl;

--- a/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_level2_chunks_data_provider.hpp
@@ -51,6 +51,7 @@ public:
    std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByTime(std::chrono::system_clock::time_point time) override;
    std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
+   std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() override;
    std::pair<size_t, size_t>           Refresh() override;
 
    void                     RequestAvailableProducts() override;

--- a/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
@@ -48,8 +48,6 @@ public:
                              LoadObjectByKey(const std::string& key) override;
    std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByTime(std::chrono::system_clock::time_point time) override;
-   std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
-   std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() override;
    std::pair<size_t, size_t> Refresh() override;
 
 protected:

--- a/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
@@ -49,6 +49,7 @@ public:
    std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByTime(std::chrono::system_clock::time_point time) override;
    std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
+   std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() override;
    std::pair<size_t, size_t> Refresh() override;
 
 protected:

--- a/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/aws_nexrad_data_provider.hpp
@@ -39,12 +39,16 @@ public:
 
    std::string FindKey(std::chrono::system_clock::time_point time) override;
    std::string FindLatestKey() override;
+   std::chrono::system_clock::time_point FindLatestTime() override;
    std::vector<std::chrono::system_clock::time_point>
    GetTimePointsByDate(std::chrono::system_clock::time_point date) override;
    std::tuple<bool, size_t, size_t>
    ListObjects(std::chrono::system_clock::time_point date) override;
    std::shared_ptr<wsr88d::NexradFile>
                              LoadObjectByKey(const std::string& key) override;
+   std::shared_ptr<wsr88d::NexradFile>
+   LoadObjectByTime(std::chrono::system_clock::time_point time) override;
+   std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() override;
    std::pair<size_t, size_t> Refresh() override;
 
 protected:

--- a/wxdata/include/scwx/provider/nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/nexrad_data_provider.hpp
@@ -60,6 +60,13 @@ public:
    virtual std::string FindLatestKey() = 0;
 
    /**
+    * Finds the most recent time in the cache.
+    *
+    * @return NEXRAD data key
+    */
+   virtual std::chrono::system_clock::time_point FindLatestTime() = 0;
+
+   /**
     * Lists NEXRAD objects for the date supplied, and adds them to the cache.
     *
     * @param date Date for which to list objects
@@ -80,6 +87,24 @@ public:
     */
    virtual std::shared_ptr<wsr88d::NexradFile>
    LoadObjectByKey(const std::string& key) = 0;
+
+   /**
+    * Loads a NEXRAD file object at the given time
+    *
+    * @param time NEXRAD time
+    *
+    * @return NEXRAD data
+    */
+   virtual std::shared_ptr<wsr88d::NexradFile>
+   LoadObjectByTime(std::chrono::system_clock::time_point time) = 0;
+
+   /**
+    * Loads the latest NEXRAD file object
+    *
+    * @return NEXRAD data
+    */
+   virtual std::shared_ptr<wsr88d::NexradFile>
+   LoadLatestObject() = 0;
 
    /**
     * Lists NEXRAD objects for the current date, and adds them to the cache. If

--- a/wxdata/include/scwx/provider/nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/nexrad_data_provider.hpp
@@ -107,6 +107,15 @@ public:
    LoadLatestObject() = 0;
 
    /**
+    * Loads the second NEXRAD file object
+    *
+    * @return NEXRAD data
+    */
+   virtual std::shared_ptr<wsr88d::NexradFile>
+   LoadSecondLatestObject() = 0;
+
+
+   /**
     * Lists NEXRAD objects for the current date, and adds them to the cache. If
     * no objects have been added to the cache for the current date, the previous
     * date is also queried for data.

--- a/wxdata/include/scwx/provider/nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/nexrad_data_provider.hpp
@@ -103,17 +103,14 @@ public:
     *
     * @return NEXRAD data
     */
-   virtual std::shared_ptr<wsr88d::NexradFile>
-   LoadLatestObject() = 0;
+   virtual std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() = 0;
 
    /**
     * Loads the second NEXRAD file object
     *
     * @return NEXRAD data
     */
-   virtual std::shared_ptr<wsr88d::NexradFile>
-   LoadSecondLatestObject() = 0;
-
+   virtual std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() = 0;
 
    /**
     * Lists NEXRAD objects for the current date, and adds them to the cache. If

--- a/wxdata/include/scwx/provider/nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/nexrad_data_provider.hpp
@@ -99,20 +99,6 @@ public:
    LoadObjectByTime(std::chrono::system_clock::time_point time) = 0;
 
    /**
-    * Loads the latest NEXRAD file object
-    *
-    * @return NEXRAD data
-    */
-   virtual std::shared_ptr<wsr88d::NexradFile> LoadLatestObject() = 0;
-
-   /**
-    * Loads the second NEXRAD file object
-    *
-    * @return NEXRAD data
-    */
-   virtual std::shared_ptr<wsr88d::NexradFile> LoadSecondLatestObject() = 0;
-
-   /**
     * Lists NEXRAD objects for the current date, and adds them to the cache. If
     * no objects have been added to the cache for the current date, the previous
     * date is also queried for data.

--- a/wxdata/include/scwx/provider/nexrad_data_provider_factory.hpp
+++ b/wxdata/include/scwx/provider/nexrad_data_provider_factory.hpp
@@ -28,6 +28,9 @@ public:
    CreateLevel2DataProvider(const std::string& radarSite);
 
    static std::shared_ptr<NexradDataProvider>
+   CreateLevel2ChunksDataProvider(const std::string& radarSite);
+
+   static std::shared_ptr<NexradDataProvider>
    CreateLevel3DataProvider(const std::string& radarSite,
                             const std::string& product);
 };

--- a/wxdata/include/scwx/wsr88d/ar2v_file.hpp
+++ b/wxdata/include/scwx/wsr88d/ar2v_file.hpp
@@ -32,6 +32,8 @@ public:
    Ar2vFile(Ar2vFile&&) noexcept;
    Ar2vFile& operator=(Ar2vFile&&) noexcept;
 
+   Ar2vFile(std::shared_ptr<Ar2vFile> current, std::shared_ptr<Ar2vFile> last);
+
    std::uint32_t julian_date() const;
    std::uint32_t milliseconds() const;
    std::string   icao() const;

--- a/wxdata/include/scwx/wsr88d/ar2v_file.hpp
+++ b/wxdata/include/scwx/wsr88d/ar2v_file.hpp
@@ -32,7 +32,8 @@ public:
    Ar2vFile(Ar2vFile&&) noexcept;
    Ar2vFile& operator=(Ar2vFile&&) noexcept;
 
-   Ar2vFile(std::shared_ptr<Ar2vFile> current, std::shared_ptr<Ar2vFile> last);
+   Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
+            const std::shared_ptr<Ar2vFile>& last);
 
    std::uint32_t julian_date() const;
    std::uint32_t milliseconds() const;

--- a/wxdata/include/scwx/wsr88d/ar2v_file.hpp
+++ b/wxdata/include/scwx/wsr88d/ar2v_file.hpp
@@ -53,6 +53,9 @@ public:
    bool LoadFile(const std::string& filename);
    bool LoadData(std::istream& is);
 
+   bool LoadLDMRecords(std::istream& is);
+   bool IndexFile();
+
 private:
    std::unique_ptr<Ar2vFileImpl> p;
 };

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -341,7 +341,7 @@ AwsLevel2ChunksDataProvider::Impl::ListObjects()
    {
       return {true, newObjects, totalObjects};
    }
-   logger_->debug("ListObjects");
+   logger_->trace("ListObjects");
    lastTimeListed_ = now;
 
    const std::string prefix = radarSite_ + "/";
@@ -356,7 +356,7 @@ AwsLevel2ChunksDataProvider::Impl::ListObjects()
    if (outcome.IsSuccess())
    {
       auto& scans = outcome.GetResult().GetCommonPrefixes();
-      // logger_->debug("Found {} scans", scans.size());
+      logger_->trace("Found {} scans", scans.size());
 
       if (scans.size() > 0)
       {
@@ -513,7 +513,7 @@ bool AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
    bool  hasNew = false;
    auto& chunks = listOutcome.GetResult().GetContents();
-   // logger_->debug("Found {} new chunks.", chunks.size());
+   logger_->trace("Found {} new chunks.", chunks.size());
    for (const auto& chunk : chunks)
    {
       const std::string& key = chunk.GetKey();
@@ -726,7 +726,7 @@ std::pair<size_t, size_t> AwsLevel2ChunksDataProvider::Refresh()
 
    timer.stop();
    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers) format to 6 digits
-   // logger_->debug("Refresh() in {}", timer.format(6, "%ws"));
+   logger_->debug("Refresh() in {}", timer.format(6, "%ws"));
    return std::make_pair(newObjects, totalObjects);
 }
 

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -101,10 +101,7 @@ public:
    Impl& operator=(Impl&&)      = delete;
 
    std::chrono::system_clock::time_point GetScanTime(const std::string& prefix);
-   int         GetScanNumber(const std::string& prefix);
-   std::string GetScanKey(const std::string&                           prefix,
-                          const std::chrono::system_clock::time_point& time,
-                          int                                          last);
+   int GetScanNumber(const std::string& prefix);
 
    bool                             LoadScan(Impl::ScanRecord& scanRecord);
    std::tuple<bool, size_t, size_t> ListObjects();
@@ -311,19 +308,6 @@ AwsLevel2ChunksDataProvider::Impl::GetScanTime(const std::string& prefix)
    return {};
 }
 
-std::string AwsLevel2ChunksDataProvider::Impl::GetScanKey(
-   const std::string&                           prefix,
-   const std::chrono::system_clock::time_point& time,
-   int                                          last)
-{
-
-   static const std::string timeFormat {"%Y%m%d-%H%M%S"};
-
-   // TODO
-   return fmt::format(
-      "{0}/{1:%Y%m%d-%H%M%S}-{2}", prefix, fmt::gmtime(time), last - 1);
-}
-
 std::tuple<bool, size_t, size_t>
 AwsLevel2ChunksDataProvider::Impl::ListObjects()
 {
@@ -406,23 +390,23 @@ AwsLevel2ChunksDataProvider::Impl::ListObjects()
             return {false, 0, 0};
          }
 
-         int lastScanNumber = -1;
-         std::chrono::system_clock::time_point lastScanTime = {};
-         std::string lastScanPrefix;
+         int                                   lastScanNumber = -1;
+         std::chrono::system_clock::time_point lastScanTime   = {};
+         std::string                           lastScanPrefix;
 
          for (const int scanNumber : possibleLastNumbers)
          {
             const std::string& scanPrefix = scanNumberMap.at(scanNumber);
-            auto scanTime = GetScanTime(scanPrefix);
+            auto               scanTime   = GetScanTime(scanPrefix);
             if (scanTime > lastScanTime)
             {
-               lastScanTime = scanTime;
+               lastScanTime   = scanTime;
                lastScanPrefix = scanPrefix;
                lastScanNumber = scanNumber;
             }
          }
 
-         const int          secondLastScanNumber =
+         const int secondLastScanNumber =
             // 999 is the last file possible
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             lastScanNumber == 1 ? 999 : lastScanNumber - 1;

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -356,7 +356,7 @@ AwsLevel2ChunksDataProvider::Impl::ListObjects()
    if (outcome.IsSuccess())
    {
       auto& scans = outcome.GetResult().GetCommonPrefixes();
-      logger_->debug("Found {} scans", scans.size());
+      // logger_->debug("Found {} scans", scans.size());
 
       if (scans.size() > 0)
       {
@@ -514,7 +514,7 @@ bool AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
    bool  hasNew = false;
    auto& chunks = listOutcome.GetResult().GetContents();
-   logger_->debug("Found {} new chunks.", chunks.size());
+   // logger_->debug("Found {} new chunks.", chunks.size());
    for (const auto& chunk : chunks)
    {
       const std::string& key = chunk.GetKey();
@@ -728,7 +728,7 @@ std::pair<size_t, size_t> AwsLevel2ChunksDataProvider::Refresh()
 
    timer.stop();
    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers) format to 6 digits
-   logger_->debug("Refresh() in {}", timer.format(6, "%ws"));
+   // logger_->debug("Refresh() in {}", timer.format(6, "%ws"));
    return std::make_pair(newObjects, totalObjects);
 }
 

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -603,7 +603,13 @@ AwsLevel2ChunksDataProvider::LoadObjectByTime(
 std::shared_ptr<wsr88d::NexradFile>
 AwsLevel2ChunksDataProvider::LoadLatestObject()
 {
-   return LoadObjectByTime(FindLatestTime());
+   return p->currentScan_.nexradFile_;
+}
+
+std::shared_ptr<wsr88d::NexradFile>
+AwsLevel2ChunksDataProvider::LoadSecondLatestObject()
+{
+   return p->lastScan_.nexradFile_;
 }
 
 int AwsLevel2ChunksDataProvider::Impl::GetScanNumber(const std::string& prefix)

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -637,7 +637,9 @@ AwsLevel2ChunksDataProvider::LoadObjectByTime(
 std::shared_ptr<wsr88d::NexradFile>
 AwsLevel2ChunksDataProvider::LoadLatestObject()
 {
-   return p->currentScan_.nexradFile_;
+   return std::make_shared<wsr88d::Ar2vFile>(p->currentScan_.nexradFile_,
+                                             p->lastScan_.nexradFile_);
+   //return p->currentScan_.nexradFile_;
 }
 
 std::shared_ptr<wsr88d::NexradFile>

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -21,7 +21,6 @@
 
 namespace scwx::provider
 {
-
 static const std::string logPrefix_ =
    "scwx::provider::aws_level2_chunks_data_provider";
 static const auto logger_ = util::Logger::Create(logPrefix_);
@@ -47,12 +46,12 @@ public:
       ScanRecord& operator=(const ScanRecord&) = default;
       ScanRecord& operator=(ScanRecord&&)      = default;
 
-      std::string prefix_;
-      std::shared_ptr<wsr88d::Ar2vFile> nexradFile_;
+      std::string                           prefix_;
+      std::shared_ptr<wsr88d::Ar2vFile>     nexradFile_;
       std::chrono::system_clock::time_point lastModified_;
       std::chrono::system_clock::time_point secondLastModified_;
-      int nextFile_{1};
-      bool hasAllFiles_{false};
+      int                                   nextFile_ {1};
+      bool                                  hasAllFiles_ {false};
    };
 
    explicit Impl(AwsLevel2ChunksDataProvider* self,
@@ -92,9 +91,9 @@ public:
    Impl& operator=(Impl&&)      = delete;
 
    std::chrono::system_clock::time_point GetScanTime(const std::string& prefix);
-   std::string GetScanKey(const std::string& prefix,
-         const std::chrono::system_clock::time_point& time,
-         int last);
+   std::string                           GetScanKey(const std::string&                           prefix,
+                                                    const std::chrono::system_clock::time_point& time,
+                                                    int                                          last);
    std::shared_ptr<wsr88d::NexradFile>   LoadScan(Impl::ScanRecord& scanRecord);
 
    std::string                        radarSite_;
@@ -111,7 +110,7 @@ public:
    std::chrono::seconds                  updatePeriod_;
 
    AwsLevel2ChunksDataProvider* self_;
-   };
+};
 
 AwsLevel2ChunksDataProvider::AwsLevel2ChunksDataProvider(
    const std::string& radarSite) :
@@ -225,7 +224,7 @@ AwsLevel2ChunksDataProvider::FindLatestTime()
 
 std::vector<std::chrono::system_clock::time_point>
 AwsLevel2ChunksDataProvider::GetTimePointsByDate(
-   std::chrono::system_clock::time_point  /*date*/)
+   std::chrono::system_clock::time_point /*date*/)
 {
    return {};
 }
@@ -254,10 +253,10 @@ std::string AwsLevel2ChunksDataProvider::Impl::GetScanKey(
    const std::chrono::system_clock::time_point& time,
    int                                          last)
 {
-   
+
    static const std::string timeFormat {"%Y%m%d-%H%M%S"};
 
-   //TODO
+   // TODO
    return fmt::format(
       "{0}/{1:%Y%m%d-%H%M%S}-{2}", prefix, fmt::gmtime(time), last - 1);
 }
@@ -288,13 +287,13 @@ AwsLevel2ChunksDataProvider::ListObjects(std::chrono::system_clock::time_point)
 
       for (const auto& scan : scans)
       {
-         const std::string& prefix = scan.GetPrefix();
+         const std::string& prefixScan = scan.GetPrefix();
 
-         auto time = p->GetScanTime(prefix);
+         auto time = p->GetScanTime(prefixScan);
 
          if (!p->scans_.contains(time))
          {
-            p->scans_.insert_or_assign(time, Impl::ScanRecord {prefix});
+            p->scans_.insert_or_assign(time, Impl::ScanRecord {prefixScan});
             newObjects++;
          }
 
@@ -306,7 +305,7 @@ AwsLevel2ChunksDataProvider::ListObjects(std::chrono::system_clock::time_point)
 }
 
 std::shared_ptr<wsr88d::NexradFile>
-AwsLevel2ChunksDataProvider::LoadObjectByKey(const std::string&  /*prefix*/)
+AwsLevel2ChunksDataProvider::LoadObjectByKey(const std::string& /*prefix*/)
 {
    return nullptr;
 }
@@ -339,10 +338,10 @@ AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
       // We just want the number of this chunk for now
       // KIND/585/20250324-134727-001-S
-      constexpr size_t startNumberPos =
+      static const size_t startNumberPos =
          std::string("KIND/585/20250324-134727-").size();
       const std::string& keyNumberStr = key.substr(startNumberPos, 3);
-      const int keyNumber = std::stoi(keyNumberStr);
+      const int          keyNumber    = std::stoi(keyNumberStr);
       if (keyNumber != scanRecord.nextFile_)
       {
          continue;
@@ -350,7 +349,7 @@ AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
       // Now we want the ending char
       // KIND/585/20250324-134727-001-S
-      constexpr size_t charPos =
+      static const size_t charPos =
          std::string("KIND/585/20250324-134727-001-").size();
       const char keyChar = key[charPos];
 
@@ -369,7 +368,8 @@ AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
       auto& body = outcome.GetResultWithOwnership().GetBody();
 
-      switch (keyChar) {
+      switch (keyChar)
+      {
       case 'S':
       { // First chunk
          scanRecord.nexradFile_ = std::make_shared<wsr88d::Ar2vFile>();
@@ -405,8 +405,7 @@ AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
 
       std::chrono::seconds lastModifiedSeconds {
          outcome.GetResult().GetLastModified().Seconds()};
-      std::chrono::system_clock::time_point lastModified {
-         lastModifiedSeconds};
+      std::chrono::system_clock::time_point lastModified {lastModifiedSeconds};
 
       scanRecord.secondLastModified_ = scanRecord.lastModified_;
       scanRecord.lastModified_       = lastModified;

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -676,12 +676,10 @@ std::pair<size_t, size_t> AwsLevel2ChunksDataProvider::Refresh()
    }
    if (p->lastScan_.valid_)
    {
-      /*
       if (p->LoadScan(p->lastScan_))
       {
          newObjects += 1;
       }
-      */
       totalObjects += 1;
    }
 

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -1,0 +1,490 @@
+#include <scwx/provider/aws_level2_chunks_data_provider.hpp>
+#include <scwx/util/environment.hpp>
+#include <scwx/util/map.hpp>
+#include <scwx/util/logger.hpp>
+#include <scwx/util/time.hpp>
+#include <scwx/wsr88d/ar2v_file.hpp>
+
+#include <shared_mutex>
+#include <utility>
+
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
+#if (__cpp_lib_chrono < 201907L)
+#   include <date/date.h>
+#endif
+
+namespace scwx::provider
+{
+
+static const std::string logPrefix_ =
+   "scwx::provider::aws_level2_chunks_data_provider";
+static const auto logger_ = util::Logger::Create(logPrefix_);
+
+static const std::string kDefaultBucketName_ = "unidata-nexrad-level2-chunks";
+static const std::string kDefaultRegion_     = "us-east-1";
+
+class AwsLevel2ChunksDataProvider::Impl
+{
+public:
+   struct ScanRecord
+   {
+      explicit ScanRecord(std::string prefix) :
+          prefix_ {std::move(prefix)},
+          nexradFile_ {},
+          lastModified_ {},
+          secondLastModified_ {}
+      {
+      }
+      ~ScanRecord()                            = default;
+      ScanRecord(const ScanRecord&)            = default;
+      ScanRecord(ScanRecord&&)                 = default;
+      ScanRecord& operator=(const ScanRecord&) = default;
+      ScanRecord& operator=(ScanRecord&&)      = default;
+
+      std::string prefix_;
+      std::shared_ptr<wsr88d::Ar2vFile> nexradFile_;
+      std::chrono::system_clock::time_point lastModified_;
+      std::chrono::system_clock::time_point secondLastModified_;
+      int nextFile_{1};
+      bool hasAllFiles_{false};
+   };
+
+   explicit Impl(AwsLevel2ChunksDataProvider* self,
+                 std::string                  radarSite,
+                 std::string                  bucketName,
+                 std::string                  region) :
+       radarSite_ {std::move(radarSite)},
+       bucketName_ {std::move(bucketName)},
+       region_ {std::move(region)},
+       client_ {nullptr},
+       scans_ {},
+       scansMutex_ {},
+       lastModified_ {},
+       updatePeriod_ {},
+       self_ {self}
+   {
+      // Disable HTTP request for region
+      util::SetEnvironment("AWS_EC2_METADATA_DISABLED", "true");
+
+      // Use anonymous credentials
+      Aws::Auth::AWSCredentials credentials {};
+
+      Aws::Client::ClientConfiguration config;
+      config.region           = region_;
+      config.connectTimeoutMs = 10000;
+
+      client_ = std::make_shared<Aws::S3::S3Client>(
+         credentials,
+         Aws::MakeShared<Aws::S3::S3EndpointProvider>(
+            Aws::S3::S3Client::GetAllocationTag()),
+         config);
+   }
+   ~Impl()                      = default;
+   Impl(const Impl&)            = delete;
+   Impl(Impl&&)                 = delete;
+   Impl& operator=(const Impl&) = delete;
+   Impl& operator=(Impl&&)      = delete;
+
+   std::chrono::system_clock::time_point GetScanTime(const std::string& prefix);
+   std::string GetScanKey(const std::string& prefix,
+         const std::chrono::system_clock::time_point& time,
+         int last);
+   std::shared_ptr<wsr88d::NexradFile>   LoadScan(Impl::ScanRecord& scanRecord);
+
+   std::string                        radarSite_;
+   std::string                        bucketName_;
+   std::string                        region_;
+   std::shared_ptr<Aws::S3::S3Client> client_;
+
+   std::mutex refreshMutex_;
+
+   std::map<std::chrono::system_clock::time_point, ScanRecord> scans_;
+   std::shared_mutex                                           scansMutex_;
+
+   std::chrono::system_clock::time_point lastModified_;
+   std::chrono::seconds                  updatePeriod_;
+
+   AwsLevel2ChunksDataProvider* self_;
+   };
+
+AwsLevel2ChunksDataProvider::AwsLevel2ChunksDataProvider(
+   const std::string& radarSite) :
+    AwsLevel2ChunksDataProvider(radarSite, kDefaultBucketName_, kDefaultRegion_)
+{
+}
+
+AwsLevel2ChunksDataProvider::AwsLevel2ChunksDataProvider(
+   const std::string& radarSite,
+   const std::string& bucketName,
+   const std::string& region) :
+    p(std::make_unique<Impl>(this, radarSite, bucketName, region))
+{
+}
+
+AwsLevel2ChunksDataProvider::~AwsLevel2ChunksDataProvider() = default;
+
+std::chrono::system_clock::time_point
+AwsLevel2ChunksDataProvider::GetTimePointByKey(const std::string& key) const
+{
+   std::chrono::system_clock::time_point time {};
+
+   const size_t lastSeparator = key.rfind('/');
+   const size_t offset =
+      (lastSeparator == std::string::npos) ? 0 : lastSeparator + 1;
+
+   // Filename format is YYYYMMDD-TTTTTT-AAA-B
+   static const size_t formatSize = std::string("YYYYMMDD-TTTTTT").size();
+
+   if (key.size() >= offset + formatSize)
+   {
+      using namespace std::chrono;
+
+#if (__cpp_lib_chrono < 201907L)
+      using namespace date;
+#endif
+
+      static const std::string timeFormat {"%Y%m%d-%H%M%S"};
+
+      std::string        timeStr {key.substr(offset, formatSize)};
+      std::istringstream in {timeStr};
+      in >> parse(timeFormat, time);
+
+      if (in.fail())
+      {
+         logger_->warn("Invalid time: \"{}\"", timeStr);
+      }
+   }
+   else
+   {
+      logger_->warn("Time not parsable from key: \"{}\"", key);
+   }
+
+   return time;
+}
+
+size_t AwsLevel2ChunksDataProvider::cache_size() const
+{
+   return p->scans_.size();
+}
+
+std::chrono::system_clock::time_point
+AwsLevel2ChunksDataProvider::last_modified() const
+{
+   return p->lastModified_;
+}
+std::chrono::seconds AwsLevel2ChunksDataProvider::update_period() const
+{
+   return p->updatePeriod_;
+}
+
+std::string
+AwsLevel2ChunksDataProvider::FindKey(std::chrono::system_clock::time_point time)
+{
+   logger_->debug("FindKey: {}", util::TimeString(time));
+
+   std::shared_lock lock(p->scansMutex_);
+
+   auto element = util::GetBoundedElement(p->scans_, time);
+
+   if (element.has_value())
+   {
+      return element->prefix_;
+   }
+
+   return {};
+}
+
+std::string AwsLevel2ChunksDataProvider::FindLatestKey()
+{
+   std::shared_lock lock(p->scansMutex_);
+   if (p->scans_.empty())
+   {
+      return "";
+   }
+
+   return p->scans_.crbegin()->second.prefix_;
+}
+
+std::chrono::system_clock::time_point
+AwsLevel2ChunksDataProvider::FindLatestTime()
+{
+   std::shared_lock lock(p->scansMutex_);
+   if (p->scans_.empty())
+   {
+      return {};
+   }
+
+   return p->scans_.crbegin()->first;
+}
+
+std::vector<std::chrono::system_clock::time_point>
+AwsLevel2ChunksDataProvider::GetTimePointsByDate(
+   std::chrono::system_clock::time_point  /*date*/)
+{
+   return {};
+}
+
+std::chrono::system_clock::time_point
+AwsLevel2ChunksDataProvider::Impl::GetScanTime(const std::string& prefix)
+{
+   Aws::S3::Model::ListObjectsV2Request request;
+   request.SetBucket(bucketName_);
+   request.SetPrefix(prefix);
+   request.SetDelimiter("/");
+   request.SetMaxKeys(1);
+
+   auto outcome = client_->ListObjectsV2(request);
+   if (outcome.IsSuccess())
+   {
+      return self_->GetTimePointByKey(
+         outcome.GetResult().GetContents().at(0).GetKey());
+   }
+
+   return {};
+}
+
+std::string AwsLevel2ChunksDataProvider::Impl::GetScanKey(
+   const std::string&                           prefix,
+   const std::chrono::system_clock::time_point& time,
+   int                                          last)
+{
+   
+   static const std::string timeFormat {"%Y%m%d-%H%M%S"};
+
+   //TODO
+   return fmt::format(
+      "{0}/{1:%Y%m%d-%H%M%S}-{2}", prefix, fmt::gmtime(time), last - 1);
+}
+
+std::tuple<bool, size_t, size_t>
+AwsLevel2ChunksDataProvider::ListObjects(std::chrono::system_clock::time_point)
+{
+   // TODO this is slow. It could probably be speed up by not reloading every
+   // scan every time.
+   const std::string prefix = p->radarSite_ + "/";
+
+   logger_->debug("ListObjects: {}", prefix);
+
+   Aws::S3::Model::ListObjectsV2Request request;
+   request.SetBucket(p->bucketName_);
+   request.SetPrefix(prefix);
+   request.SetDelimiter("/");
+
+   auto outcome = p->client_->ListObjectsV2(request);
+
+   size_t newObjects   = 0;
+   size_t totalObjects = 0;
+
+   if (outcome.IsSuccess())
+   {
+      auto& scans = outcome.GetResult().GetCommonPrefixes();
+      logger_->debug("Found {} scans", scans.size());
+
+      for (const auto& scan : scans)
+      {
+         const std::string& prefix = scan.GetPrefix();
+
+         auto time = p->GetScanTime(prefix);
+
+         if (!p->scans_.contains(time))
+         {
+            p->scans_.insert_or_assign(time, Impl::ScanRecord {prefix});
+            newObjects++;
+         }
+
+         totalObjects++;
+      }
+   }
+
+   return {outcome.IsSuccess(), newObjects, totalObjects};
+}
+
+std::shared_ptr<wsr88d::NexradFile>
+AwsLevel2ChunksDataProvider::LoadObjectByKey(const std::string&  /*prefix*/)
+{
+   return nullptr;
+}
+
+std::shared_ptr<wsr88d::NexradFile>
+AwsLevel2ChunksDataProvider::Impl::LoadScan(Impl::ScanRecord& scanRecord)
+{
+   if (scanRecord.hasAllFiles_)
+   {
+      return scanRecord.nexradFile_;
+   }
+
+   // TODO can get  only new records using scanRecords last
+   Aws::S3::Model::ListObjectsV2Request listRequest;
+   listRequest.SetBucket(bucketName_);
+   listRequest.SetPrefix(scanRecord.prefix_);
+   listRequest.SetDelimiter("/");
+
+   auto listOutcome = client_->ListObjectsV2(listRequest);
+   if (!listOutcome.IsSuccess())
+   {
+      logger_->warn("Could not find scan at {}", scanRecord.prefix_);
+      return nullptr;
+   }
+
+   auto& chunks = listOutcome.GetResult().GetContents();
+   for (const auto& chunk : chunks)
+   {
+      const std::string& key = chunk.GetKey();
+
+      // We just want the number of this chunk for now
+      // KIND/585/20250324-134727-001-S
+      constexpr size_t startNumberPos =
+         std::string("KIND/585/20250324-134727-").size();
+      const std::string& keyNumberStr = key.substr(startNumberPos, 3);
+      const int keyNumber = std::stoi(keyNumberStr);
+      if (keyNumber != scanRecord.nextFile_)
+      {
+         continue;
+      }
+
+      // Now we want the ending char
+      // KIND/585/20250324-134727-001-S
+      constexpr size_t charPos =
+         std::string("KIND/585/20250324-134727-001-").size();
+      const char keyChar = key[charPos];
+
+      Aws::S3::Model::GetObjectRequest objectRequest;
+      objectRequest.SetBucket(bucketName_);
+      objectRequest.SetKey(key);
+
+      auto outcome = client_->GetObject(objectRequest);
+
+      if (!outcome.IsSuccess())
+      {
+         logger_->warn("Could not get object: {}",
+                       outcome.GetError().GetMessage());
+         return nullptr;
+      }
+
+      auto& body = outcome.GetResultWithOwnership().GetBody();
+
+      switch (keyChar) {
+      case 'S':
+      { // First chunk
+         scanRecord.nexradFile_ = std::make_shared<wsr88d::Ar2vFile>();
+         if (!scanRecord.nexradFile_->LoadData(body))
+         {
+            logger_->warn("Failed to load first chunk");
+            return nullptr;
+         }
+         break;
+      }
+      case 'I':
+      { // Middle chunk
+         if (!scanRecord.nexradFile_->LoadLDMRecords(body))
+         {
+            logger_->warn("Failed to load middle chunk");
+            return nullptr;
+         }
+         break;
+      }
+      case 'E':
+      { // Last chunk
+         if (!scanRecord.nexradFile_->LoadLDMRecords(body))
+         {
+            logger_->warn("Failed to load last chunk");
+            return nullptr;
+         }
+         scanRecord.hasAllFiles_ = true;
+         break;
+      }
+      default:
+         return nullptr;
+      }
+
+      std::chrono::seconds lastModifiedSeconds {
+         outcome.GetResult().GetLastModified().Seconds()};
+      std::chrono::system_clock::time_point lastModified {
+         lastModifiedSeconds};
+
+      scanRecord.secondLastModified_ = scanRecord.lastModified_;
+      scanRecord.lastModified_       = lastModified;
+
+      scanRecord.nextFile_ += 1;
+   }
+   scanRecord.nexradFile_->IndexFile();
+
+   if (!scans_.empty())
+   {
+      auto& lastScan = scans_.crend()->second;
+      lastModified_  = lastScan.lastModified_;
+      if (lastScan.secondLastModified_ !=
+          std::chrono::system_clock::time_point())
+      {
+         auto delta = lastScan.lastModified_ - lastScan.secondLastModified_;
+         updatePeriod_ =
+            std::chrono::duration_cast<std::chrono::seconds>(delta);
+      }
+   }
+
+   return scanRecord.nexradFile_;
+}
+
+std::shared_ptr<wsr88d::NexradFile>
+AwsLevel2ChunksDataProvider::LoadObjectByTime(
+   std::chrono::system_clock::time_point time)
+{
+   std::shared_lock lock(p->scansMutex_);
+
+   logger_->error("LoadObjectByTime({})", time);
+
+   auto scanRecord = util::GetBoundedElementPointer(p->scans_, time);
+   if (scanRecord == nullptr)
+   {
+      logger_->warn("Could not find object at time {}", time);
+      return nullptr;
+   }
+
+   // The scanRecord must be a reference
+   return p->LoadScan(p->scans_.at(scanRecord->first));
+}
+
+std::shared_ptr<wsr88d::NexradFile>
+AwsLevel2ChunksDataProvider::LoadLatestObject()
+{
+   return LoadObjectByTime(FindLatestTime());
+}
+
+std::pair<size_t, size_t> AwsLevel2ChunksDataProvider::Refresh()
+{
+   using namespace std::chrono;
+
+   std::unique_lock lock(p->refreshMutex_);
+
+   auto [success, newObjects, totalObjects] = ListObjects({});
+
+   for (auto& scanRecord : p->scans_)
+   {
+      if (scanRecord.second.nexradFile_ != nullptr)
+      {
+         p->LoadScan(scanRecord.second);
+         newObjects += 1;
+      }
+   }
+
+   return std::make_pair(newObjects, totalObjects);
+}
+
+void AwsLevel2ChunksDataProvider::RequestAvailableProducts() {}
+std::vector<std::string> AwsLevel2ChunksDataProvider::GetAvailableProducts()
+{
+   return {};
+}
+
+AwsLevel2ChunksDataProvider::AwsLevel2ChunksDataProvider(
+   AwsLevel2ChunksDataProvider&&) noexcept = default;
+AwsLevel2ChunksDataProvider& AwsLevel2ChunksDataProvider::operator=(
+   AwsLevel2ChunksDataProvider&&) noexcept = default;
+
+} // namespace scwx::provider

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -735,8 +735,7 @@ float AwsLevel2ChunksDataProvider::GetCurrentElevation()
 
    if (vcpData != nullptr)
    {
-      // NOLINTNEXTLINE(*-narrowing-conversions) Float is plenty
-      return vcpData->elevation_angle(lastElevation->first);
+      return static_cast<float>(vcpData->elevation_angle(lastElevation->first));
    }
    else if (digitalRadarData0 != nullptr)
    {

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -405,7 +405,6 @@ AwsLevel2ChunksDataProvider::Impl::ListObjects()
          if (possibleLastNumbers.empty())
          {
             logger_->warn("Could not find last scan");
-            // TODO make sure this makes sence
             return {false, 0, 0};
          }
 
@@ -705,7 +704,6 @@ std::pair<size_t, size_t> AwsLevel2ChunksDataProvider::Refresh()
                      if (p->lastScan_.nexradFile_ != nullptr)
                      {
                         p->lastScan_.hasAllFiles_ = true;
-                        // TODO maybe set lastModified for timing
                      }
                   }
                   // Fall back to chunks if files did not load

--- a/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_chunks_data_provider.cpp
@@ -699,12 +699,12 @@ AwsLevel2ChunksDataProvider::AwsLevel2ChunksDataProvider(
 AwsLevel2ChunksDataProvider& AwsLevel2ChunksDataProvider::operator=(
    AwsLevel2ChunksDataProvider&&) noexcept = default;
 
-float AwsLevel2ChunksDataProvider::GetCurrentElevation()
+std::optional<float> AwsLevel2ChunksDataProvider::GetCurrentElevation()
 {
    if (!p->currentScan_.valid_ || p->currentScan_.nexradFile_ == nullptr)
    {
       // Does not have any scan elevation. -90 is beyond what is possible
-      return INVALID_ELEVATION;
+      return {};
    }
 
    auto vcpData   = p->currentScan_.nexradFile_->vcp_data();
@@ -712,7 +712,7 @@ float AwsLevel2ChunksDataProvider::GetCurrentElevation()
    if (radarData.size() == 0)
    {
       // Does not have any scan elevation. -90 is beyond what is possible
-      return INVALID_ELEVATION;
+      return {};
    }
 
    const auto& lastElevation = radarData.crbegin();
@@ -729,7 +729,7 @@ float AwsLevel2ChunksDataProvider::GetCurrentElevation()
       return digitalRadarData0->elevation_angle().value();
    }
 
-   return INVALID_ELEVATION;
+   return {};
 }
 
 } // namespace scwx::provider

--- a/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
@@ -346,17 +346,6 @@ std::shared_ptr<wsr88d::NexradFile> AwsNexradDataProvider::LoadObjectByTime(
    }
 }
 
-std::shared_ptr<wsr88d::NexradFile> AwsNexradDataProvider::LoadLatestObject()
-{
-   return LoadObjectByKey(FindLatestKey());
-}
-
-std::shared_ptr<wsr88d::NexradFile>
-AwsNexradDataProvider::LoadSecondLatestObject()
-{
-   return nullptr;
-}
-
 std::pair<size_t, size_t> AwsNexradDataProvider::Refresh()
 {
    using namespace std::chrono;

--- a/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
@@ -170,6 +170,11 @@ std::string AwsNexradDataProvider::FindLatestKey()
    return key;
 }
 
+std::chrono::system_clock::time_point AwsNexradDataProvider::FindLatestTime()
+{
+   return GetTimePointByKey(FindLatestKey());
+}
+
 std::vector<std::chrono::system_clock::time_point>
 AwsNexradDataProvider::GetTimePointsByDate(
    std::chrono::system_clock::time_point date)
@@ -325,6 +330,25 @@ AwsNexradDataProvider::LoadObjectByKey(const std::string& key)
    }
 
    return nexradFile;
+}
+
+std::shared_ptr<wsr88d::NexradFile> AwsNexradDataProvider::LoadObjectByTime(
+   std::chrono::system_clock::time_point time)
+{
+   const std::string key = FindKey(time);
+   if (key.empty())
+   {
+      return nullptr;
+   }
+   else
+   {
+      return LoadObjectByKey(key);
+   }
+}
+
+std::shared_ptr<wsr88d::NexradFile> AwsNexradDataProvider::LoadLatestObject()
+{
+   return LoadObjectByKey(FindLatestKey());
 }
 
 std::pair<size_t, size_t> AwsNexradDataProvider::Refresh()

--- a/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
@@ -351,6 +351,12 @@ std::shared_ptr<wsr88d::NexradFile> AwsNexradDataProvider::LoadLatestObject()
    return LoadObjectByKey(FindLatestKey());
 }
 
+std::shared_ptr<wsr88d::NexradFile>
+AwsNexradDataProvider::LoadSecondLatestObject()
+{
+   return nullptr;
+}
+
 std::pair<size_t, size_t> AwsNexradDataProvider::Refresh()
 {
    using namespace std::chrono;

--- a/wxdata/source/scwx/provider/nexrad_data_provider_factory.cpp
+++ b/wxdata/source/scwx/provider/nexrad_data_provider_factory.cpp
@@ -1,5 +1,6 @@
 #include <scwx/provider/nexrad_data_provider_factory.hpp>
-#include <scwx/provider/aws_level2_data_provider.hpp>
+//#include <scwx/provider/aws_level2_data_provider.hpp>
+#include <scwx/provider/aws_level2_chunks_data_provider.hpp>
 #include <scwx/provider/aws_level3_data_provider.hpp>
 
 namespace scwx
@@ -14,7 +15,7 @@ std::shared_ptr<NexradDataProvider>
 NexradDataProviderFactory::CreateLevel2DataProvider(
    const std::string& radarSite)
 {
-   return std::make_unique<AwsLevel2DataProvider>(radarSite);
+   return std::make_unique<AwsLevel2ChunksDataProvider>(radarSite);
 }
 
 std::shared_ptr<NexradDataProvider>

--- a/wxdata/source/scwx/provider/nexrad_data_provider_factory.cpp
+++ b/wxdata/source/scwx/provider/nexrad_data_provider_factory.cpp
@@ -1,5 +1,5 @@
 #include <scwx/provider/nexrad_data_provider_factory.hpp>
-//#include <scwx/provider/aws_level2_data_provider.hpp>
+#include <scwx/provider/aws_level2_data_provider.hpp>
 #include <scwx/provider/aws_level2_chunks_data_provider.hpp>
 #include <scwx/provider/aws_level3_data_provider.hpp>
 
@@ -13,6 +13,13 @@ static const std::string logPrefix_ =
 
 std::shared_ptr<NexradDataProvider>
 NexradDataProviderFactory::CreateLevel2DataProvider(
+   const std::string& radarSite)
+{
+   return std::make_unique<AwsLevel2DataProvider>(radarSite);
+}
+
+std::shared_ptr<NexradDataProvider>
+NexradDataProviderFactory::CreateLevel2ChunksDataProvider(
    const std::string& radarSite)
 {
    return std::make_unique<AwsLevel2ChunksDataProvider>(radarSite);

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -465,8 +465,8 @@ void Ar2vFileImpl::IndexFile()
 
       if (vcpData_ != nullptr)
       {
-         // NOLINTNEXTLINE(*-narrowing-conversions) Float is plenty
-         elevationAngle = vcpData_->elevation_angle(elevationCut.first);
+         elevationAngle =
+            static_cast<float>(vcpData_->elevation_angle(elevationCut.first));
          waveformType   = vcpData_->waveform_type(elevationCut.first);
       }
       else if ((digitalRadarData0 =

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -519,5 +519,25 @@ void Ar2vFileImpl::IndexFile()
    }
 }
 
+bool Ar2vFile::LoadLDMRecords(std::istream& is) {
+   size_t decompressedRecords = p->DecompressLDMRecords(is);
+   if (decompressedRecords == 0)
+   {
+      p->ParseLDMRecord(is);
+   }
+   else
+   {
+      p->ParseLDMRecords();
+   }
+
+   return true;
+}
+
+bool Ar2vFile::IndexFile()
+{
+   p->IndexFile();
+   return true;
+}
+
 } // namespace wsr88d
 } // namespace scwx

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -568,6 +568,15 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
                continue;
             }
 
+            // Add previous scans for stepping back in time
+            for (auto scan = ++(elevation.second.rbegin());
+                 scan != elevation.second.rend();
+                 ++scan)
+            {
+               p->index_[type.first][elevation.first][scan->first] =
+                  scan->second;
+            }
+
             // Merge this scan with the last one if it is incomplete
             if (IsRadarDataIncomplete(mostRecent->second))
             {

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -138,7 +138,7 @@ Ar2vFile::GetElevationScan(rda::DataBlockType                    dataBlockType,
                            float                                 elevation,
                            std::chrono::system_clock::time_point time) const
 {
-   logger_->debug("GetElevationScan: {} degrees", elevation);
+   //logger_->debug("GetElevationScan: {} degrees", elevation);
 
    std::shared_ptr<rda::ElevationScan> elevationScan = nullptr;
    float                               elevationCut  = 0.0f;
@@ -273,7 +273,7 @@ bool Ar2vFile::LoadData(std::istream& is)
 
 std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
 {
-   logger_->debug("Decompressing LDM Records");
+   //logger_->debug("Decompressing LDM Records");
 
    std::size_t numRecords = 0;
 
@@ -321,22 +321,22 @@ std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
       ++numRecords;
    }
 
-   logger_->debug("Decompressed {} LDM Records", numRecords);
+   //logger_->debug("Decompressed {} LDM Records", numRecords);
 
    return numRecords;
 }
 
 void Ar2vFileImpl::ParseLDMRecords()
 {
-   logger_->debug("Parsing LDM Records");
+   //logger_->debug("Parsing LDM Records");
 
-   std::size_t count = 0;
+   //std::size_t count = 0;
 
    for (auto it = rawRecords_.begin(); it != rawRecords_.end(); it++)
    {
       std::stringstream& ss = *it;
 
-      logger_->trace("Record {}", count++);
+      //logger_->trace("Record {}", count++);
 
       ParseLDMRecord(ss);
    }
@@ -445,7 +445,7 @@ void Ar2vFileImpl::ProcessRadarData(
 
 void Ar2vFileImpl::IndexFile()
 {
-   logger_->debug("Indexing file");
+   //logger_->debug("Indexing file");
 
    constexpr float scaleFactor = 8.0f / 0.043945f;
 

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -467,7 +467,7 @@ void Ar2vFileImpl::IndexFile()
       {
          elevationAngle =
             static_cast<float>(vcpData_->elevation_angle(elevationCut.first));
-         waveformType   = vcpData_->waveform_type(elevationCut.first);
+         waveformType = vcpData_->waveform_type(elevationCut.first);
       }
       else if ((digitalRadarData0 =
                    std::dynamic_pointer_cast<rda::DigitalRadarData>(radial0)) !=
@@ -705,8 +705,8 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
          // Find the highest elevation this type has for the current scan
          // Start below any reasonable elevation
          // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-         float       highestCurrentElevation  = -90;
-         const auto& elevationScans = p->index_.find(type.first);
+         float       highestCurrentElevation = -90;
+         const auto& elevationScans          = p->index_.find(type.first);
          if (elevationScans != p->index_.cend())
          {
             const auto& highestElevation = elevationScans->second.crbegin();

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -138,7 +138,7 @@ Ar2vFile::GetElevationScan(rda::DataBlockType                    dataBlockType,
                            float                                 elevation,
                            std::chrono::system_clock::time_point time) const
 {
-   // logger_->debug("GetElevationScan: {} degrees", elevation);
+   logger_->trace("GetElevationScan: {} degrees", elevation);
 
    std::shared_ptr<rda::ElevationScan> elevationScan = nullptr;
    float                               elevationCut  = 0.0f;
@@ -273,7 +273,7 @@ bool Ar2vFile::LoadData(std::istream& is)
 
 std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
 {
-   // logger_->debug("Decompressing LDM Records");
+   logger_->trace("Decompressing LDM Records");
 
    std::size_t numRecords = 0;
 
@@ -321,22 +321,22 @@ std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
       ++numRecords;
    }
 
-   // logger_->debug("Decompressed {} LDM Records", numRecords);
+   logger_->trace("Decompressed {} LDM Records", numRecords);
 
    return numRecords;
 }
 
 void Ar2vFileImpl::ParseLDMRecords()
 {
-   // logger_->debug("Parsing LDM Records");
+   logger_->trace("Parsing LDM Records");
 
-   // std::size_t count = 0;
+   std::size_t count = 0;
 
    for (auto it = rawRecords_.begin(); it != rawRecords_.end(); it++)
    {
       std::stringstream& ss = *it;
 
-      // logger_->trace("Record {}", count++);
+      logger_->trace("Record {}", count++);
 
       ParseLDMRecord(ss);
    }
@@ -445,7 +445,7 @@ void Ar2vFileImpl::ProcessRadarData(
 
 void Ar2vFileImpl::IndexFile()
 {
-   // logger_->debug("Indexing file");
+   logger_->trace("Indexing file");
 
    for (auto& elevationCut : radarData_)
    {

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -138,7 +138,7 @@ Ar2vFile::GetElevationScan(rda::DataBlockType                    dataBlockType,
                            float                                 elevation,
                            std::chrono::system_clock::time_point time) const
 {
-   //logger_->debug("GetElevationScan: {} degrees", elevation);
+   // logger_->debug("GetElevationScan: {} degrees", elevation);
 
    std::shared_ptr<rda::ElevationScan> elevationScan = nullptr;
    float                               elevationCut  = 0.0f;
@@ -273,7 +273,7 @@ bool Ar2vFile::LoadData(std::istream& is)
 
 std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
 {
-   //logger_->debug("Decompressing LDM Records");
+   // logger_->debug("Decompressing LDM Records");
 
    std::size_t numRecords = 0;
 
@@ -321,22 +321,22 @@ std::size_t Ar2vFileImpl::DecompressLDMRecords(std::istream& is)
       ++numRecords;
    }
 
-   //logger_->debug("Decompressed {} LDM Records", numRecords);
+   // logger_->debug("Decompressed {} LDM Records", numRecords);
 
    return numRecords;
 }
 
 void Ar2vFileImpl::ParseLDMRecords()
 {
-   //logger_->debug("Parsing LDM Records");
+   // logger_->debug("Parsing LDM Records");
 
-   //std::size_t count = 0;
+   // std::size_t count = 0;
 
    for (auto it = rawRecords_.begin(); it != rawRecords_.end(); it++)
    {
       std::stringstream& ss = *it;
 
-      //logger_->trace("Record {}", count++);
+      // logger_->trace("Record {}", count++);
 
       ParseLDMRecord(ss);
    }
@@ -445,7 +445,7 @@ void Ar2vFileImpl::ProcessRadarData(
 
 void Ar2vFileImpl::IndexFile()
 {
-   //logger_->debug("Indexing file");
+   // logger_->debug("Indexing file");
 
    for (auto& elevationCut : radarData_)
    {
@@ -465,6 +465,7 @@ void Ar2vFileImpl::IndexFile()
 
       if (vcpData_ != nullptr)
       {
+         // NOLINTNEXTLINE(*-narrowing-conversions) Float is plenty
          elevationAngle = vcpData_->elevation_angle(elevationCut.first);
          waveformType   = vcpData_->waveform_type(elevationCut.first);
       }
@@ -500,15 +501,15 @@ void Ar2vFileImpl::IndexFile()
             auto time = util::TimePoint(radial0->modified_julian_date(),
                                         radial0->collection_time());
 
-            index_[dataBlockType][elevationAngle][time] =
-               elevationCut.second;
+            index_[dataBlockType][elevationAngle][time] = elevationCut.second;
          }
       }
    }
 }
 
-bool Ar2vFile::LoadLDMRecords(std::istream& is) {
-   size_t decompressedRecords = p->DecompressLDMRecords(is);
+bool Ar2vFile::LoadLDMRecords(std::istream& is)
+{
+   const size_t decompressedRecords = p->DecompressLDMRecords(is);
    if (decompressedRecords == 0)
    {
       p->ParseLDMRecord(is);
@@ -528,6 +529,7 @@ bool Ar2vFile::IndexFile()
 }
 
 // TODO not good
+// NOLINTNEXTLINE
 bool IsRadarDataIncomplete(
    const std::shared_ptr<const rda::ElevationScan>& radarData)
 {
@@ -695,12 +697,13 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
          // Find the highest elevation this type has for the current scan
          // Start below any reasonable elevation
          // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-         float highestCurrentElevation = -90;
-         const auto& maybe1 = p->index_.find(type.first);
+         float       highestCurrentElevation = -90;
+         const auto& maybe1                  = p->index_.find(type.first);
          if (maybe1 != p->index_.cend())
          {
             const auto& maybe2 = maybe1->second.crbegin();
-            if (maybe2 != maybe1->second.crend()) {
+            if (maybe2 != maybe1->second.crend())
+            {
                // Add a slight offset to ensure good floating point compare.
                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                highestCurrentElevation = maybe2->first + 0.01f;

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -528,7 +528,6 @@ bool Ar2vFile::IndexFile()
    return true;
 }
 
-// TODO not good
 // NOLINTNEXTLINE
 bool IsRadarDataIncomplete(
    const std::shared_ptr<const rda::ElevationScan>& radarData)
@@ -583,10 +582,10 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
                std::shared_ptr<rda::ElevationScan> secondMostRecent = nullptr;
 
                // check if this volume scan has an earlier elevation scan
-               auto maybe = elevation.second.rbegin(); // TODO name
-               ++maybe;
+               auto possibleSecondMostRecent = elevation.second.rbegin();
+               ++possibleSecondMostRecent;
 
-               if (maybe == elevation.second.rend())
+               if (possibleSecondMostRecent == elevation.second.rend())
                {
                   if (last == nullptr)
                   {
@@ -613,7 +612,7 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
                }
                else
                {
-                  secondMostRecent = maybe->second;
+                  secondMostRecent = possibleSecondMostRecent->second;
                }
 
                // Make the new scan
@@ -706,16 +705,16 @@ Ar2vFile::Ar2vFile(const std::shared_ptr<Ar2vFile>& current,
          // Find the highest elevation this type has for the current scan
          // Start below any reasonable elevation
          // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-         float       highestCurrentElevation = -90;
-         const auto& maybe1                  = p->index_.find(type.first);
-         if (maybe1 != p->index_.cend())
+         float       highestCurrentElevation  = -90;
+         const auto& elevationScans = p->index_.find(type.first);
+         if (elevationScans != p->index_.cend())
          {
-            const auto& maybe2 = maybe1->second.crbegin();
-            if (maybe2 != maybe1->second.crend())
+            const auto& highestElevation = elevationScans->second.crbegin();
+            if (highestElevation != elevationScans->second.crend())
             {
                // Add a slight offset to ensure good floating point compare.
                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-               highestCurrentElevation = maybe2->first + 0.01f;
+               highestCurrentElevation = highestElevation->first + 0.01f;
             }
          }
 

--- a/wxdata/source/scwx/wsr88d/ar2v_file.cpp
+++ b/wxdata/source/scwx/wsr88d/ar2v_file.cpp
@@ -447,11 +447,9 @@ void Ar2vFileImpl::IndexFile()
 {
    //logger_->debug("Indexing file");
 
-   constexpr float scaleFactor = 8.0f / 0.043945f;
-
    for (auto& elevationCut : radarData_)
    {
-      std::uint16_t     elevationAngle {};
+      float             elevationAngle {};
       rda::WaveformType waveformType = rda::WaveformType::Unknown;
 
       std::shared_ptr<rda::GenericRadarData>& radial0 =
@@ -467,14 +465,14 @@ void Ar2vFileImpl::IndexFile()
 
       if (vcpData_ != nullptr)
       {
-         elevationAngle = vcpData_->elevation_angle_raw(elevationCut.first);
+         elevationAngle = vcpData_->elevation_angle(elevationCut.first);
          waveformType   = vcpData_->waveform_type(elevationCut.first);
       }
       else if ((digitalRadarData0 =
                    std::dynamic_pointer_cast<rda::DigitalRadarData>(radial0)) !=
                nullptr)
       {
-         elevationAngle = digitalRadarData0->elevation_angle_raw();
+         elevationAngle = digitalRadarData0->elevation_angle().value();
       }
       else
       {
@@ -502,18 +500,7 @@ void Ar2vFileImpl::IndexFile()
             auto time = util::TimePoint(radial0->modified_julian_date(),
                                         radial0->collection_time());
 
-            // NOLINTNEXTLINE This conversion is accurate
-            float elevationAngleConverted = elevationAngle / scaleFactor;
-            // Any elevation above 90 degrees should be interpreted as a
-            // negative angle
-            // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-            if (elevationAngleConverted > 90)
-            {
-               elevationAngleConverted -= 360;
-            }
-            // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-
-            index_[dataBlockType][elevationAngleConverted][time] =
+            index_[dataBlockType][elevationAngle][time] =
                elevationCut.second;
          }
       }

--- a/wxdata/source/scwx/wsr88d/rda/digital_radar_data.cpp
+++ b/wxdata/source/scwx/wsr88d/rda/digital_radar_data.cpp
@@ -154,7 +154,18 @@ std::uint16_t DigitalRadarData::elevation_angle_raw() const
 
 units::degrees<float> DigitalRadarData::elevation_angle() const
 {
-   return units::degrees<float> {p->elevationAngle_ * kAngleDataScale};
+   // NOLINTNEXTLINE This conversion is accurate
+   float elevationAngleConverted = p->elevationAngle_ * kAngleDataScale;
+   // Any elevation above 90 degrees should be interpreted as a
+   // negative angle
+   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+   if (elevationAngleConverted > 90)
+   {
+      elevationAngleConverted -= 360;
+   }
+   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+
+   return units::degrees<float> {elevationAngleConverted};
 }
 
 std::uint16_t DigitalRadarData::elevation_number() const

--- a/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
+++ b/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
@@ -221,8 +221,8 @@ uint16_t VolumeCoveragePatternData::number_of_base_tilts() const
 double VolumeCoveragePatternData::elevation_angle(uint16_t e) const
 {
 
-   // NOLINTNEXTLINE This conversion is accurate
    float elevationAngleConverted =
+      // NOLINTNEXTLINE This conversion is accurate
       p->elevationCuts_[e].elevationAngle_ * ANGLE_DATA_SCALE;
    // Any elevation above 90 degrees should be interpreted as a
    // negative angle

--- a/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
+++ b/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
@@ -220,7 +220,20 @@ uint16_t VolumeCoveragePatternData::number_of_base_tilts() const
 
 double VolumeCoveragePatternData::elevation_angle(uint16_t e) const
 {
-   return p->elevationCuts_[e].elevationAngle_ * ANGLE_DATA_SCALE;
+
+   // NOLINTNEXTLINE This conversion is accurate
+   float elevationAngleConverted =
+      p->elevationCuts_[e].elevationAngle_ * ANGLE_DATA_SCALE;
+   // Any elevation above 90 degrees should be interpreted as a
+   // negative angle
+   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+   if (elevationAngleConverted > 90)
+   {
+      elevationAngleConverted -= 360;
+   }
+   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+
+   return elevationAngleConverted;
 }
 
 uint16_t VolumeCoveragePatternData::elevation_angle_raw(uint16_t e) const

--- a/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
+++ b/wxdata/source/scwx/wsr88d/rda/volume_coverage_pattern_data.cpp
@@ -221,8 +221,7 @@ uint16_t VolumeCoveragePatternData::number_of_base_tilts() const
 double VolumeCoveragePatternData::elevation_angle(uint16_t e) const
 {
 
-   float elevationAngleConverted =
-      // NOLINTNEXTLINE This conversion is accurate
+   double elevationAngleConverted =
       p->elevationCuts_[e].elevationAngle_ * ANGLE_DATA_SCALE;
    // Any elevation above 90 degrees should be interpreted as a
    // negative angle

--- a/wxdata/wxdata.cmake
+++ b/wxdata/wxdata.cmake
@@ -60,6 +60,7 @@ set(HDR_NETWORK include/scwx/network/cpr.hpp
 set(SRC_NETWORK source/scwx/network/cpr.cpp
                 source/scwx/network/dir_list.cpp)
 set(HDR_PROVIDER include/scwx/provider/aws_level2_data_provider.hpp
+                 include/scwx/provider/aws_level2_chunks_data_provider.hpp
                  include/scwx/provider/aws_level3_data_provider.hpp
                  include/scwx/provider/aws_nexrad_data_provider.hpp
                  include/scwx/provider/iem_api_provider.hpp
@@ -68,6 +69,7 @@ set(HDR_PROVIDER include/scwx/provider/aws_level2_data_provider.hpp
                  include/scwx/provider/nexrad_data_provider_factory.hpp
                  include/scwx/provider/warnings_provider.hpp)
 set(SRC_PROVIDER source/scwx/provider/aws_level2_data_provider.cpp
+                 source/scwx/provider/aws_level2_chunks_data_provider.cpp
                  source/scwx/provider/aws_level3_data_provider.cpp
                  source/scwx/provider/aws_nexrad_data_provider.cpp
                  source/scwx/provider/iem_api_provider.cpp


### PR DESCRIPTION
# Level 2 Chunks
I ordered these most to least important.

## Terminology
scan = volume scan
sweep = elevation sweep

## Commented out logging
I have some logging commented out. I am not sure what you will want to keep, and not. I think 1 or 2 lines per chunk is not horrible, but more than that is too much. Most should be fully removed, or turned into trace's. Chunks come in around every 4-10 seconds most of the time.

## Radar Product Manager
1. Lowered the fast and slow refresh intervals for level 2 chunks
2. Added a separate level 2 chunks provider manager
3. Added ability to have multiple provider managers refreshing at once for one UUID, (Managed by product manager. Set up in a way to be usable for derived products)
4. Refresh level 2 chunks and level 2 archive at the same time so that it can fall back to the archive if the chunks end up too old and to allow for chunks to load the last scan from the archive if it has not already loaded it.
5. Attempt to load chunks data for a time first ("loading" does not involve network access). If it cannot be loaded for that time, load from the archive.

## Chunks file names (`ListObjects`)
Making this fast and reliable has been difficult. Each radar site has a folder. In each folder, there are scans, with a folder each. The scan folder is named its extension number. That is a number 1-999, consecutive scans have consecutive numbers, wrapping around. I list the numbers, then find gaps in them. I check the last number before each gap for its time, and take the latest of those. That speeds up loading of the data significantly. I check all gaps because there are some odd edge cases that cause issues, and this is the best way around them I have found. I only keep the 2 most recent scans loaded.

## Refresh
During the refresh I list objects, and load the data. This is to minimize the time it takes to "load" data when getting the data.

## Scan/Sweep merging
I merge the last and current scans to prevent the radar from disappearing. The code for this is in the ar2v file code, and this is done by the level 2 chunks data provider.
1. VCP data is not copied during the merge. I do not think it is being used, but fixing this may be a good idea for future use. I cannot remember why it was not working.
1. There can be some slight overlap (< 1 radial) when merging data. I feel this is fine, and is only really noticeable if you have a transparent palette.
1. This process also makes a new elevation scan object for each chunk. This is needed for the product manager and view to actually update when new chunks are received. Once a sweep is completed, its final version is kept, and caching can work properly

## Level 2 Settings Widget
1. Added incoming elevation display
3. Quite a few files modified to get the data from the file to the display
4. Updates level 2 settings widget more often

## Loading chunked data
The ar2v_file code already handled loading the chunked data fine already. The biggest issue was getting around caching in product manager and views, but that was solved by merging the sweep.