### PR TITLE
Add a maximum number of forward/backward time steps that can be queued

### DIFF
--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -686,13 +686,17 @@ else()
     target_compile_options(supercell-wx PRIVATE "$<$<CONFIG:Release>:-g>")
 endif()
 
+# link atomic only for Linux
+if (!MSVC)
+    target_link_libraries(scwx-qt PUBLIC atomic)
+endif()
+
 target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::OpenGLWidgets
                                      Qt${QT_VERSION_MAJOR}::Multimedia
                                      Qt${QT_VERSION_MAJOR}::Positioning
                                      Qt${QT_VERSION_MAJOR}::SerialPort
                                      Qt${QT_VERSION_MAJOR}::Svg
-                                     atomic
                                      Boost::json
                                      Boost::timer
                                      QMapLibre::Core

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -372,6 +372,7 @@ set(HDR_UTIL source/scwx/qt/util/color.hpp
              source/scwx/qt/util/q_color_modulate.hpp
              source/scwx/qt/util/q_file_buffer.hpp
              source/scwx/qt/util/q_file_input_stream.hpp
+             source/scwx/qt/util/queue_counter.hpp
              source/scwx/qt/util/time.hpp
              source/scwx/qt/util/tooltip.hpp)
 set(SRC_UTIL source/scwx/qt/util/color.cpp
@@ -385,6 +386,7 @@ set(SRC_UTIL source/scwx/qt/util/color.cpp
              source/scwx/qt/util/q_color_modulate.cpp
              source/scwx/qt/util/q_file_buffer.cpp
              source/scwx/qt/util/q_file_input_stream.cpp
+             source/scwx/qt/util/queue_counter.cpp
              source/scwx/qt/util/time.cpp
              source/scwx/qt/util/tooltip.cpp)
 set(HDR_VIEW source/scwx/qt/view/level2_product_view.hpp

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -692,6 +692,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::Positioning
                                      Qt${QT_VERSION_MAJOR}::SerialPort
                                      Qt${QT_VERSION_MAJOR}::Svg
+                                     atomic
                                      Boost::json
                                      Boost::timer
                                      QMapLibre::Core

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -686,11 +686,6 @@ else()
     target_compile_options(supercell-wx PRIVATE "$<$<CONFIG:Release>:-g>")
 endif()
 
-# link atomic only for Linux
-if (!MSVC)
-    target_link_libraries(scwx-qt PUBLIC atomic)
-endif()
-
 target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::OpenGLWidgets
                                      Qt${QT_VERSION_MAJOR}::Multimedia
@@ -699,6 +694,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::Svg
                                      Boost::json
                                      Boost::timer
+                                     Boost::atomic
                                      QMapLibre::Core
                                      $<$<CXX_COMPILER_ID:MSVC>:opengl32>
                                      $<$<CXX_COMPILER_ID:MSVC>:SetupAPI>

--- a/scwx-qt/source/scwx/qt/util/queue_counter.cpp
+++ b/scwx-qt/source/scwx/qt/util/queue_counter.cpp
@@ -1,0 +1,49 @@
+#include <scwx/qt/util/queue_counter.hpp>
+
+#include <atomic>
+
+namespace scwx::qt::util
+{
+
+class QueueCounter::Impl
+{
+public:
+   explicit Impl(size_t maxCount) : maxCount_ {maxCount} {}
+
+   const size_t        maxCount_;
+   std::atomic<size_t> count_ {0};
+};
+
+QueueCounter::QueueCounter(size_t maxCount) :
+    p {std::make_unique<Impl>(maxCount)}
+{
+}
+
+QueueCounter::~QueueCounter() = default;
+
+bool QueueCounter::add()
+{
+   const size_t count = p->count_.fetch_add(1);
+   // Must be >= (not ==) to avoid race conditions
+   if (count >= p->maxCount_)
+   {
+      p->count_.fetch_sub(1);
+      return false;
+   }
+   else
+   {
+      return true;
+   }
+}
+
+void QueueCounter::remove()
+{
+   p->count_.fetch_sub(1);
+}
+
+bool QueueCounter::is_lock_free()
+{
+   return p->count_.is_lock_free();
+}
+
+} // namespace scwx::qt::util

--- a/scwx-qt/source/scwx/qt/util/queue_counter.cpp
+++ b/scwx-qt/source/scwx/qt/util/queue_counter.cpp
@@ -1,6 +1,6 @@
 #include <scwx/qt/util/queue_counter.hpp>
 
-#include <atomic>
+#include <boost/atomic/atomic.hpp>
 
 namespace scwx::qt::util
 {
@@ -10,8 +10,8 @@ class QueueCounter::Impl
 public:
    explicit Impl(size_t maxCount) : maxCount_ {maxCount} {}
 
-   const size_t        maxCount_;
-   std::atomic<size_t> count_ {0};
+   const size_t          maxCount_;
+   boost::atomic<size_t> count_ {0};
 };
 
 QueueCounter::QueueCounter(size_t maxCount) :

--- a/scwx-qt/source/scwx/qt/util/queue_counter.hpp
+++ b/scwx-qt/source/scwx/qt/util/queue_counter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <atomic>
+#include <boost/atomic/atomic.hpp>
 
 namespace scwx::qt::util
 {
@@ -54,7 +54,7 @@ public:
     * otherwise
     */
    static constexpr bool is_always_lock_free =
-      std::atomic<size_t>::is_always_lock_free;
+      boost::atomic<size_t>::is_always_lock_free;
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/util/queue_counter.hpp
+++ b/scwx-qt/source/scwx/qt/util/queue_counter.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <memory>
+#include <atomic>
+
+namespace scwx::qt::util
+{
+
+class QueueCounter
+{
+public:
+   /**
+    * Counts the number of items in a queue, and prevents it from exceeding a
+    * count in a thread safe manor. This is lock free, assuming
+    * std::atomic<size_t> supports lock free fetch_add and fetch_sub.
+    */
+
+   /**
+    * Construct a QueueCounter with a given maximum count
+    *
+    * @param maxCount The maximum number of items in the queue
+    */
+   explicit QueueCounter(size_t maxCount);
+
+   ~QueueCounter();
+   QueueCounter(const QueueCounter&)            = delete;
+   QueueCounter(QueueCounter&&)                 = delete;
+   QueueCounter& operator=(const QueueCounter&) = delete;
+   QueueCounter& operator=(QueueCounter&&)      = delete;
+
+   /**
+    * Called before adding an item. If it returns true, it is ok to add. If it
+    * returns false, it should not be added
+    *
+    * @return true if it is ok to add, false if the queue is full
+    */
+   bool add();
+
+   /**
+    * Called when item is removed from the queue. Should only be called after a
+    * corresponding and successful call to add.
+    */
+   void remove();
+
+   /**
+    * Tells if this instance is lock free
+    *
+    * @return true if it is lock free, false otherwise
+    */
+   bool is_lock_free();
+
+   /**
+    * Tells if this class is always lock free. True if it is lock free, false
+    * otherwise
+    */
+   static constexpr bool is_always_lock_free =
+      std::atomic<size_t>::is_always_lock_free;
+
+private:
+   class Impl;
+   std::unique_ptr<Impl> p;
+};
+
+} // namespace scwx::qt::util


### PR DESCRIPTION
Currently, if you press and hold the left or right arrow keys, you can end up queuing a lot of forward/backward time steps, and having to wait awhile for it to stop moving. This adds a maximum number of steps that can be added to the queue.

I set the maximum number to 3, but that may need more testing. I tried a few numbers, and I felt like 2-5 balanced being able to precisely seek a few scans at a time, while also not taking too long to stop after letting go while holding a key.

Moving to the start or end of the loop uses the same thread pool (queue), but do not check or change the counter that is used for the steps, so is mostly unaffected by this change.

The code should be thread safe, but feel free to check me on that.