### PR TITLE
Add setting for cursor icon scale

### DIFF
--- a/scwx-qt/res/textures/images/dot.svg
+++ b/scwx-qt/res/textures/images/dot.svg
@@ -1,0 +1,9 @@
+<svg version="1.1"
+     viewBox="0 0 100 100"
+     width="3" height="3"
+     xmlns="http://www.w3.org/2000/svg">
+
+     <circle r="50" cx="50" cy="50" fill="black"></circle>
+     <circle r="25" cx="50" cy="50" fill="white"></circle>
+
+ </svg>

--- a/scwx-qt/scwx-qt.qrc
+++ b/scwx-qt/scwx-qt.qrc
@@ -91,6 +91,7 @@
         <file>res/textures/images/cursor-17.png</file>
         <file>res/textures/images/crosshairs-24.png</file>
         <file>res/textures/images/dot-3.png</file>
+        <file>res/textures/images/dot.svg</file>
         <file>res/textures/images/location-marker.svg</file>
         <file>res/textures/images/mapbox-logo.svg</file>
         <file>res/textures/images/maptiler-logo.svg</file>

--- a/scwx-qt/source/scwx/qt/manager/resource_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/resource_manager.cpp
@@ -43,10 +43,17 @@ void Initialize()
 void Shutdown() {}
 
 std::shared_ptr<boost::gil::rgba8_image_t>
-LoadImageResource(const std::string& urlString)
+LoadImageResource(const std::string& urlString, double scale)
 {
    util::TextureAtlas& textureAtlas = util::TextureAtlas::Instance();
-   return textureAtlas.CacheTexture(urlString, urlString);
+   return textureAtlas.CacheTexture(urlString, urlString, scale);
+}
+
+std::shared_ptr<boost::gil::rgba8_image_t> LoadImageResource(
+   const std::string& urlString, const std::string& textureName, double scale)
+{
+   util::TextureAtlas& textureAtlas = util::TextureAtlas::Instance();
+   return textureAtlas.CacheTexture(textureName, urlString, scale);
 }
 
 std::vector<std::shared_ptr<boost::gil::rgba8_image_t>>

--- a/scwx-qt/source/scwx/qt/manager/resource_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/resource_manager.hpp
@@ -19,9 +19,13 @@ void Initialize();
 void Shutdown();
 
 std::shared_ptr<boost::gil::rgba8_image_t>
-LoadImageResource(const std::string& urlString);
+LoadImageResource(const std::string& urlString, double scale = 1);
+std::shared_ptr<boost::gil::rgba8_image_t>
+LoadImageResource(const std::string& urlString,
+                  const std::string& textureName,
+                  double             scale = 1);
 std::vector<std::shared_ptr<boost::gil::rgba8_image_t>>
-LoadImageResources(const std::vector<std::string>& urlStrings);
+     LoadImageResources(const std::vector<std::string>& urlStrings);
 void BuildAtlas();
 
 } // namespace ResourceManager

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -166,12 +166,8 @@ OverlayLayer::~OverlayLayer() = default;
 
 void OverlayLayerImpl::SetCusorLocation(common::Coordinate coordinate)
 {
-   const double offset = 3 * cursorScale_ / 2;
-   geoIcons_->SetIconLocation(cursorIcon_,
-                              coordinate.latitude_,
-                              coordinate.longitude_,
-                              -offset,
-                              offset);
+   geoIcons_->SetIconLocation(
+      cursorIcon_, coordinate.latitude_, coordinate.longitude_);
 }
 
 void OverlayLayerImpl::SetupGeoIcons()
@@ -182,6 +178,7 @@ void OverlayLayerImpl::SetupGeoIcons()
       "{}x{}", types::GetTextureName(types::ImageTexture::Dot3), cursorScale_);
    cursorIconImage_ = manager::ResourceManager::LoadImageResource(
       texturePath, cursorIconName_, cursorScale_);
+   manager::ResourceManager::BuildAtlas();
 
    auto coordinate = currentPosition_.coordinate();
    geoIcons_->StartIconSheets();

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -166,7 +166,10 @@ OverlayLayer::OverlayLayer(std::shared_ptr<MapContext> context) :
    p->activeBoxOuter_->SetPosition(0.0f, 0.0f);
 }
 
