### PR TITLE
Add theme editor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,4 +39,4 @@
 	url = https://github.com/dpaulat/maplibre-gl-native.git
 [submodule "external/qt6ct"]
 	path = external/qt6ct
-	url = https://github.com/trialuser02/qt6ct.git
+	url = https://github.com/AdenKoperczak/qt6ct.git

--- a/external/qt6ct.cmake
+++ b/external/qt6ct.cmake
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.16.0)
 set(PROJECT_NAME scwx-qt6ct)
 
 find_package(QT NAMES Qt6
-             COMPONENTS Gui
+             COMPONENTS Gui Widgets
              REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR}
-             COMPONENTS Gui
+             COMPONENTS Gui Widgets
              REQUIRED)
 
 #extract version from qt6ct.h
@@ -24,20 +24,39 @@ else()
   message(FATAL_ERROR "invalid header")
 endif()
 
-set(app_SRCS
+set(qt6ct-common-source
   qt6ct/src/qt6ct-common/qt6ct.cpp
 )
 
-add_library(qt6ct-common STATIC ${app_SRCS})
+set(qt6ct-widgets-source
+  qt6ct/src/qt6ct/paletteeditdialog.cpp
+  qt6ct/src/qt6ct/paletteeditdialog.ui
+)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+include_directories(qt6ct/src/qt6ct-common)
+
+add_library(qt6ct-common STATIC ${qt6ct-common-source})
 set_target_properties(qt6ct-common PROPERTIES VERSION ${QT6CT_VERSION})
 target_link_libraries(qt6ct-common PRIVATE Qt6::Gui)
 target_compile_definitions(qt6ct-common PRIVATE QT6CT_LIBRARY)
 
+add_library(qt6ct-widgets STATIC ${qt6ct-widgets-source})
+set_target_properties(qt6ct-widgets PROPERTIES VERSION ${QT6CT_VERSION})
+target_link_libraries(qt6ct-widgets PRIVATE Qt6::Widgets Qt6::WidgetsPrivate qt6ct-common)
+target_compile_definitions(qt6ct-widgets PRIVATE QT6CT_LIBRARY)
+
 if (MSVC)
     # Produce PDB file for debug
     target_compile_options(qt6ct-common PRIVATE "$<$<CONFIG:Release>:/Zi>")
+    target_compile_options(qt6ct-widgets PRIVATE "$<$<CONFIG:Release>:/Zi>")
 else()
     target_compile_options(qt6ct-common PRIVATE "$<$<CONFIG:Release>:-g>")
+    target_compile_options(qt6ct-widgets PRIVATE "$<$<CONFIG:Release>:-g>")
 endif()
 
 target_include_directories( qt6ct-common INTERFACE qt6ct/src )
+target_include_directories( qt6ct-widgets INTERFACE qt6ct/src )

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -703,6 +703,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      glm::glm
                                      imgui
                                      qt6ct-common
+                                     qt6ct-widgets
                                      SQLite::SQLite3
                                      wxdata)
 

--- a/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings_dialog.cpp
@@ -45,6 +45,7 @@
 #include <QGeoPositionInfo>
 #include <QPushButton>
 #include <QStandardItemModel>
+#include <QStandardPaths>
 #include <QToolButton>
 #include <utility>
 
@@ -585,8 +586,18 @@ void SettingsDialogImpl::SetupGeneralTab()
       {
          const settings::GeneralSettings& generalSettings =
             settings::GeneralSettings::Instance();
-         const QString file =
-            generalSettings.theme_file().GetStagedOrValue().c_str();
+         QString file = generalSettings.theme_file().GetStagedOrValue().c_str();
+
+         if (file.isEmpty())
+         {
+            const QString appDataPath {QStandardPaths::writableLocation(
+               QStandardPaths::AppLocalDataLocation)};
+            file = appDataPath + "/theme.conf";
+            self_->ui->themeFileLineEdit->setText(file);
+            // setText does not emit the textEdited signal
+            Q_EMIT self_->ui->themeFileLineEdit->textEdited(file);
+         }
+
          const QPalette palette =
             Qt6CT::loadColorScheme(file, QApplication::palette());
          QStyle* style = QApplication::style();


### PR DESCRIPTION
Adds the editor for the color palettes from Qt6CT.

Currently, this opens the editor when the `...` button next to the Theme File setting is clicked. If the Theme File setting is empty, it fills it with a path in AppData. I am not sure this is the best way to handle it, but default settings must be constant for the tests. I do think it is most likely for people to only use the custom theme file for Supercell Wx (me being an exception).

I also switched to my own fork of Qt6CT. I have only fixed some deprecation warnings, and moved the export palette function to a different location, so it could be used within Supercell Wx.