### PR TITLE
Share GL resources between maps

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -788,6 +788,7 @@ void MainWindowImpl::ConfigureMapLayout()
       {
          if (maps_.at(mapIndex) == nullptr)
          {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Owned by parent
             maps_[mapIndex] =
                new map::MapWidget(mapIndex, settings_, glContext);
          }

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -1,6 +1,7 @@
 #include "main_window.hpp"
 #include "./ui_main_window.h"
 
+#include <scwx/qt/gl/gl_context.hpp>
 #include <scwx/qt/main/application.hpp>
 #include <scwx/qt/main/versions.hpp>
 #include <scwx/qt/manager/alert_manager.hpp>
@@ -776,6 +777,8 @@ void MainWindowImpl::ConfigureMapLayout()
       }
    };
 
+   auto glContext = std::make_shared<gl::GlContext>();
+
    for (int64_t y = 0; y < gridHeight; y++)
    {
       QSplitter* hs = new QSplitter(vs);
@@ -785,7 +788,8 @@ void MainWindowImpl::ConfigureMapLayout()
       {
          if (maps_.at(mapIndex) == nullptr)
          {
-            maps_[mapIndex] = new map::MapWidget(mapIndex, settings_);
+            maps_[mapIndex] =
+               new map::MapWidget(mapIndex, settings_, glContext);
          }
 
          hs->addWidget(maps_[mapIndex]);
@@ -818,9 +822,9 @@ void MainWindowImpl::ConfigureMapStyles()
       if ((customStyleAvailable_ && styleName == "Custom") ||
           std::find_if(mapProviderInfo.mapStyles_.cbegin(),
                        mapProviderInfo.mapStyles_.cend(),
-                       [&](const auto& mapStyle) {
-                          return mapStyle.name_ == styleName;
-                       }) != mapProviderInfo.mapStyles_.cend())
+                       [&](const auto& mapStyle)
+                       { return mapStyle.name_ == styleName; }) !=
+             mapProviderInfo.mapStyles_.cend())
       {
          // Initialize map style from settings
          maps_.at(i)->SetInitialMapStyle(styleName);
@@ -1154,22 +1158,22 @@ void MainWindowImpl::ConnectOtherSignals()
             mapSettings.radar_product(i).StageValue(map->GetRadarProductName());
          }
       });
-   connect(level2ProductsWidget_,
-           &ui::Level2ProductsWidget::RadarProductSelected,
-           mainWindow_,
-           [&](common::RadarProductGroup group,
-               const std::string&        productName,
-               int16_t                   productCode) {
-              SelectRadarProduct(activeMap_, group, productName, productCode);
-           });
-   connect(level3ProductsWidget_,
-           &ui::Level3ProductsWidget::RadarProductSelected,
-           mainWindow_,
-           [&](common::RadarProductGroup group,
-               const std::string&        productName,
-               int16_t                   productCode) {
-              SelectRadarProduct(activeMap_, group, productName, productCode);
-           });
+   connect(
+      level2ProductsWidget_,
+      &ui::Level2ProductsWidget::RadarProductSelected,
+      mainWindow_,
+      [&](common::RadarProductGroup group,
+          const std::string&        productName,
+          int16_t                   productCode)
+      { SelectRadarProduct(activeMap_, group, productName, productCode); });
+   connect(
+      level3ProductsWidget_,
+      &ui::Level3ProductsWidget::RadarProductSelected,
+      mainWindow_,
+      [&](common::RadarProductGroup group,
+          const std::string&        productName,
+          int16_t                   productCode)
+      { SelectRadarProduct(activeMap_, group, productName, productCode); });
    connect(level2SettingsWidget_,
            &ui::Level2SettingsWidget::ElevationSelected,
            mainWindow_,

--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -135,9 +135,9 @@ public:
       std::size_t lineWidth_ {};
    };
 
-   explicit Impl(AlertLayer*                 self,
-                 std::shared_ptr<MapContext> context,
-                 awips::Phenomenon           phenomenon) :
+   explicit Impl(AlertLayer*                    self,
+                 std::shared_ptr<gl::GlContext> context,
+                 awips::Phenomenon              phenomenon) :
        self_ {self},
        phenomenon_ {phenomenon},
        ibw_ {awips::ibw::GetImpactBasedWarningInfo(phenomenon)},