-OverlayLayer::~OverlayLayer() = default;
+OverlayLayer::~OverlayLayer()
+{
+   p->cursorScaleConnection_.disconnect();
+}
 
 void OverlayLayerImpl::SetCusorLocation(common::Coordinate coordinate)
 {

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -193,7 +193,6 @@ void OverlayLayerImpl::SetupGeoIcons()
 
    locationIcon_ = geoIcons_->AddIcon();
    geoIcons_->SetIconTexture(locationIcon_, locationIconName_, 0);
-   geoIcons_->SetIconAngle(locationIcon_, units::angle::degrees<double> {45.0});
    geoIcons_->SetIconLocation(
       locationIcon_, coordinate.latitude(), coordinate.longitude());
 

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -1,10 +1,11 @@
-#include <scwx/qt/map/overlay_layer.hpp>
 #include <scwx/qt/gl/draw/geo_icons.hpp>
 #include <scwx/qt/gl/draw/icons.hpp>
 #include <scwx/qt/gl/draw/rectangle.hpp>
 #include <scwx/qt/manager/font_manager.hpp>
 #include <scwx/qt/manager/position_manager.hpp>
+#include <scwx/qt/manager/resource_manager.hpp>
 #include <scwx/qt/map/map_settings.hpp>
+#include <scwx/qt/map/overlay_layer.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/types/texture_types.hpp>
 #include <scwx/qt/view/radar_product_view.hpp>
@@ -88,6 +89,9 @@ public:
          showMapLogoCallbackUuid_);
    }
 
+   void SetupGeoIcons();
+   void SetCusorLocation(common::Coordinate coordinate);
+
    OverlayLayer* self_;
 
    boost::uuids::uuid clockFormatCallbackUuid_;
@@ -115,10 +119,12 @@ public:
       types::GetTextureName(types::ImageTexture::CardinalPoint24)};
    const std::string& compassIconName_ {
       types::GetTextureName(types::ImageTexture::Compass24)};
