### PR TITLE
Disable compile time selection of certs on Linux

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,9 @@ class SupercellWxConan(ConanFile):
         if self.settings.os == "Windows":
             self.options["libcurl"].with_ssl = "schannel"
         elif self.settings.os == "Linux":
-            self.options["openssl"].shared = True
+            self.options["openssl"].shared    = True
+            self.options["libcurl"].ca_bundle = "none"
+            self.options["libcurl"].ca_path   = "none"
 
     def requirements(self):
         if self.settings.os == "Linux":


### PR DESCRIPTION
Fix for #421.
SSL certificate locations are not standardized on Linux. There are a few common ones, which OpenSSL should check at runtime, instead of curl checking at compile time. This should improve portability. I was not able to fully test this without running it on CI.