@@ -250,7 +250,7 @@ AlertLayer::AlertLayer(const std::shared_ptr<MapContext>& context,
     DrawLayer(
        context,
        fmt::format("AlertLayer {}", awips::GetPhenomenonText(phenomenon))),
-    p(std::make_unique<Impl>(this, context, phenomenon))
+    p(std::make_unique<Impl>(this, context->gl_context(), phenomenon))
 {
    for (auto alertActive : {false, true})
    {
@@ -298,7 +298,7 @@ void AlertLayer::Initialize()
 
 void AlertLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    for (auto alertActive : {false, true})
    {

--- a/scwx-qt/source/scwx/qt/map/alert_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.hpp
@@ -6,14 +6,8 @@
 #include <scwx/qt/types/text_event_key.hpp>
 
 #include <memory>
-#include <string>
-#include <vector>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class AlertLayer : public DrawLayer
@@ -40,6 +34,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/alert_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.hpp
@@ -16,13 +16,14 @@ class AlertLayer : public DrawLayer
    Q_DISABLE_COPY_MOVE(AlertLayer)
 
 public:
-   explicit AlertLayer(const std::shared_ptr<MapContext>& context,
-                       scwx::awips::Phenomenon            phenomenon);
+   explicit AlertLayer(const std::shared_ptr<gl::GlContext>& glContext,
+                       scwx::awips::Phenomenon               phenomenon);
    ~AlertLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
    static void InitializeHandler();
 

--- a/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
@@ -14,11 +14,7 @@
 #   pragma warning(pop)
 #endif
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::color_table_layer";
@@ -51,7 +47,7 @@ public:
    bool colorTableNeedsUpdate_;
 };
 
-ColorTableLayer::ColorTableLayer(std::shared_ptr<MapContext> context) :
+ColorTableLayer::ColorTableLayer(const std::shared_ptr<MapContext>& context) :
     GenericLayer(context), p(std::make_unique<ColorTableLayerImpl>())
 {
 }
@@ -61,11 +57,13 @@ void ColorTableLayer::Initialize()
 {
    logger_->debug("Initialize()");
 
-   gl::OpenGLFunctions& gl = context()->gl();
+   auto glContext = context()->gl_context();
+
+   gl::OpenGLFunctions& gl = glContext->gl();
 
    // Load and configure overlay shader
    p->shaderProgram_ =
-      context()->GetShaderProgram(":/gl/texture1d.vert", ":/gl/texture1d.frag");
+      glContext->GetShaderProgram(":/gl/texture1d.vert", ":/gl/texture1d.frag");
 
    p->uMVPMatrixLocation_ =
       gl.glGetUniformLocation(p->shaderProgram_->id(), "uMVPMatrix");
@@ -118,7 +116,7 @@ void ColorTableLayer::Initialize()
 void ColorTableLayer::Render(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl               = context()->gl();
+   gl::OpenGLFunctions& gl               = context()->gl_context()->gl();
    auto                 radarProductView = context()->radar_product_view();
 
    if (context()->radar_product_view() == nullptr ||
@@ -196,7 +194,7 @@ void ColorTableLayer::Deinitialize()
 {
    logger_->debug("Deinitialize()");
 
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    gl.glDeleteVertexArrays(1, &p->vao_);
    gl.glDeleteBuffers(2, p->vbo_.data());
@@ -210,6 +208,4 @@ void ColorTableLayer::Deinitialize()
    context()->set_color_table_margins(QMargins {});
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
@@ -176,7 +176,13 @@ void ColorTableLayer::Render(
       gl.glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
       gl.glDrawArrays(GL_TRIANGLES, 0, 6);
 
-      mapContext->set_color_table_margins(QMargins {0, 0, 0, 10});
+      static constexpr int kLeftMargin_   = 0;
+      static constexpr int kTopMargin_    = 0;
+      static constexpr int kRightMargin_  = 0;
+      static constexpr int kBottomMargin_ = 10;
+
+      mapContext->set_color_table_margins(
+         QMargins {kLeftMargin_, kTopMargin_, kRightMargin_, kBottomMargin_});
    }
    else
    {

--- a/scwx-qt/source/scwx/qt/map/color_table_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/color_table_layer.hpp
@@ -2,11 +2,7 @@
 
 #include <scwx/qt/map/generic_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class ColorTableLayerImpl;
@@ -14,7 +10,7 @@ class ColorTableLayerImpl;
 class ColorTableLayer : public GenericLayer
 {
 public:
-   explicit ColorTableLayer(std::shared_ptr<MapContext> context);
+   explicit ColorTableLayer(const std::shared_ptr<MapContext>& context);
    ~ColorTableLayer();
 
    void Initialize() override final;
@@ -25,6 +21,4 @@ private:
    std::unique_ptr<ColorTableLayerImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/color_table_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/color_table_layer.hpp
@@ -5,20 +5,22 @@
 namespace scwx::qt::map
 {
 
-class ColorTableLayerImpl;
-
 class ColorTableLayer : public GenericLayer
 {
+   Q_DISABLE_COPY_MOVE(ColorTableLayer)
+
 public:
-   explicit ColorTableLayer(const std::shared_ptr<MapContext>& context);
+   explicit ColorTableLayer(std::shared_ptr<gl::GlContext> glContext);
    ~ColorTableLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
 private:
-   std::unique_ptr<ColorTableLayerImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -77,7 +77,7 @@ DrawLayer::~DrawLayer() = default;
 
 void DrawLayer::Initialize()
 {
-   p->textureAtlas_ = p->context_->GetTextureAtlas();
+   p->textureAtlas_ = p->context_->gl_context()->GetTextureAtlas();
 
    for (auto& item : p->drawList_)
    {
@@ -123,13 +123,14 @@ void DrawLayer::ImGuiInitialize()
 void DrawLayer::RenderWithoutImGui(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = p->context_->gl();
-   p->textureAtlas_        = p->context_->GetTextureAtlas();
+   auto glContext = p->context_->gl_context();
+
+   gl::OpenGLFunctions& gl = glContext->gl();
+   p->textureAtlas_        = glContext->GetTextureAtlas();
 
    // Determine if the texture atlas changed since last render
-   std::uint64_t newTextureAtlasBuildCount =
-      p->context_->texture_buffer_count();
-   bool textureAtlasChanged =
+   std::uint64_t newTextureAtlasBuildCount = glContext->texture_buffer_count();
+   bool          textureAtlasChanged =
       newTextureAtlasBuildCount != p->textureAtlasBuildCount_;
 
    // Set OpenGL blend mode for transparency

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -1,9 +1,10 @@
-#include <ranges>
 #include <scwx/qt/manager/font_manager.hpp>
 #include <scwx/qt/map/draw_layer.hpp>
 #include <scwx/qt/model/imgui_context_model.hpp>
 #include <scwx/qt/gl/shader_program.hpp>
 #include <scwx/util/logger.hpp>
+
+#include <ranges>
 
 #include <backends/imgui_impl_opengl3.h>
 #include <backends/imgui_impl_qt.hpp>
@@ -17,12 +18,12 @@ namespace scwx::qt::map
 static const std::string logPrefix_ = "scwx::qt::map::draw_layer";
 static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 
-class DrawLayerImpl
+class DrawLayer::Impl
 {
 public:
-   explicit DrawLayerImpl(std::shared_ptr<MapContext> context,
-                          const std::string&          imGuiContextName) :
-       context_ {std::move(context)}, drawList_ {}
+   explicit Impl(std::shared_ptr<gl::GlContext> glContext,
+                 const std::string&             imGuiContextName) :
+       glContext_ {std::move(glContext)}
    {
       static size_t currentLayerId_ {0u};
       imGuiContextName_ =
@@ -35,7 +36,7 @@ public:
       // Initialize ImGui Qt backend
       ImGui_ImplQt_Init();
    }
-   ~DrawLayerImpl()
+   ~Impl()
    {
       // Set ImGui Context
       ImGui::SetCurrentContext(imGuiContext_);
@@ -51,13 +52,14 @@ public:
       model::ImGuiContextModel::Instance().DestroyContext(imGuiContextName_);
    }
 
-   DrawLayerImpl(const DrawLayerImpl&)             = delete;
-   DrawLayerImpl& operator=(const DrawLayerImpl&)  = delete;
-   DrawLayerImpl(const DrawLayerImpl&&)            = delete;
-   DrawLayerImpl& operator=(const DrawLayerImpl&&) = delete;
+   Impl(const Impl&)             = delete;
+   Impl& operator=(const Impl&)  = delete;
+   Impl(const Impl&&)            = delete;
+   Impl& operator=(const Impl&&) = delete;
 
-   std::shared_ptr<MapContext>                      context_;
-   std::vector<std::shared_ptr<gl::draw::DrawItem>> drawList_;
+   std::shared_ptr<gl::GlContext> glContext_;
+
+   std::vector<std::shared_ptr<gl::draw::DrawItem>> drawList_ {};
    GLuint textureAtlas_ {GL_INVALID_INDEX};
 
    std::uint64_t textureAtlasBuildCount_ {};
@@ -67,27 +69,27 @@ public:
    bool          imGuiRendererInitialized_ {};
 };
 
-DrawLayer::DrawLayer(const std::shared_ptr<MapContext>& context,
-                     const std::string&                 imGuiContextName) :
-    GenericLayer(context),
-    p(std::make_unique<DrawLayerImpl>(context, imGuiContextName))
+DrawLayer::DrawLayer(std::shared_ptr<gl::GlContext> glContext,
+                     const std::string&             imGuiContextName) :
+    GenericLayer(glContext),
+    p(std::make_unique<Impl>(std::move(glContext), imGuiContextName))
 {
 }
 DrawLayer::~DrawLayer() = default;
 
-void DrawLayer::Initialize()
+void DrawLayer::Initialize(const std::shared_ptr<MapContext>& mapContext)
 {
-   p->textureAtlas_ = p->context_->gl_context()->GetTextureAtlas();
+   p->textureAtlas_ = p->glContext_->GetTextureAtlas();
 
    for (auto& item : p->drawList_)
    {
       item->Initialize();
    }
 
-   ImGuiInitialize();
+   ImGuiInitialize(mapContext);
 }
 
-void DrawLayer::ImGuiFrameStart()
+void DrawLayer::ImGuiFrameStart(const std::shared_ptr<MapContext>& mapContext)
 {
    auto defaultFont = manager::FontManager::Instance().GetImGuiFont(
       types::FontCategory::Default);
@@ -96,7 +98,7 @@ void DrawLayer::ImGuiFrameStart()
    ImGui::SetCurrentContext(p->imGuiContext_);
 
    // Start ImGui Frame
-   ImGui_ImplQt_NewFrame(p->context_->widget());
+   ImGui_ImplQt_NewFrame(mapContext->widget());
    ImGui_ImplOpenGL3_NewFrame();
    ImGui::NewFrame();
    ImGui::PushFont(defaultFont->font());
@@ -112,10 +114,10 @@ void DrawLayer::ImGuiFrameEnd()
    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
 
-void DrawLayer::ImGuiInitialize()
+void DrawLayer::ImGuiInitialize(const std::shared_ptr<MapContext>& mapContext)
 {
    ImGui::SetCurrentContext(p->imGuiContext_);
-   ImGui_ImplQt_RegisterWidget(p->context_->widget());
+   ImGui_ImplQt_RegisterWidget(mapContext->widget());
    ImGui_ImplOpenGL3_Init();
    p->imGuiRendererInitialized_ = true;
 }
@@ -123,7 +125,7 @@ void DrawLayer::ImGuiInitialize()
 void DrawLayer::RenderWithoutImGui(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   auto glContext = p->context_->gl_context();
+   auto& glContext = p->glContext_;
 
    gl::OpenGLFunctions& gl = glContext->gl();
    p->textureAtlas_        = glContext->GetTextureAtlas();
@@ -146,14 +148,16 @@ void DrawLayer::RenderWithoutImGui(
 
    p->textureAtlasBuildCount_ = newTextureAtlasBuildCount;
 }
+
 void DrawLayer::ImGuiSelectContext()
 {
    ImGui::SetCurrentContext(p->imGuiContext_);
 }
 
-void DrawLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
+void DrawLayer::Render(const std::shared_ptr<MapContext>&            mapContext,
+                       const QMapLibre::CustomLayerRenderParameters& params)
 {
-   ImGuiFrameStart();
+   ImGuiFrameStart(mapContext);
    RenderWithoutImGui(params);
    ImGuiFrameEnd();
 }
@@ -169,6 +173,7 @@ void DrawLayer::Deinitialize()
 }
 
 bool DrawLayer::RunMousePicking(
+   const std::shared_ptr<MapContext>& /* mapContext */,
    const QMapLibre::CustomLayerRenderParameters& params,
    const QPointF&                                mouseLocalPos,
    const QPointF&                                mouseGlobalPos,

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -131,8 +131,9 @@ void DrawLayer::RenderWithoutImGui(
    p->textureAtlas_        = glContext->GetTextureAtlas();
 
    // Determine if the texture atlas changed since last render
-   std::uint64_t newTextureAtlasBuildCount = glContext->texture_buffer_count();
-   bool          textureAtlasChanged =
+   const std::uint64_t newTextureAtlasBuildCount =
+      glContext->texture_buffer_count();
+   const bool textureAtlasChanged =
       newTextureAtlasBuildCount != p->textureAtlasBuildCount_;
 
    // Set OpenGL blend mode for transparency

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -3,11 +3,7 @@
 #include <scwx/qt/gl/draw/draw_item.hpp>
 #include <scwx/qt/map/generic_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class DrawLayerImpl;
@@ -44,6 +40,4 @@ private:
    std::unique_ptr<DrawLayerImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/draw_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.hpp
@@ -6,21 +6,23 @@
 namespace scwx::qt::map
 {
 
-class DrawLayerImpl;
-
 class DrawLayer : public GenericLayer
 {
+   Q_DISABLE_COPY_MOVE(DrawLayer)
+
 public:
-   explicit DrawLayer(const std::shared_ptr<MapContext>& context,
-                      const std::string&                 imGuiContextName);
+   explicit DrawLayer(std::shared_ptr<gl::GlContext> glContext,
+                      const std::string&             imGuiContextName);
    virtual ~DrawLayer();
 
-   virtual void Initialize() override;
-   virtual void Render(const QMapLibre::CustomLayerRenderParameters&) override;
-   virtual void Deinitialize() override;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) override;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) override;
+   void Deinitialize() override;
 
-   virtual bool
-   RunMousePicking(const QMapLibre::CustomLayerRenderParameters& params,
+   bool
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
                    const QPointF&                                mouseLocalPos,
                    const QPointF&                                mouseGlobalPos,
                    const glm::vec2&                              mouseCoords,
@@ -29,15 +31,16 @@ public:
 
 protected:
    void AddDrawItem(const std::shared_ptr<gl::draw::DrawItem>& drawItem);
-   void ImGuiFrameStart();
+   void ImGuiFrameStart(const std::shared_ptr<MapContext>& mapContext);
    void ImGuiFrameEnd();
-   void ImGuiInitialize();
+   void ImGuiInitialize(const std::shared_ptr<MapContext>& mapContext);
    void
    RenderWithoutImGui(const QMapLibre::CustomLayerRenderParameters& params);
    void ImGuiSelectContext();
 
 private:
-   std::unique_ptr<DrawLayerImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.cpp
@@ -3,26 +3,32 @@
 namespace scwx::qt::map
 {
 
-class GenericLayerImpl
+class GenericLayer::Impl
 {
 public:
-   explicit GenericLayerImpl(std::shared_ptr<MapContext> context) :
-       context_ {std::move(context)}
+   explicit Impl(std::shared_ptr<gl::GlContext> glContext) :
+       glContext_ {std::move(glContext)}
    {
    }
 
-   ~GenericLayerImpl() {}
+   ~Impl() = default;
 
-   std::shared_ptr<MapContext> context_;
+   Impl(const Impl&)             = delete;
+   Impl& operator=(const Impl&)  = delete;
+   Impl(const Impl&&)            = delete;
+   Impl& operator=(const Impl&&) = delete;
+
+   std::shared_ptr<gl::GlContext> glContext_;
 };
 
-GenericLayer::GenericLayer(const std::shared_ptr<MapContext>& context) :
-    p(std::make_unique<GenericLayerImpl>(context))
+GenericLayer::GenericLayer(std::shared_ptr<gl::GlContext> glContext) :
+    p(std::make_unique<Impl>(std::move(glContext)))
 {
 }
 GenericLayer::~GenericLayer() = default;
 
 bool GenericLayer::RunMousePicking(
+   const std::shared_ptr<MapContext>& /* mapContext */,
    const QMapLibre::CustomLayerRenderParameters& /* params */,
    const QPointF& /* mouseLocalPos */,
    const QPointF& /* mouseGlobalPos */,
@@ -34,9 +40,9 @@ bool GenericLayer::RunMousePicking(
    return false;
 }
 
-std::shared_ptr<MapContext> GenericLayer::context() const
+std::shared_ptr<gl::GlContext> GenericLayer::gl_context() const
 {
-   return p->context_;
+   return p->glContext_;
 }
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.cpp
@@ -1,17 +1,13 @@
 #include <scwx/qt/map/generic_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class GenericLayerImpl
 {
 public:
    explicit GenericLayerImpl(std::shared_ptr<MapContext> context) :
-       context_ {context}
+       context_ {std::move(context)}
    {
    }
 
@@ -20,7 +16,7 @@ public:
    std::shared_ptr<MapContext> context_;
 };
 
-GenericLayer::GenericLayer(std::shared_ptr<MapContext> context) :
+GenericLayer::GenericLayer(const std::shared_ptr<MapContext>& context) :
     p(std::make_unique<GenericLayerImpl>(context))
 {
 }
@@ -43,6 +39,4 @@ std::shared_ptr<MapContext> GenericLayer::context() const
    return p->context_;
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <scwx/qt/gl/gl_context.hpp>
 #include <scwx/qt/map/map_context.hpp>
 #include <scwx/qt/types/event_types.hpp>
 #include <scwx/common/geographic.hpp>
@@ -13,23 +14,24 @@
 namespace scwx::qt::map
 {
 
-class GenericLayerImpl;
-
 class GenericLayer : public QObject
 {
    Q_OBJECT
+   Q_DISABLE_COPY_MOVE(GenericLayer)
 
 public:
-   explicit GenericLayer(const std::shared_ptr<MapContext>& context);
+   explicit GenericLayer(std::shared_ptr<gl::GlContext> glContext);
    virtual ~GenericLayer();
 
-   virtual void Initialize()                                          = 0;
-   virtual void Render(const QMapLibre::CustomLayerRenderParameters&) = 0;
-   virtual void Deinitialize()                                        = 0;
+   virtual void Initialize(const std::shared_ptr<MapContext>& mapContext)   = 0;
+   virtual void Render(const std::shared_ptr<MapContext>& mapContext,
+                       const QMapLibre::CustomLayerRenderParameters&)       = 0;
+   virtual void Deinitialize() = 0;
 
    /**
     * @brief Run mouse picking on the layer.
     *
+    * @param [in] mapContext Map context
     * @param [in] params Custom layer render parameters
     * @param [in] mouseLocalPos Mouse cursor widget position
     * @param [in] mouseGlobalPos Mouse cursor screen position
@@ -40,7 +42,8 @@ public:
     * @return true if a draw item was picked, otherwise false
     */
    virtual bool
-   RunMousePicking(const QMapLibre::CustomLayerRenderParameters& params,
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
                    const QPointF&                                mouseLocalPos,
                    const QPointF&                                mouseGlobalPos,
                    const glm::vec2&                              mouseCoords,
@@ -51,10 +54,11 @@ signals:
    void NeedsRendering();
 
 protected:
-   std::shared_ptr<MapContext> context() const;
+   [[nodiscard]] std::shared_ptr<gl::GlContext> gl_context() const;
 
 private:
-   std::unique_ptr<GenericLayerImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.hpp
@@ -10,11 +10,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <qmaplibre.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class GenericLayerImpl;
@@ -24,7 +20,7 @@ class GenericLayer : public QObject
    Q_OBJECT
 
 public:
-   explicit GenericLayer(std::shared_ptr<MapContext> context);
+   explicit GenericLayer(const std::shared_ptr<MapContext>& context);
    virtual ~GenericLayer();
 
    virtual void Initialize()                                          = 0;
@@ -61,6 +57,4 @@ private:
    std::unique_ptr<GenericLayerImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.hpp
@@ -23,10 +23,10 @@ public:
    explicit GenericLayer(std::shared_ptr<gl::GlContext> glContext);
    virtual ~GenericLayer();
 
-   virtual void Initialize(const std::shared_ptr<MapContext>& mapContext)   = 0;
+   virtual void Initialize(const std::shared_ptr<MapContext>& mapContext) = 0;
    virtual void Render(const std::shared_ptr<MapContext>& mapContext,
-                       const QMapLibre::CustomLayerRenderParameters&)       = 0;
-   virtual void Deinitialize() = 0;
+                       const QMapLibre::CustomLayerRenderParameters&)     = 0;
+   virtual void Deinitialize()                                            = 0;
 
    /**
     * @brief Run mouse picking on the layer.

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
@@ -3,21 +3,29 @@
 namespace scwx::qt::map
 {
 
-class LayerWrapperImpl
+class LayerWrapper::Impl
 {
 public:
-   explicit LayerWrapperImpl(std::shared_ptr<GenericLayer> layer) :
-       layer_ {std::move(layer)}
+   explicit Impl(std::shared_ptr<GenericLayer> layer,
+                 std::shared_ptr<MapContext>   mapContext) :
+       layer_ {std::move(layer)}, mapContext_ {std::move(mapContext)}
    {
    }
 
-   ~LayerWrapperImpl() {}
+   ~Impl() = default;
+
+   Impl(const Impl&)             = delete;
+   Impl& operator=(const Impl&)  = delete;
+   Impl(const Impl&&)            = delete;
+   Impl& operator=(const Impl&&) = delete;
 
    std::shared_ptr<GenericLayer> layer_;
+   std::shared_ptr<MapContext>   mapContext_;
 };
 
-LayerWrapper::LayerWrapper(const std::shared_ptr<GenericLayer>& layer) :
-    p(std::make_unique<LayerWrapperImpl>(layer))
+LayerWrapper::LayerWrapper(std::shared_ptr<GenericLayer> layer,
+                           std::shared_ptr<MapContext>   mapContext) :
+    p(std::make_unique<Impl>(std::move(layer), std::move(mapContext)))
 {
 }
 LayerWrapper::~LayerWrapper() = default;
@@ -30,7 +38,7 @@ void LayerWrapper::initialize()
    auto& layer = p->layer_;
    if (layer != nullptr)
    {
-      layer->Initialize();
+      layer->Initialize(p->mapContext_);
    }
 }
 
@@ -39,7 +47,7 @@ void LayerWrapper::render(const QMapLibre::CustomLayerRenderParameters& params)
    auto& layer = p->layer_;
    if (layer != nullptr)
    {
-      layer->Render(params);
+      layer->Render(p->mapContext_, params);
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
@@ -1,17 +1,13 @@
 #include <scwx/qt/map/layer_wrapper.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class LayerWrapperImpl
 {
 public:
    explicit LayerWrapperImpl(std::shared_ptr<GenericLayer> layer) :
-       layer_ {layer}
+       layer_ {std::move(layer)}
    {
    }
 
@@ -20,7 +16,7 @@ public:
    std::shared_ptr<GenericLayer> layer_;
 };
 
-LayerWrapper::LayerWrapper(std::shared_ptr<GenericLayer> layer) :
+LayerWrapper::LayerWrapper(const std::shared_ptr<GenericLayer>& layer) :
     p(std::make_unique<LayerWrapperImpl>(layer))
 {
 }
@@ -58,6 +54,4 @@ void LayerWrapper::deinitialize()
    }
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.hpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
 #include <scwx/qt/map/generic_layer.hpp>
+#include <scwx/qt/map/map_context.hpp>
 
 namespace scwx::qt::map
 {
 
-class LayerWrapperImpl;
-
 class LayerWrapper : public QMapLibre::CustomLayerHostInterface
 {
 public:
-   explicit LayerWrapper(const std::shared_ptr<GenericLayer>& layer);
+   explicit LayerWrapper(std::shared_ptr<GenericLayer> layer,
+                         std::shared_ptr<MapContext>   mapContext);
    ~LayerWrapper();
 
    LayerWrapper(const LayerWrapper&)            = delete;
@@ -19,12 +19,13 @@ public:
    LayerWrapper(LayerWrapper&&) noexcept;
    LayerWrapper& operator=(LayerWrapper&&) noexcept;
 
-   void initialize() override final;
-   void render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void deinitialize() override final;
+   void initialize() final;
+   void render(const QMapLibre::CustomLayerRenderParameters&) final;
+   void deinitialize() final;
 
 private:
-   std::unique_ptr<LayerWrapperImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.hpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.hpp
@@ -2,11 +2,7 @@
 
 #include <scwx/qt/map/generic_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class LayerWrapperImpl;
@@ -14,7 +10,7 @@ class LayerWrapperImpl;
 class LayerWrapper : public QMapLibre::CustomLayerHostInterface
 {
 public:
-   explicit LayerWrapper(std::shared_ptr<GenericLayer> layer);
+   explicit LayerWrapper(const std::shared_ptr<GenericLayer>& layer);
    ~LayerWrapper();
 
    LayerWrapper(const LayerWrapper&)            = delete;
@@ -31,6 +27,4 @@ private:
    std::unique_ptr<LayerWrapperImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -16,9 +16,6 @@ public:
 
    ~Impl() {}
 
-   std::shared_ptr<gl::GlContext> glContext_ {
-      std::make_shared<gl::GlContext>()};
-
    std::weak_ptr<QMapLibre::Map> map_ {};
    MapSettings                   settings_ {};
    float                         pixelRatio_ {1.0f};
@@ -49,11 +46,6 @@ MapContext::~MapContext() = default;
 
 MapContext::MapContext(MapContext&&) noexcept            = default;
 MapContext& MapContext::operator=(MapContext&&) noexcept = default;
-
-std::shared_ptr<gl::GlContext> MapContext::gl_context() const
-{
-   return p->glContext_;
-}
 
 std::weak_ptr<QMapLibre::Map> MapContext::map() const
 {

--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -3,11 +3,7 @@
 #include <scwx/qt/view/overlay_product_view.hpp>
 #include <scwx/qt/view/radar_product_view.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class MapContext::Impl
@@ -20,14 +16,17 @@ public:
 
    ~Impl() {}
 
+   std::shared_ptr<gl::GlContext> glContext_ {
+      std::make_shared<gl::GlContext>()};
+
    std::weak_ptr<QMapLibre::Map> map_ {};
    MapSettings                   settings_ {};
    float                         pixelRatio_ {1.0f};
    common::RadarProductGroup     radarProductGroup_ {
       common::RadarProductGroup::Unknown};
-   std::string                            radarProduct_ {"???"};
-   int16_t                                radarProductCode_ {0};
-   std::shared_ptr<config::RadarSite>     radarSite_ {nullptr};
+   std::string                        radarProduct_ {"???"};
+   int16_t                            radarProductCode_ {0};
+   std::shared_ptr<config::RadarSite> radarSite_ {nullptr};
 
    MapProvider mapProvider_ {MapProvider::Unknown};
    std::string mapCopyrights_ {};
@@ -50,6 +49,11 @@ MapContext::~MapContext() = default;
 
 MapContext::MapContext(MapContext&&) noexcept            = default;
 MapContext& MapContext::operator=(MapContext&&) noexcept = default;
+
+std::shared_ptr<gl::GlContext> MapContext::gl_context() const
+{
+   return p->glContext_;
+}
 
 std::weak_ptr<QMapLibre::Map> MapContext::map() const
 {
@@ -190,6 +194,4 @@ void MapContext::set_widget(QWidget* widget)
    p->widget_ = widget;
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <scwx/qt/gl/gl_context.hpp>
 #include <scwx/qt/map/map_provider.hpp>
 #include <scwx/common/geographic.hpp>
 #include <scwx/common/products.hpp>
@@ -34,8 +33,6 @@ public:
 
    MapContext(MapContext&&) noexcept;
    MapContext& operator=(MapContext&&) noexcept;
-
-   [[nodiscard]] std::shared_ptr<gl::GlContext> gl_context() const;
 
    [[nodiscard]] std::weak_ptr<QMapLibre::Map> map() const;
    [[nodiscard]] std::string                   map_copyrights() const;

--- a/scwx-qt/source/scwx/qt/map/map_context.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.hpp
@@ -9,33 +9,33 @@
 #include <qmaplibre.hpp>
 #include <QMargins>
 
-namespace scwx::qt
-{
-namespace view
+namespace scwx::qt::view
 {
 
 class OverlayProductView;
 class RadarProductView;
 
-} // namespace view
+} // namespace scwx::qt::view
 
-namespace map
+namespace scwx::qt::map
 {
 
 struct MapSettings;
 
-class MapContext : public gl::GlContext
+class MapContext
 {
 public:
    explicit MapContext(
       std::shared_ptr<view::RadarProductView> radarProductView = nullptr);
-   ~MapContext() override;
+   ~MapContext();
 
    MapContext(const MapContext&)            = delete;
    MapContext& operator=(const MapContext&) = delete;
 
    MapContext(MapContext&&) noexcept;
    MapContext& operator=(MapContext&&) noexcept;
+
+   [[nodiscard]] std::shared_ptr<gl::GlContext> gl_context() const;
 
    [[nodiscard]] std::weak_ptr<QMapLibre::Map> map() const;
    [[nodiscard]] std::string                   map_copyrights() const;
@@ -76,5 +76,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace scwx::qt
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_provider.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_provider.cpp
@@ -5,11 +5,7 @@
 
 #include <boost/algorithm/string.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::unordered_map<MapProvider, std::string> mapProviderName_ {
@@ -243,6 +239,4 @@ const MapProviderInfo& GetMapProviderInfo(MapProvider mapProvider)
    return mapProviderInfo_.at(mapProvider);
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_provider.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_provider.hpp
@@ -6,11 +6,7 @@
 
 #include <QMapLibre/Settings>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 enum class MapProvider
@@ -19,9 +15,8 @@ enum class MapProvider
    MapTiler,
    Unknown
 };
-typedef scwx::util::
-   Iterator<MapProvider, MapProvider::Mapbox, MapProvider::MapTiler>
-      MapProviderIterator;
+using MapProviderIterator = scwx::util::
+   Iterator<MapProvider, MapProvider::Mapbox, MapProvider::MapTiler>;
 
 struct MapStyle
 {
@@ -29,7 +24,7 @@ struct MapStyle
    std::string              url_;
    std::vector<std::string> drawBelow_;
 
-   bool IsValid() const;
+   [[nodiscard]] bool IsValid() const;
 };
 
 struct MapProviderInfo
@@ -45,6 +40,4 @@ std::string            GetMapProviderName(MapProvider mapProvider);
 std::string            GetMapProviderApiKey(MapProvider mapProvider);
 const MapProviderInfo& GetMapProviderInfo(MapProvider mapProvider);
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_settings.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_settings.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 struct MapSettings
@@ -22,6 +18,4 @@ struct MapSettings
    bool radarWireframeEnabled_ {false};
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1,4 +1,3 @@
-#include <ranges>
 #include <scwx/qt/map/map_widget.hpp>
 #include <scwx/qt/gl/gl.hpp>
 #include <scwx/qt/manager/font_manager.hpp>
@@ -32,6 +31,7 @@
 #include <scwx/util/time.hpp>
 
 #include <algorithm>
+#include <ranges>
 #include <set>
 
 #include <backends/imgui_impl_opengl3.h>
@@ -57,11 +57,7 @@
 #include <QString>
 #include <QTextDocument>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::map_widget";
@@ -1545,7 +1541,8 @@ void MapWidget::initializeGL()
    logger_->debug("initializeGL()");
 
    makeCurrent();
-   p->context_->Initialize();
+
+   p->context_->gl_context()->Initialize();
 
    // Lock ImGui font atlas prior to new ImGui frame
    std::shared_lock imguiFontAtlasLock {
@@ -1599,7 +1596,7 @@ void MapWidget::paintGL()
 
    p->frameDraws_++;
 
-   p->context_->StartFrame();
+   p->context_->gl_context()->StartFrame();
 
    // Handle hotkey updates
    p->HandleHotkeyUpdates();
@@ -2251,8 +2248,6 @@ void MapWidgetImpl::CheckLevel3Availability()
    }
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map
 
 #include "map_widget.moc"

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -68,11 +68,13 @@ class MapWidgetImpl : public QObject
    Q_OBJECT
 
 public:
-   explicit MapWidgetImpl(MapWidget*                 widget,
-                          std::size_t                id,
-                          const QMapLibre::Settings& settings) :
+   explicit MapWidgetImpl(MapWidget*                     widget,
+                          std::size_t                    id,
+                          const QMapLibre::Settings&     settings,
+                          std::shared_ptr<gl::GlContext> glContext) :
        id_ {id},
        uuid_ {boost::uuids::random_generator()()},
+       glContext_ {std::move(glContext)},
        widget_ {widget},
        settings_(settings),
        map_(),
@@ -194,8 +196,7 @@ public:
    boost::uuids::uuid uuid_;
 
    std::shared_ptr<MapContext>    context_ {std::make_shared<MapContext>()};
-   std::shared_ptr<gl::GlContext> glContext_ {
-      std::make_shared<gl::GlContext>()};
+   std::shared_ptr<gl::GlContext> glContext_;
 
    MapWidget*                      widget_;
    QMapLibre::Settings             settings_;
@@ -280,8 +281,10 @@ public slots:
    void Update();
 };
 
-MapWidget::MapWidget(std::size_t id, const QMapLibre::Settings& settings) :
-    p(std::make_unique<MapWidgetImpl>(this, id, settings))
+MapWidget::MapWidget(std::size_t                    id,
+                     const QMapLibre::Settings&     settings,
+                     std::shared_ptr<gl::GlContext> glContext) :
+    p(std::make_unique<MapWidgetImpl>(this, id, settings, std::move(glContext)))
 {
    if (settings::GeneralSettings::Instance().anti_aliasing_enabled().GetValue())
    {

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <ranges>
 #include <set>
+#include <utility>
 
 #include <backends/imgui_impl_opengl3.h>
 #include <backends/imgui_impl_qt.hpp>
@@ -70,13 +71,13 @@ class MapWidgetImpl : public QObject
 public:
    explicit MapWidgetImpl(MapWidget*                     widget,
                           std::size_t                    id,
-                          const QMapLibre::Settings&     settings,
+                          QMapLibre::Settings            settings,
                           std::shared_ptr<gl::GlContext> glContext) :
        id_ {id},
        uuid_ {boost::uuids::random_generator()()},
        glContext_ {std::move(glContext)},
        widget_ {widget},
-       settings_(settings),
+       settings_(std::move(settings)),
        map_(),
        layerList_ {},
        imGuiRendererInitialized_ {false},

--- a/scwx-qt/source/scwx/qt/map/map_widget.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.hpp
@@ -22,11 +22,7 @@ class QKeyEvent;
 class QMouseEvent;
 class QWheelEvent;
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class MapWidgetImpl;
@@ -188,6 +184,4 @@ signals:
    void IncomingLevel2ElevationChanged(std::optional<float> incomingElevation);
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/map_widget.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.hpp
@@ -22,6 +22,11 @@ class QKeyEvent;
 class QMouseEvent;
 class QWheelEvent;
 
+namespace scwx::qt::gl
+{
+class GlContext;
+}
+
 namespace scwx::qt::map
 {
 
@@ -32,7 +37,9 @@ class MapWidget : public QOpenGLWidget
    Q_OBJECT
 
 public:
-   explicit MapWidget(std::size_t id, const QMapLibre::Settings&);
+   explicit MapWidget(std::size_t id,
+                      const QMapLibre::Settings&,
+                      std::shared_ptr<gl::GlContext> glContext);
    ~MapWidget();
 
    void DumpLayerList() const;

--- a/scwx-qt/source/scwx/qt/map/marker_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/marker_layer.cpp
@@ -10,11 +10,7 @@
 
 #include <string>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::marker_layer";
@@ -23,7 +19,7 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class MarkerLayer::Impl
 {
 public:
-   explicit Impl(MarkerLayer* self, std::shared_ptr<MapContext> context) :
+   explicit Impl(MarkerLayer* self, std::shared_ptr<gl::GlContext> context) :
        self_ {self},
        geoIcons_ {std::make_shared<gl::draw::GeoIcons>(context)},
        editMarkerDialog_ {std::make_shared<ui::EditMarkerDialog>()}
@@ -42,7 +38,7 @@ public:
 
    MarkerLayer* self_;
 
-   std::shared_ptr<gl::draw::GeoIcons> geoIcons_;
+   std::shared_ptr<gl::draw::GeoIcons>   geoIcons_;
    std::shared_ptr<ui::EditMarkerDialog> editMarkerDialog_;
 };
 
@@ -130,7 +126,7 @@ void MarkerLayer::Impl::ReloadMarkers()
 
 MarkerLayer::MarkerLayer(const std::shared_ptr<MapContext>& context) :
     DrawLayer(context, "MarkerLayer"),
-    p(std::make_unique<MarkerLayer::Impl>(this, context))
+    p(std::make_unique<MarkerLayer::Impl>(this, context->gl_context()))
 {
    AddDrawItem(p->geoIcons_);
 }
@@ -162,7 +158,7 @@ void MarkerLayer::Impl::set_icon_sheets()
 
 void MarkerLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    DrawLayer::Render(params);
 
@@ -176,6 +172,4 @@ void MarkerLayer::Deinitialize()
    DrawLayer::Deinitialize();
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/marker_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/marker_layer.hpp
@@ -8,14 +8,16 @@ namespace scwx::qt::map
 class MarkerLayer : public DrawLayer
 {
    Q_OBJECT
+   Q_DISABLE_COPY_MOVE(MarkerLayer)
 
 public:
-   explicit MarkerLayer(const std::shared_ptr<MapContext>& context);
+   explicit MarkerLayer(const std::shared_ptr<gl::GlContext>& context);
    ~MarkerLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/map/marker_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/marker_layer.hpp
@@ -2,13 +2,7 @@
 
 #include <scwx/qt/map/draw_layer.hpp>
 
-#include <string>
-
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class MarkerLayer : public DrawLayer
@@ -28,6 +22,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -26,11 +26,7 @@
 #   pragma warning(pop)
 #endif
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::overlay_layer";
@@ -39,8 +35,8 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class OverlayLayerImpl
 {
 public:
-   explicit OverlayLayerImpl(OverlayLayer*               self,
-                             std::shared_ptr<MapContext> context) :
+   explicit OverlayLayerImpl(OverlayLayer*                  self,
+                             std::shared_ptr<gl::GlContext> context) :
        self_ {self},
        activeBoxOuter_ {std::make_shared<gl::draw::Rectangle>(context)},
        activeBoxInner_ {std::make_shared<gl::draw::Rectangle>(context)},
@@ -155,9 +151,9 @@ public:
    bool        sweepTimePicked_ {false};
 };
 
-OverlayLayer::OverlayLayer(std::shared_ptr<MapContext> context) :
+OverlayLayer::OverlayLayer(const std::shared_ptr<MapContext>& context) :
     DrawLayer(context, "OverlayLayer"),
-    p(std::make_unique<OverlayLayerImpl>(this, context))
+    p(std::make_unique<OverlayLayerImpl>(this, context->gl_context()))
 {
    AddDrawItem(p->activeBoxOuter_);
    AddDrawItem(p->activeBoxInner_);
@@ -336,7 +332,7 @@ void OverlayLayer::Render(const QMapLibre::CustomLayerRenderParameters& params)
 {
    const std::unique_lock lock {p->renderMutex_};
 
-   gl::OpenGLFunctions& gl               = context()->gl();
+   gl::OpenGLFunctions& gl               = context()->gl_context()->gl();
    auto                 radarProductView = context()->radar_product_view();
    auto&                settings         = context()->settings();
    const float          pixelRatio       = context()->pixel_ratio();
@@ -616,6 +612,4 @@ void OverlayLayer::UpdateSweepTimeNextFrame()
    p->sweepTimeNeedsUpdate_ = true;
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -513,7 +513,7 @@ void OverlayLayer::Render(const std::shared_ptr<MapContext>& mapContext,
    p->icons_->SetIconVisible(p->mapCenterIcon_,
                              generalSettings.show_map_center().GetValue());
 
-   QMargins colorTableMargins = mapContext->color_table_margins();
+   const QMargins colorTableMargins = mapContext->color_table_margins();
    if (colorTableMargins != p->lastColorTableMargins_ || p->firstRender_)
    {
       // Draw map logo with a 10x10 indent from the bottom left

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.hpp
@@ -5,33 +5,34 @@
 namespace scwx::qt::map
 {
 
-class OverlayLayerImpl;
-
 class OverlayLayer : public DrawLayer
 {
    Q_DISABLE_COPY_MOVE(OverlayLayer)
 
 public:
-   explicit OverlayLayer(const std::shared_ptr<MapContext>& context);
+   explicit OverlayLayer(const std::shared_ptr<gl::GlContext>& glContext);
    ~OverlayLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
-   bool RunMousePicking(
-      const QMapLibre::CustomLayerRenderParameters& params,
-      const QPointF&                                mouseLocalPos,
-      const QPointF&                                mouseGlobalPos,
-      const glm::vec2&                              mouseCoords,
-      const common::Coordinate&                     mouseGeoCoords,
-      std::shared_ptr<types::EventHandler>& eventHandler) override final;
+   bool
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
+                   const QPointF&                                mouseLocalPos,
+                   const QPointF&                                mouseGlobalPos,
+                   const glm::vec2&                              mouseCoords,
+                   const common::Coordinate&                     mouseGeoCoords,
+                   std::shared_ptr<types::EventHandler>& eventHandler) final;
 
 public slots:
    void UpdateSweepTimeNextFrame();
 
 private:
-   std::unique_ptr<OverlayLayerImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.hpp
@@ -2,11 +2,7 @@
 
 #include <scwx/qt/map/draw_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class OverlayLayerImpl;
@@ -16,7 +12,7 @@ class OverlayLayer : public DrawLayer
    Q_DISABLE_COPY_MOVE(OverlayLayer)
 
 public:
-   explicit OverlayLayer(std::shared_ptr<MapContext> context);
+   explicit OverlayLayer(const std::shared_ptr<MapContext>& context);
    ~OverlayLayer();
 
    void Initialize() override final;
@@ -38,6 +34,4 @@ private:
    std::unique_ptr<OverlayLayerImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
@@ -20,10 +20,10 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class OverlayProductLayer::Impl
 {
 public:
-   explicit Impl(OverlayProductLayer*           self,
-                 std::shared_ptr<gl::GlContext> context) :
+   explicit Impl(OverlayProductLayer*                  self,
+                 const std::shared_ptr<gl::GlContext>& glContext) :
        self_ {self},
-       linkedVectors_ {std::make_shared<gl::draw::LinkedVectors>(context)}
+       linkedVectors_ {std::make_shared<gl::draw::LinkedVectors>(glContext)}
    {
       auto& productSettings = settings::ProductSettings::Instance();
 
@@ -60,7 +60,8 @@ public:
          stiPastEnabledCallbackUuid_);
    }
 
-   void UpdateStormTrackingInformation();
+   void UpdateStormTrackingInformation(
+      const std::shared_ptr<MapContext>& mapContext);
 
    static void HandleLinkedVectorPacket(
       const std::shared_ptr<const wsr88d::rpg::Packet>& packet,
@@ -105,11 +106,21 @@ public:
 };
 
 OverlayProductLayer::OverlayProductLayer(
-   const std::shared_ptr<MapContext>& context) :
-    DrawLayer(context, "OverlayProductLayer"),
-    p(std::make_unique<Impl>(this, context->gl_context()))
+   const std::shared_ptr<gl::GlContext>& glContext) :
+    DrawLayer(glContext, "OverlayProductLayer"),
+    p(std::make_unique<Impl>(this, glContext))
 {
-   auto overlayProductView = context->overlay_product_view();
+   AddDrawItem(p->linkedVectors_);
+}
+
+OverlayProductLayer::~OverlayProductLayer() = default;
+
+void OverlayProductLayer::Initialize(
+   const std::shared_ptr<MapContext>& mapContext)
+{
+   logger_->debug("Initialize()");
+
+   auto overlayProductView = mapContext->overlay_product_view();
    connect(overlayProductView.get(),
            &view::OverlayProductView::ProductUpdated,
            this,
@@ -122,31 +133,23 @@ OverlayProductLayer::OverlayProductLayer(
               }
            });
 
-   AddDrawItem(p->linkedVectors_);
-}
+   p->UpdateStormTrackingInformation(mapContext);
 
-OverlayProductLayer::~OverlayProductLayer() = default;
-
-void OverlayProductLayer::Initialize()
-{
-   logger_->debug("Initialize()");
-
-   p->UpdateStormTrackingInformation();
-
-   DrawLayer::Initialize();
+   DrawLayer::Initialize(mapContext);
 }
 
 void OverlayProductLayer::Render(
+   const std::shared_ptr<MapContext>&            mapContext,
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
+   gl::OpenGLFunctions& gl = gl_context()->gl();
 
    if (p->stiNeedsUpdate_)
    {
-      p->UpdateStormTrackingInformation();
+      p->UpdateStormTrackingInformation(mapContext);
    }
 
-   DrawLayer::Render(params);
+   DrawLayer::Render(mapContext, params);
 
    SCWX_GL_CHECK_ERROR();
 }
@@ -155,16 +158,19 @@ void OverlayProductLayer::Deinitialize()
 {
    logger_->debug("Deinitialize()");
 
+   disconnect(this);
+
    DrawLayer::Deinitialize();
 }
 
-void OverlayProductLayer::Impl::UpdateStormTrackingInformation()
+void OverlayProductLayer::Impl::UpdateStormTrackingInformation(
+   const std::shared_ptr<MapContext>& mapContext)
 {
    logger_->debug("Update Storm Tracking Information");
 
    stiNeedsUpdate_ = false;
 
-   auto overlayProductView  = self_->context()->overlay_product_view();
+   auto overlayProductView  = mapContext->overlay_product_view();
    auto radarProductManager = overlayProductView->radar_product_manager();
    auto message             = overlayProductView->radar_product_message("NST");
 
@@ -431,6 +437,7 @@ std::string OverlayProductLayer::Impl::BuildHoverText(
 }
 
 bool OverlayProductLayer::RunMousePicking(
+   const std::shared_ptr<MapContext>&            mapContext,
    const QMapLibre::CustomLayerRenderParameters& params,
    const QPointF&                                mouseLocalPos,
    const QPointF&                                mouseGlobalPos,
@@ -438,7 +445,8 @@ bool OverlayProductLayer::RunMousePicking(
    const common::Coordinate&                     mouseGeoCoords,
    std::shared_ptr<types::EventHandler>&         eventHandler)
 {
-   return DrawLayer::RunMousePicking(params,
+   return DrawLayer::RunMousePicking(mapContext,
+                                     params,
                                      mouseLocalPos,
                                      mouseGlobalPos,
                                      mouseCoords,

--- a/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_product_layer.cpp
@@ -11,11 +11,7 @@
 #include <scwx/util/logger.hpp>
 #include <scwx/util/time.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::overlay_product_layer";
@@ -24,8 +20,8 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class OverlayProductLayer::Impl
 {
 public:
-   explicit Impl(OverlayProductLayer*               self,
-                 const std::shared_ptr<MapContext>& context) :
+   explicit Impl(OverlayProductLayer*           self,
+                 std::shared_ptr<gl::GlContext> context) :
        self_ {self},
        linkedVectors_ {std::make_shared<gl::draw::LinkedVectors>(context)}
    {
@@ -108,9 +104,10 @@ public:
    std::shared_ptr<gl::draw::LinkedVectors> linkedVectors_;
 };
 
-OverlayProductLayer::OverlayProductLayer(std::shared_ptr<MapContext> context) :
+OverlayProductLayer::OverlayProductLayer(
+   const std::shared_ptr<MapContext>& context) :
     DrawLayer(context, "OverlayProductLayer"),
-    p(std::make_unique<Impl>(this, context))
+    p(std::make_unique<Impl>(this, context->gl_context()))
 {
    auto overlayProductView = context->overlay_product_view();
    connect(overlayProductView.get(),
@@ -142,7 +139,7 @@ void OverlayProductLayer::Initialize()
 void OverlayProductLayer::Render(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    if (p->stiNeedsUpdate_)
    {
@@ -449,6 +446,4 @@ bool OverlayProductLayer::RunMousePicking(
                                      eventHandler);
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/overlay_product_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_product_layer.hpp
@@ -7,21 +7,26 @@ namespace scwx::qt::map
 
 class OverlayProductLayer : public DrawLayer
 {
+   Q_DISABLE_COPY_MOVE(OverlayProductLayer)
+
 public:
-   explicit OverlayProductLayer(const std::shared_ptr<MapContext>& context);
+   explicit OverlayProductLayer(
+      const std::shared_ptr<gl::GlContext>& glContext);
    ~OverlayProductLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
-   bool RunMousePicking(
-      const QMapLibre::CustomLayerRenderParameters& params,
-      const QPointF&                                mouseLocalPos,
-      const QPointF&                                mouseGlobalPos,
-      const glm::vec2&                              mouseCoords,
-      const common::Coordinate&                     mouseGeoCoords,
-      std::shared_ptr<types::EventHandler>& eventHandler) override final;
+   bool
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
+                   const QPointF&                                mouseLocalPos,
+                   const QPointF&                                mouseGlobalPos,
+                   const glm::vec2&                              mouseCoords,
+                   const common::Coordinate&                     mouseGeoCoords,
+                   std::shared_ptr<types::EventHandler>& eventHandler) final;
 
 private:
    class Impl;

--- a/scwx-qt/source/scwx/qt/map/overlay_product_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_product_layer.hpp
@@ -2,17 +2,13 @@
 
 #include <scwx/qt/map/draw_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class OverlayProductLayer : public DrawLayer
 {
 public:
-   explicit OverlayProductLayer(std::shared_ptr<MapContext> context);
+   explicit OverlayProductLayer(const std::shared_ptr<MapContext>& context);
    ~OverlayProductLayer();
 
    void Initialize() override final;
@@ -32,6 +28,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
@@ -12,11 +12,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::placefile_layer";
@@ -25,9 +21,9 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class PlacefileLayer::Impl
 {
 public:
-   explicit Impl(PlacefileLayer*                    self,
-                 const std::shared_ptr<MapContext>& context,
-                 const std::string&                 placefileName) :
+   explicit Impl(PlacefileLayer*                self,
+                 std::shared_ptr<gl::GlContext> context,
+                 const std::string&             placefileName) :
        self_ {self},
        placefileName_ {placefileName},
        placefileIcons_ {std::make_shared<gl::draw::PlacefileIcons>(context)},
@@ -67,7 +63,8 @@ public:
 PlacefileLayer::PlacefileLayer(const std::shared_ptr<MapContext>& context,
                                const std::string& placefileName) :
     DrawLayer(context, fmt::format("PlacefileLayer {}", placefileName)),
-    p(std::make_unique<PlacefileLayer::Impl>(this, context, placefileName))
+    p(std::make_unique<PlacefileLayer::Impl>(
+       this, context->gl_context(), placefileName))
 {
    AddDrawItem(p->placefileImages_);
    AddDrawItem(p->placefilePolygons_);
@@ -129,7 +126,7 @@ void PlacefileLayer::Initialize()
 void PlacefileLayer::Render(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    std::shared_ptr<manager::PlacefileManager> placefileManager =
       manager::PlacefileManager::Instance();
@@ -261,6 +258,4 @@ void PlacefileLayer::Impl::ReloadDataSync()
    Q_EMIT self_->DataReloaded();
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/placefile_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/placefile_layer.hpp
@@ -4,11 +4,7 @@
 
 #include <string>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class PlacefileLayer : public DrawLayer
@@ -38,6 +34,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/placefile_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/placefile_layer.hpp
@@ -10,19 +10,21 @@ namespace scwx::qt::map
 class PlacefileLayer : public DrawLayer
 {
    Q_OBJECT
+   Q_DISABLE_COPY_MOVE(PlacefileLayer)
 
 public:
-   explicit PlacefileLayer(const std::shared_ptr<MapContext>& context,
-                           const std::string&                 placefileName);
+   explicit PlacefileLayer(const std::shared_ptr<gl::GlContext>& glContext,
+                           const std::string&                    placefileName);
    ~PlacefileLayer();
 
    std::string placefile_name() const;
 
    void set_placefile_name(const std::string& placefileName);
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
    void ReloadData();
 

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -26,11 +26,7 @@
 #   pragma warning(pop)
 #endif
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::radar_product_layer";
@@ -76,7 +72,8 @@ public:
    bool sweepNeedsUpdate_;
 };
 
-RadarProductLayer::RadarProductLayer(std::shared_ptr<MapContext> context) :
+RadarProductLayer::RadarProductLayer(
+   const std::shared_ptr<MapContext>& context) :
     GenericLayer(context), p(std::make_unique<RadarProductLayerImpl>())
 {
    auto radarProductView = context->radar_product_view();
@@ -95,11 +92,13 @@ void RadarProductLayer::Initialize()
 {
    logger_->debug("Initialize()");
 
-   gl::OpenGLFunctions& gl = context()->gl();
+   auto glContext = context()->gl_context();
+
+   gl::OpenGLFunctions& gl = glContext->gl();
 
    // Load and configure radar shader
    p->shaderProgram_ =
-      context()->GetShaderProgram(":/gl/radar.vert", ":/gl/radar.frag");
+      glContext->GetShaderProgram(":/gl/radar.vert", ":/gl/radar.frag");
 
    p->uMVPMatrixLocation_ =
       gl.glGetUniformLocation(p->shaderProgram_->id(), "uMVPMatrix");
@@ -159,7 +158,7 @@ void RadarProductLayer::Initialize()
 
 void RadarProductLayer::UpdateSweep()
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    boost::timer::cpu_timer timer;
 
@@ -261,7 +260,7 @@ void RadarProductLayer::UpdateSweep()
 void RadarProductLayer::Render(
    const QMapLibre::CustomLayerRenderParameters& params)
 {
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    p->shaderProgram_->Use();
 
@@ -324,7 +323,7 @@ void RadarProductLayer::Deinitialize()
 {
    logger_->debug("Deinitialize()");
 
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    gl.glDeleteVertexArrays(1, &p->vao_);
    gl.glDeleteBuffers(3, p->vbo_.data());
@@ -536,7 +535,7 @@ void RadarProductLayer::UpdateColorTable()
 
    p->colorTableNeedsUpdate_ = false;
 
-   gl::OpenGLFunctions&                    gl = context()->gl();
+   gl::OpenGLFunctions&                    gl = context()->gl_context()->gl();
    std::shared_ptr<view::RadarProductView> radarProductView =
       context()->radar_product_view();
 
@@ -563,6 +562,4 @@ void RadarProductLayer::UpdateColorTable()
    gl.glUniform1f(p->uDataMomentScaleLocation_, scale);
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.hpp
@@ -2,11 +2,7 @@
 
 #include <scwx/qt/map/generic_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class RadarProductLayerImpl;
@@ -14,7 +10,7 @@ class RadarProductLayerImpl;
 class RadarProductLayer : public GenericLayer
 {
 public:
-   explicit RadarProductLayer(std::shared_ptr<MapContext> context);
+   explicit RadarProductLayer(const std::shared_ptr<MapContext>& context);
    ~RadarProductLayer();
 
    void Initialize() override final;
@@ -37,6 +33,4 @@ private:
    std::unique_ptr<RadarProductLayerImpl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.hpp
@@ -5,20 +5,22 @@
 namespace scwx::qt::map
 {
 
-class RadarProductLayerImpl;
-
 class RadarProductLayer : public GenericLayer
 {
+   Q_DISABLE_COPY_MOVE(RadarProductLayer)
+
 public:
-   explicit RadarProductLayer(const std::shared_ptr<MapContext>& context);
+   explicit RadarProductLayer(std::shared_ptr<gl::GlContext> glContext);
    ~RadarProductLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
-   virtual bool
-   RunMousePicking(const QMapLibre::CustomLayerRenderParameters& params,
+   bool
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
                    const QPointF&                                mouseLocalPos,
                    const QPointF&                                mouseGlobalPos,
                    const glm::vec2&                              mouseCoords,
@@ -26,11 +28,12 @@ public:
                    std::shared_ptr<types::EventHandler>& eventHandler) override;
 
 private:
-   void UpdateColorTable();
-   void UpdateSweep();
+   void UpdateColorTable(const std::shared_ptr<MapContext>& mapContext);
+   void UpdateSweep(const std::shared_ptr<MapContext>& mapContext);
 
 private:
-   std::unique_ptr<RadarProductLayerImpl> p;
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
@@ -5,11 +5,7 @@
 
 #include <glm/glm.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::radar_range_layer";
@@ -98,6 +94,4 @@ GetRangeCircle(float range, QMapLibre::Coordinate center)
    return rangeCircle;
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
@@ -2,13 +2,7 @@
 
 #include <qmaplibre.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
-{
-namespace RadarRangeLayer
+namespace scwx::qt::map::RadarRangeLayer
 {
 
 void Add(std::shared_ptr<QMapLibre::Map> map,
@@ -19,7 +13,4 @@ void Update(std::shared_ptr<QMapLibre::Map> map,
             float                           range,
             QMapLibre::Coordinate           center);
 
-} // namespace RadarRangeLayer
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map::RadarRangeLayer

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.cpp
@@ -13,11 +13,7 @@
 
 #include <QGuiApplication>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 static const std::string logPrefix_ = "scwx::qt::map::radar_site_layer";
@@ -26,7 +22,7 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 class RadarSiteLayer::Impl
 {
 public:
-   explicit Impl(RadarSiteLayer* self, std::shared_ptr<MapContext>& context) :
+   explicit Impl(RadarSiteLayer* self, std::shared_ptr<gl::GlContext> context) :
        self_ {self}, geoLines_ {std::make_shared<gl::draw::GeoLines>(context)}
    {
    }
@@ -54,9 +50,9 @@ public:
       nullptr, nullptr};
 };
 
-RadarSiteLayer::RadarSiteLayer(std::shared_ptr<MapContext> context) :
+RadarSiteLayer::RadarSiteLayer(const std::shared_ptr<MapContext>& context) :
     DrawLayer(context, "RadarSiteLayer"),
-    p(std::make_unique<Impl>(this, context))
+    p(std::make_unique<Impl>(this, context->gl_context()))
 {
 }
 
@@ -103,7 +99,7 @@ void RadarSiteLayer::Render(
       return;
    }
 
-   gl::OpenGLFunctions& gl = context()->gl();
+   gl::OpenGLFunctions& gl = context()->gl_context()->gl();
 
    // Update map screen coordinate and scale information
    p->mapScreenCoordLocation_ = util::maplibre::LatLongToScreenCoordinate(
@@ -251,6 +247,4 @@ bool RadarSiteLayer::RunMousePicking(
    return false;
 }
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.hpp
@@ -11,20 +11,22 @@ class RadarSiteLayer : public DrawLayer
    Q_DISABLE_COPY_MOVE(RadarSiteLayer)
 
 public:
-   explicit RadarSiteLayer(const std::shared_ptr<MapContext>& context);
+   explicit RadarSiteLayer(const std::shared_ptr<gl::GlContext>& glContext);
    ~RadarSiteLayer();
 
-   void Initialize() override final;
-   void Render(const QMapLibre::CustomLayerRenderParameters&) override final;
-   void Deinitialize() override final;
+   void Initialize(const std::shared_ptr<MapContext>& mapContext) final;
+   void Render(const std::shared_ptr<MapContext>& mapContext,
+               const QMapLibre::CustomLayerRenderParameters&) final;
+   void Deinitialize() final;
 
-   bool RunMousePicking(
-      const QMapLibre::CustomLayerRenderParameters& params,
-      const QPointF&                                mouseLocalPos,
-      const QPointF&                                mouseGlobalPos,
-      const glm::vec2&                              mouseCoords,
-      const common::Coordinate&                     mouseGeoCoords,
-      std::shared_ptr<types::EventHandler>& eventHandler) override final;
+   bool
+   RunMousePicking(const std::shared_ptr<MapContext>&            mapContext,
+                   const QMapLibre::CustomLayerRenderParameters& params,
+                   const QPointF&                                mouseLocalPos,
+                   const QPointF&                                mouseGlobalPos,
+                   const glm::vec2&                              mouseCoords,
+                   const common::Coordinate&                     mouseGeoCoords,
+                   std::shared_ptr<types::EventHandler>& eventHandler) final;
 
 signals:
    void RadarSiteSelected(const std::string& id);

--- a/scwx-qt/source/scwx/qt/map/radar_site_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_site_layer.hpp
@@ -2,11 +2,7 @@
 
 #include <scwx/qt/map/draw_layer.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace map
+namespace scwx::qt::map
 {
 
 class RadarSiteLayer : public DrawLayer
@@ -15,7 +11,7 @@ class RadarSiteLayer : public DrawLayer
    Q_DISABLE_COPY_MOVE(RadarSiteLayer)
 
 public:
-   explicit RadarSiteLayer(std::shared_ptr<MapContext> context);
+   explicit RadarSiteLayer(const std::shared_ptr<MapContext>& context);
    ~RadarSiteLayer();
 
    void Initialize() override final;
@@ -38,6 +34,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace map
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::map


### PR DESCRIPTION
Right now, there is some data duplicated between each map, because it's easy. Noteworthy items this will deduplicate:
- Shaders
- Texture atlas (this can get large with image-heavy placefiles)

A couple things have changed:
- `GlContext` is split from `MapContext`, these are now two separate contexts. `GlContext` is common, `MapContext` is unique
- Layer constructors take a `GlContext`, used to initialize draw objects
- `Initialize`/`Render`/`RunMousePicking` functions now have a `MapContext` argument

Moving `MapContext` out of the constructor is more a longer term goal beyond this pull request. Eventually, I'd like to get to the point where a layer could be shared between map panes (e.g., the alert and placefile draw lists can get especially large). Only the `LayerWrapper` would be unique between panes. I don't think that's doable yet, as I think `MapContext` would need removed from the Initialize function, and I'm not sure what that looks like yet. But doing so could increase resource efficiency even further.

There's no functional change with this pull request, but I do expect some resource improvements.