-   const std::string& cursorIconName_ {
+   std::string cursorIconName_ {
       types::GetTextureName(types::ImageTexture::Dot3)};
    const std::string& mapCenterIconName_ {
       types::GetTextureName(types::ImageTexture::Cursor17)};
+
+   std::shared_ptr<boost::gil::rgba8_image_t> cursorIconImage_ {nullptr};
 
    const std::string& mapboxLogoImageName_ {
       types::GetTextureName(types::ImageTexture::MapboxLogo)};
@@ -136,6 +142,8 @@ public:
    double   lastHeight_ {0.0};
    float    lastFontSize_ {0.0f};
    QMargins lastColorTableMargins_ {};
+
+   double cursorScale_ {1};
 
    std::string sweepTimeString_ {};
    bool        sweepTimeNeedsUpdate_ {true};
@@ -156,6 +164,45 @@ OverlayLayer::OverlayLayer(std::shared_ptr<MapContext> context) :
 
 OverlayLayer::~OverlayLayer() = default;
 
+void OverlayLayerImpl::SetCusorLocation(common::Coordinate coordinate)
+{
+   const double offset = 3 * cursorScale_ / 2;
+   geoIcons_->SetIconLocation(cursorIcon_,
+                              coordinate.latitude_,
+                              coordinate.longitude_,
+                              -offset,
+                              offset);
+}
+
+void OverlayLayerImpl::SetupGeoIcons()
+{
+   const std::string& texturePath =
+      types::GetTexturePath(types::ImageTexture::Dot3);
+   cursorIconName_ = fmt::format(
+      "{}x{}", types::GetTextureName(types::ImageTexture::Dot3), cursorScale_);
+   cursorIconImage_ = manager::ResourceManager::LoadImageResource(
+      texturePath, cursorIconName_, cursorScale_);
+
+   auto coordinate = currentPosition_.coordinate();
+   geoIcons_->StartIconSheets();
+   geoIcons_->AddIconSheet(cursorIconName_);
+   geoIcons_->AddIconSheet(locationIconName_);
+   geoIcons_->FinishIconSheets();
+
+   geoIcons_->StartIcons();
+
+   cursorIcon_ = geoIcons_->AddIcon();
+   geoIcons_->SetIconTexture(cursorIcon_, cursorIconName_, 0);
+
+   locationIcon_ = geoIcons_->AddIcon();
+   geoIcons_->SetIconTexture(locationIcon_, locationIconName_, 0);
+   geoIcons_->SetIconAngle(locationIcon_, units::angle::degrees<double> {45.0});
+   geoIcons_->SetIconLocation(
+      locationIcon_, coordinate.latitude(), coordinate.longitude());
+
+   geoIcons_->FinishIcons();
+}
+
 void OverlayLayer::Initialize()
 {
    logger_->debug("Initialize()");
@@ -173,27 +220,18 @@ void OverlayLayer::Initialize()
    }
 
    p->currentPosition_ = p->positionManager_->position();
-   auto coordinate     = p->currentPosition_.coordinate();
 
    // Geo Icons
-   p->geoIcons_->StartIconSheets();
-   p->geoIcons_->AddIconSheet(p->cursorIconName_);
-   p->geoIcons_->AddIconSheet(p->locationIconName_);
-   p->geoIcons_->FinishIconSheets();
-
-   p->geoIcons_->StartIcons();
-
-   p->cursorIcon_ = p->geoIcons_->AddIcon();
-   p->geoIcons_->SetIconTexture(p->cursorIcon_, p->cursorIconName_, 0);
-
-   p->locationIcon_ = p->geoIcons_->AddIcon();
-   p->geoIcons_->SetIconTexture(p->locationIcon_, p->locationIconName_, 0);
-   p->geoIcons_->SetIconAngle(p->locationIcon_,
-                              units::angle::degrees<double> {45.0});
-   p->geoIcons_->SetIconLocation(
-      p->locationIcon_, coordinate.latitude(), coordinate.longitude());
-
-   p->geoIcons_->FinishIcons();
+   auto& generalSettings = settings::GeneralSettings::Instance();
+   p->cursorScale_       = generalSettings.cursor_icon_scale().GetValue();
+   p->SetupGeoIcons();
+   generalSettings.cursor_icon_scale().RegisterValueChangedCallback(
+      [this](double value)
+      {
+         p->cursorScale_ = value;
+         p->SetupGeoIcons();
+         Q_EMIT NeedsRendering();
+      });
 
    // Icons
    p->icons_->StartIconSheets();
@@ -339,9 +377,7 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
    p->geoIcons_->SetIconVisible(p->cursorIcon_, cursorIconVisible);
    if (cursorIconVisible)
    {
-      common::Coordinate mouseCoordinate = context()->mouse_coordinate();
-      p->geoIcons_->SetIconLocation(
-         p->cursorIcon_, mouseCoordinate.latitude_, mouseCoordinate.longitude_);
+      p->SetCusorLocation(context()->mouse_coordinate());
    }
 
    // Location Icon

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -78,7 +78,10 @@ public:
       cursorIconAlwaysOn_.SetDefault(false);
       radarSiteThreshold_.SetDefault(0.0);
       highPrivilegeWarningEnabled_.SetDefault(true);
+      cursorIconScale_.SetDefault(1.0);
 
+      cursorIconScale_.SetMinimum(1.0);
+      cursorIconScale_.SetMaximum(5.0);
       fontSizes_.SetElementMinimum(1);
       fontSizes_.SetElementMaximum(72);
       fontSizes_.SetValidator([](const std::vector<std::int64_t>& value)
@@ -185,6 +188,7 @@ public:
    SettingsVariable<double>      radarSiteThreshold_ {"radar_site_threshold"};
    SettingsVariable<bool>        highPrivilegeWarningEnabled_ {
       "high_privilege_warning_enabled"};
+   SettingsVariable<double> cursorIconScale_ {"cursor_icon_scale"};
 };
 
 GeneralSettings::GeneralSettings() :
@@ -222,7 +226,8 @@ GeneralSettings::GeneralSettings() :
                       &p->warningsProvider_,
                       &p->cursorIconAlwaysOn_,
                       &p->radarSiteThreshold_,
-                      &p->highPrivilegeWarningEnabled_});
+                      &p->highPrivilegeWarningEnabled_,
+                      &p->cursorIconScale_});
    SetDefaults();
 }
 GeneralSettings::~GeneralSettings() = default;
@@ -397,6 +402,11 @@ SettingsVariable<bool>& GeneralSettings::high_privilege_warning_enabled() const
    return p->highPrivilegeWarningEnabled_;
 }
 
+SettingsVariable<double>& GeneralSettings::cursor_icon_scale() const
+{
+   return p->cursorIconScale_;
+}
+
 bool GeneralSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -455,7 +465,8 @@ bool operator==(const GeneralSettings& lhs, const GeneralSettings& rhs)
            lhs.p->cursorIconAlwaysOn_ == rhs.p->cursorIconAlwaysOn_ &&
            lhs.p->radarSiteThreshold_ == rhs.p->radarSiteThreshold_ &&
            lhs.p->highPrivilegeWarningEnabled_ ==
-              rhs.p->highPrivilegeWarningEnabled_);
+              rhs.p->highPrivilegeWarningEnabled_ &&
+           lhs.p->cursorIconScale_ == rhs.p->cursorIconScale_);
 }
 
 } // namespace scwx::qt::settings

--- a/scwx-qt/source/scwx/qt/settings/general_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.hpp
@@ -56,6 +56,7 @@ public:
    [[nodiscard]] SettingsVariable<bool>&        cursor_icon_always_on() const;
    [[nodiscard]] SettingsVariable<double>&      radar_site_threshold() const;
    [[nodiscard]] SettingsVariable<bool>& high_privilege_warning_enabled() const;
+   [[nodiscard]] SettingsVariable<double>& cursor_icon_scale() const;
 
    static GeneralSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/types/texture_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/texture_types.cpp
@@ -24,7 +24,7 @@ static const std::unordered_map<ImageTexture, TextureInfo> imageTextureInfo_ {
     {"images/crosshairs-24", ":/res/textures/images/crosshairs-24.png"}},
    {ImageTexture::Cursor17,
     {"images/cursor-17", ":/res/textures/images/cursor-17.png"}},
-   {ImageTexture::Dot3, {"images/dot-3", ":/res/textures/images/dot-3.png"}},
+   {ImageTexture::Dot3, {"images/dot-3", ":/res/textures/images/dot.svg"}},
    {ImageTexture::LocationBriefcase,
     {"images/location-briefcase",
      ":/res/icons/font-awesome-6/briefcase-solid.svg"}},

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -146,6 +146,7 @@ public:
           &showSmoothedRangeFolding_,
           &updateNotificationsEnabled_,
           &cursorIconAlwaysOn_,
+          &cursorIconScale_,
           &debugEnabled_,
           &alertAudioSoundFile_,
           &alertAudioLocationMethod_,
@@ -266,6 +267,7 @@ public:
    settings::SettingsInterface<bool>         showSmoothedRangeFolding_ {};
    settings::SettingsInterface<bool>         updateNotificationsEnabled_ {};
    settings::SettingsInterface<bool>         cursorIconAlwaysOn_ {};
+   settings::SettingsInterface<double>       cursorIconScale_ {};
    settings::SettingsInterface<bool>         debugEnabled_ {};
 
    std::unordered_map<std::string, settings::SettingsInterface<std::string>>
@@ -810,6 +812,10 @@ void SettingsDialogImpl::SetupGeneralTab()
       .RegisterValueStagedCallback(radarSiteThresholdUpdateUnits);
    radarSiteThresholdUpdateUnits(
       settings::UnitSettings::Instance().distance_units().GetValue());
+
+   cursorIconScale_.SetSettingsVariable(generalSettings.cursor_icon_scale());
+   cursorIconScale_.SetEditWidget(self_->ui->cursorIconScaleSpinBox);
+   cursorIconScale_.SetResetButton(self_->ui->resetCursorIconScaleButton);
 
    antiAliasingEnabled_.SetSettingsVariable(
       generalSettings.anti_aliasing_enabled());

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.ui
@@ -137,7 +137,7 @@
                 <x>0</x>
                 <y>-412</y>
                 <width>511</width>
-                <height>841</height>
+                <height>873</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout">
@@ -159,31 +159,33 @@
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="label_2">
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="clockFormatComboBox"/>
+                  </item>
+                  <item row="8" column="2">
+                   <widget class="QComboBox" name="positioningPluginComboBox"/>
+                  </item>
+                  <item row="6" column="2">
+                   <widget class="QSpinBox" name="gridHeightSpinBox"/>
+                  </item>
+                  <item row="23" column="0">
+                   <widget class="QLabel" name="label_31">
                     <property name="text">
-                     <string>Grid Width</string>
+                     <string>Radar Site Threshold</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="18" column="2">
-                   <widget class="QComboBox" name="themeComboBox"/>
-                  </item>
-                  <item row="13" column="4">
-                   <widget class="QToolButton" name="resetMapTilerApiKeyButton">
+                  <item row="14" column="0">
+                   <widget class="QLabel" name="label_26">
                     <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                     <string>Custom Map URL</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="3">
-                   <widget class="QToolButton" name="gpsSourceSelectButton">
+                  <item row="22" column="0">
+                   <widget class="QLabel" name="label_22">
                     <property name="text">
-                     <string>...</string>
+                     <string>Warnings Provider</string>
                     </property>
                    </widget>
                   </item>
@@ -198,18 +200,25 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="2">
-                   <widget class="QComboBox" name="clockFormatComboBox"/>
-                  </item>
-                  <item row="12" column="0">
-                   <widget class="QLabel" name="label_4">
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="label_25">
                     <property name="text">
-                     <string>Mapbox API Key</string>
+                     <string>GPS Source</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="22" column="4">
-                   <widget class="QToolButton" name="resetWarningsProviderButton">
+                  <item row="14" column="2">
+                   <widget class="QLineEdit" name="customMapUrlLineEdit"/>
+                  </item>
+                  <item row="13" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string>MapTiler API Key</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="4">
+                   <widget class="QToolButton" name="resetRadarSiteButton">
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -219,8 +228,54 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="19" column="4">
-                   <widget class="QToolButton" name="resetThemeFileButton">
+                  <item row="5" column="4">
+                   <widget class="QToolButton" name="resetGridWidthButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="4">
+                   <widget class="QToolButton" name="resetThemeButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label">
+                    <property name="text">
+                     <string>Default Radar Site</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="15" column="0">
+                   <widget class="QLabel" name="label_27">
+                    <property name="text">
+                     <string>Custom Map Layer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QComboBox" name="defaultAlertActionComboBox"/>
+                  </item>
+                  <item row="12" column="0">
+                   <widget class="QLabel" name="label_4">
+                    <property name="text">
+                     <string>Mapbox API Key</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="14" column="4">
+                   <widget class="QToolButton" name="resetCustomMapUrlButton">
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -237,165 +292,11 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="4">
-                   <widget class="QToolButton" name="resetNmeaSourceButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_21">
-                    <property name="text">
-                     <string>Default Time Zone</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="2">
-                   <widget class="scwx::qt::ui::QApiKeyEdit" name="mapTilerApiKeyLineEdit">
-                    <property name="echoMode">
-                     <enum>QLineEdit::EchoMode::Password</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="2">
-                   <widget class="scwx::qt::ui::QApiKeyEdit" name="mapboxApiKeyLineEdit">
-                    <property name="echoMode">
-                     <enum>QLineEdit::EchoMode::Password</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="2">
-                   <widget class="QComboBox" name="positioningPluginComboBox"/>
-                  </item>
-                  <item row="18" column="4">
-                   <widget class="QToolButton" name="resetThemeButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="19" column="0">
-                   <widget class="QLabel" name="label_30">
-                    <property name="text">
-                     <string>Theme File</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item row="5" column="2">
                    <widget class="QSpinBox" name="gridWidthSpinBox"/>
                   </item>
-                  <item row="6" column="4">
-                   <widget class="QToolButton" name="resetGridHeightButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="4">
-                   <widget class="QToolButton" name="resetRadarSiteButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
                   <item row="4" column="2">
                    <widget class="QComboBox" name="defaultTimeZoneComboBox"/>
-                  </item>
-                  <item row="5" column="4">
-                   <widget class="QToolButton" name="resetGridWidthButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="2">
-                   <widget class="QLineEdit" name="customMapUrlLineEdit"/>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="defaultAlertActionLabel">
-                    <property name="text">
-                     <string>Default Alert Action</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="0">
-                   <widget class="QLabel" name="label_6">
-                    <property name="text">
-                     <string>MapTiler API Key</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="4">
-                   <widget class="QToolButton" name="resetMapProviderButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="19" column="3">
-                   <widget class="QToolButton" name="themeFileSelectButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_25">
-                    <property name="text">
-                     <string>GPS Source</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="2">
-                   <widget class="QLineEdit" name="customMapLayerLineEdit"/>
-                  </item>
-                  <item row="14" column="0">
-                   <widget class="QLabel" name="label_26">
-                    <property name="text">
-                     <string>Custom Map URL</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="2">
-                   <widget class="QSpinBox" name="nmeaBaudRateSpinBox">
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                    <property name="maximum">
-                     <number>999999999</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="2">
-                   <widget class="QComboBox" name="mapProviderComboBox"/>
-                  </item>
-                  <item row="19" column="2">
-                   <widget class="QLineEdit" name="themeFileLineEdit"/>
                   </item>
                   <item row="2" column="4">
                    <widget class="QToolButton" name="resetDefaultAlertActionButton">
@@ -419,20 +320,38 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="2">
-                   <widget class="QLineEdit" name="nmeaSourceLineEdit"/>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="label_7">
-                    <property name="text">
-                     <string>Map Provider</string>
+                  <item row="10" column="2">
+                   <widget class="QSpinBox" name="nmeaBaudRateSpinBox">
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>999999999</number>
                     </property>
                    </widget>
                   </item>
-                  <item row="18" column="0">
-                   <widget class="QLabel" name="label_5">
+                  <item row="12" column="4">
+                   <widget class="QToolButton" name="resetMapboxApiKeyButton">
                     <property name="text">
-                     <string>Theme</string>
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="0">
+                   <widget class="QLabel" name="label_30">
+                    <property name="text">
+                     <string>Theme File</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>Grid Width</string>
                     </property>
                    </widget>
                   </item>
@@ -447,80 +366,14 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="22" column="0">
-                   <widget class="QLabel" name="label_22">
-                    <property name="text">
-                     <string>Warnings Provider</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label">
-                    <property name="text">
-                     <string>Default Radar Site</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="4">
-                   <widget class="QToolButton" name="resetCustomMapUrlButton">
+                  <item row="9" column="4">
+                   <widget class="QToolButton" name="resetNmeaSourceButton">
                     <property name="text">
                      <string>...</string>
                     </property>
                     <property name="icon">
                      <iconset resource="../../../../scwx-qt.qrc">
                       <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QLabel" name="label_24">
-                    <property name="text">
-                     <string>GPS Baud Rate</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="15" column="0">
-                   <widget class="QLabel" name="label_27">
-                    <property name="text">
-                     <string>Custom Map Layer</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="2">
-                   <widget class="QSpinBox" name="gridHeightSpinBox"/>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QComboBox" name="defaultAlertActionComboBox"/>
-                  </item>
-                  <item row="12" column="4">
-                   <widget class="QToolButton" name="resetMapboxApiKeyButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="22" column="2">
-                   <widget class="QLineEdit" name="warningsProviderLineEdit"/>
-                  </item>
-                  <item row="8" column="4">
-                   <widget class="QToolButton" name="resetPositioningPluginButton">
-                    <property name="text">
-                     <string>...</string>
-                    </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="3">
-                   <widget class="QToolButton" name="radarSiteSelectButton">
-                    <property name="text">
-                     <string>...</string>
                     </property>
                    </widget>
                   </item>
@@ -531,8 +384,11 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="4">
-                   <widget class="QToolButton" name="resetClockFormatButton">
+                  <item row="15" column="2">
+                   <widget class="QLineEdit" name="customMapLayerLineEdit"/>
+                  </item>
+                  <item row="22" column="4">
+                   <widget class="QToolButton" name="resetWarningsProviderButton">
                     <property name="text">
                      <string>...</string>
                     </property>
@@ -542,31 +398,70 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="label_23">
+                  <item row="15" column="3">
+                   <widget class="QToolButton" name="customMapLayerToolButton">
                     <property name="text">
-                     <string>GPS Plugin</string>
+                     <string>...</string>
                     </property>
                    </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_21">
+                    <property name="text">
+                     <string>Default Time Zone</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="2">
+                   <widget class="QComboBox" name="mapProviderComboBox"/>
+                  </item>
+                  <item row="9" column="2">
+                   <widget class="QLineEdit" name="nmeaSourceLineEdit"/>
                   </item>
                   <item row="3" column="2">
                    <widget class="QComboBox" name="radarSiteComboBox"/>
                   </item>
-                  <item row="23" column="0">
-                   <widget class="QLabel" name="label_31">
-                    <property name="text">
-                     <string>Radar Site Threshold</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="23" column="4">
-                   <widget class="QToolButton" name="resetRadarSiteThresholdButton">
+                  <item row="19" column="3">
+                   <widget class="QToolButton" name="themeFileSelectButton">
                     <property name="text">
                      <string>...</string>
                     </property>
-                    <property name="icon">
-                     <iconset resource="../../../../scwx-qt.qrc">
-                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                   </widget>
+                  </item>
+                  <item row="11" column="0">
+                   <widget class="QLabel" name="label_7">
+                    <property name="text">
+                     <string>Map Provider</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="12" column="2">
+                   <widget class="scwx::qt::ui::QApiKeyEdit" name="mapboxApiKeyLineEdit">
+                    <property name="echoMode">
+                     <enum>QLineEdit::EchoMode::Password</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="18" column="2">
+                   <widget class="QComboBox" name="themeComboBox"/>
+                  </item>
+                  <item row="18" column="0">
+                   <widget class="QLabel" name="label_5">
+                    <property name="text">
+                     <string>Theme</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="22" column="2">
+                   <widget class="QLineEdit" name="warningsProviderLineEdit"/>
+                  </item>
+                  <item row="23" column="3">
+                   <widget class="QLabel" name="radarSiteThresholdUnitLabel">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="text">
+                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -598,20 +493,162 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="23" column="3">
-                   <widget class="QLabel" name="radarSiteThresholdUnitLabel">
-                    <property name="toolTip">
-                     <string/>
-                    </property>
+                  <item row="23" column="4">
+                   <widget class="QToolButton" name="resetRadarSiteThresholdButton">
                     <property name="text">
-                     <string/>
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
                     </property>
                    </widget>
                   </item>
-                  <item row="15" column="3">
-                   <widget class="QToolButton" name="customMapLayerToolButton">
+                  <item row="13" column="4">
+                   <widget class="QToolButton" name="resetMapTilerApiKeyButton">
                     <property name="text">
                      <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="2">
+                   <widget class="scwx::qt::ui::QApiKeyEdit" name="mapTilerApiKeyLineEdit">
+                    <property name="echoMode">
+                     <enum>QLineEdit::EchoMode::Password</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="4">
+                   <widget class="QToolButton" name="resetPositioningPluginButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="10" column="0">
+                   <widget class="QLabel" name="label_24">
+                    <property name="text">
+                     <string>GPS Baud Rate</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="4">
+                   <widget class="QToolButton" name="resetThemeFileButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="defaultAlertActionLabel">
+                    <property name="text">
+                     <string>Default Alert Action</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="19" column="2">
+                   <widget class="QLineEdit" name="themeFileLineEdit"/>
+                  </item>
+                  <item row="3" column="3">
+                   <widget class="QToolButton" name="radarSiteSelectButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="4">
+                   <widget class="QToolButton" name="resetGridHeightButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="4">
+                   <widget class="QToolButton" name="resetClockFormatButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0">
+                   <widget class="QLabel" name="label_23">
+                    <property name="text">
+                     <string>GPS Plugin</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="9" column="3">
+                   <widget class="QToolButton" name="gpsSourceSelectButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="11" column="4">
+                   <widget class="QToolButton" name="resetMapProviderButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="24" column="0">
+                   <widget class="QLabel" name="label_32">
+                    <property name="text">
+                     <string>Multi-Pane Cursor Size</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="24" column="2">
+                   <widget class="QDoubleSpinBox" name="cursorIconScaleSpinBox">
+                    <property name="decimals">
+                     <number>1</number>
+                    </property>
+                    <property name="minimum">
+                     <double>1.000000000000000</double>
+                    </property>
+                    <property name="maximum">
+                     <double>5.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>0.100000000000000</double>
+                    </property>
+                    <property name="stepType">
+                     <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="24" column="4">
+                   <widget class="QToolButton" name="resetCursorIconScaleButton">
+                    <property name="text">
+                     <string>...</string>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="../../../../scwx-qt.qrc">
+                      <normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</normaloff>:/res/icons/font-awesome-6/rotate-left-solid.svg</iconset>
                     </property>
                    </widget>
                   </item>

--- a/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
+++ b/scwx-qt/source/scwx/qt/util/texture_atlas.cpp
@@ -50,12 +50,12 @@ public:
    ~Impl() {}
 
    static std::shared_ptr<boost::gil::rgba8_image_t>
-   LoadImage(const std::string& imagePath);
+   LoadImage(const std::string& imagePath, double scale = 1);
 
    static std::shared_ptr<boost::gil::rgba8_image_t>
    ReadPngFile(const QString& imagePath);
    static std::shared_ptr<boost::gil::rgba8_image_t>
-   ReadSvgFile(const QString& imagePath);
+   ReadSvgFile(const QString& imagePath, double scale = 1);
 
    std::vector<std::shared_ptr<boost::gil::rgba8_image_t>>
                      registeredTextures_ {};
@@ -92,12 +92,12 @@ void TextureAtlas::RegisterTexture(const std::string& name,
    p->registeredTextures_.emplace_back(std::move(image));
 }
 
-std::shared_ptr<boost::gil::rgba8_image_t>
-TextureAtlas::CacheTexture(const std::string& name, const std::string& path)
+std::shared_ptr<boost::gil::rgba8_image_t> TextureAtlas::CacheTexture(
+   const std::string& name, const std::string& path, double scale)
 {
    // Attempt to load the image
    std::shared_ptr<boost::gil::rgba8_image_t> image =
-      TextureAtlas::Impl::LoadImage(path);
+      TextureAtlas::Impl::LoadImage(path, scale);
 
    // If the image is valid
    if (image != nullptr && image->width() > 0 && image->height() > 0)
@@ -380,7 +380,7 @@ TextureAttributes TextureAtlas::GetTextureAttributes(const std::string& name)
 }
 
 std::shared_ptr<boost::gil::rgba8_image_t>
-TextureAtlas::Impl::LoadImage(const std::string& imagePath)
+TextureAtlas::Impl::LoadImage(const std::string& imagePath, double scale)
 {
    logger_->debug("Loading image: {}", imagePath);
 
@@ -398,7 +398,7 @@ TextureAtlas::Impl::LoadImage(const std::string& imagePath)
 
       if (suffix == "svg")
       {
-         image = ReadSvgFile(qLocalImagePath);
+         image = ReadSvgFile(qLocalImagePath, scale);
       }
       else
       {
@@ -509,10 +509,10 @@ TextureAtlas::Impl::ReadPngFile(const QString& imagePath)
 }
 
 std::shared_ptr<boost::gil::rgba8_image_t>
-TextureAtlas::Impl::ReadSvgFile(const QString& imagePath)
+TextureAtlas::Impl::ReadSvgFile(const QString& imagePath, double scale)
 {
    QSvgRenderer renderer {imagePath};
-   QPixmap      pixmap {renderer.defaultSize()};
+   QPixmap      pixmap {renderer.defaultSize() * scale};
    pixmap.fill(Qt::GlobalColor::transparent);
 
    QPainter painter {&pixmap};

--- a/scwx-qt/source/scwx/qt/util/texture_atlas.hpp
+++ b/scwx-qt/source/scwx/qt/util/texture_atlas.hpp
@@ -74,8 +74,8 @@ public:
    std::uint64_t BuildCount() const;
 
    void RegisterTexture(const std::string& name, const std::string& path);
-   std::shared_ptr<boost::gil::rgba8_image_t>
-        CacheTexture(const std::string& name, const std::string& path);
+   std::shared_ptr<boost::gil::rgba8_image_t> CacheTexture(
+      const std::string& name, const std::string& path, double scale = 1);
    void BuildAtlas(std::size_t width, std::size_t height);
    void BufferAtlas(gl::OpenGLFunctions& gl, GLuint texture);
 


### PR DESCRIPTION
Add a setting to allow for scaling the cursor icon up. This is needed for usage on monitors with high resolutions, because the icon becomes very hard to find.