### PR TITLE
Add Windows arm64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-windows_vs2022_x64
+            conan_build_profile: scwx-windows_vs2022_x64
+            conan_host_profile: scwx-windows_vs2022_x64
             appimage_arch: ''
             artifact_suffix: windows-vs2022-x64
           - name: windows_vs2026_x64
@@ -55,9 +56,30 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-windows_vs2026_x64
+            conan_build_profile: scwx-windows_vs2026_x64
+            conan_host_profile: scwx-windows_vs2026_x64
             appimage_arch: ''
             artifact_suffix: windows-vs2026-x64
+          - name: windows_vs2026_arm64
+            os: windows-2025-vs2026
+            build_type: Release
+            env_cc: ''
+            env_cxx: ''
+            compiler: msvc
+            cppflags: ''
+            ldflags: ''
+            vs_arch: arm64
+            vs_version: 18
+            qt_version: 6.11.1
+            qt_arch_aqt: win64_msvc2022_arm64_cross_compiled
+            qt_arch_dir: win64_msvc2022_arm64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: ''
+            conan_build_profile: scwx-windows_vs2026_x64
+            conan_host_profile: scwx-windows_vs2026_armv8
+            appimage_arch: ''
+            artifact_suffix: windows-vs2026-arm64
           - name: linux_gcc-11_x64
             os: ubuntu-22.04
             build_type: Release
@@ -72,7 +94,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-11
+            conan_build_profile: scwx-linux_gcc-11
+            conan_host_profile: scwx-linux_gcc-11
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-11-x64
             compiler_packages: g++-11
@@ -90,7 +113,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-13
+            conan_build_profile: scwx-linux_gcc-13
+            conan_host_profile: scwx-linux_gcc-13
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-13-x64
             compiler_packages: g++-13
@@ -108,7 +132,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-14
+            conan_build_profile: scwx-linux_gcc-14
+            conan_host_profile: scwx-linux_gcc-14
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-14-x64
             compiler_packages: g++-14
@@ -126,7 +151,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-15
+            conan_build_profile: scwx-linux_gcc-15
+            conan_host_profile: scwx-linux_gcc-15
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-15-x64
             compiler_packages: g++-15
@@ -144,7 +170,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-16
+            conan_build_profile: scwx-linux_gcc-16
+            conan_host_profile: scwx-linux_gcc-16
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-16-x64
             compiler_packages: g++-16
@@ -162,7 +189,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-18
+            conan_build_profile: scwx-linux_clang-18
+            conan_host_profile: scwx-linux_clang-18
             appimage_arch: x86_64
             artifact_suffix: linux-clang-18-x64
             compiler_packages: clang-18
@@ -180,7 +208,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-19
+            conan_build_profile: scwx-linux_clang-19
+            conan_host_profile: scwx-linux_clang-19
             appimage_arch: x86_64
             artifact_suffix: linux-clang-19-x64
             compiler_packages: clang-19
@@ -198,7 +227,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-20
+            conan_build_profile: scwx-linux_clang-20
+            conan_host_profile: scwx-linux_clang-20
             appimage_arch: x86_64
             artifact_suffix: linux-clang-20-x64
             compiler_packages: clang-20
@@ -216,7 +246,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-21
+            conan_build_profile: scwx-linux_clang-21
+            conan_host_profile: scwx-linux_clang-21
             appimage_arch: x86_64
             artifact_suffix: linux-clang-21-x64
             compiler_packages: clang-21
@@ -234,7 +265,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-22
+            conan_build_profile: scwx-linux_clang-22
+            conan_host_profile: scwx-linux_clang-22
             appimage_arch: x86_64
             artifact_suffix: linux-clang-22-x64
             compiler_packages: clang-22
@@ -252,7 +284,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-13_armv8
+            conan_build_profile: scwx-linux_gcc-13_armv8
+            conan_host_profile: scwx-linux_gcc-13_armv8
             appimage_arch: aarch64
             artifact_suffix: linux-gcc-13-arm64
             compiler_packages: g++-13
@@ -268,7 +301,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-macos_clang-18
+            conan_build_profile: scwx-macos_clang-18
+            conan_host_profile: scwx-macos_clang-18
             appimage_arch: ''
             artifact_suffix: macos-x64
           - name: macos_clang-18_arm64
@@ -283,7 +317,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-macos_clang-18_armv8
+            conan_build_profile: scwx-macos_clang-18_armv8
+            conan_host_profile: scwx-macos_clang-18_armv8
             appimage_arch: ''
             artifact_suffix: macos-arm64
     name: ${{ matrix.name }}
@@ -380,8 +415,9 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.conan2
-        key: build-v2-${{ matrix.conan_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
+        key: build-v2-${{ matrix.conan_host_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/${{ matrix.conan_build_profile }}', './source/tools/conan/profiles/${{ matrix.conan_host_profile }}') }}
 
+        # Confirm this section
     - name: Install Conan Packages
       id: conan-install
       shell: pwsh
@@ -389,7 +425,10 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $PSNativeCommandUseErrorActionPreference = $true
         conan config install `
-          ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
+          ./source/tools/conan/profiles/${{ matrix.conan_build_profile }} `
+          -tf profiles
+        conan config install `
+          ./source/tools/conan/profiles/${{ matrix.conan_host_profile }} `
           -tf profiles
         mkdir build
         cd build
@@ -397,7 +436,8 @@ jobs:
         conan install ../source/ `
           --remote conancenter `
           --build missing `
-          --profile:all ${{ matrix.conan_profile }} `
+          --profile:build ${{ matrix.conan_build_profile }} `
+          --profile:host ${{ matrix.conan_host_profile }} `
           --settings:all build_type=${{ matrix.build_type }} `
           --output-folder ./conan/ `
           ${{ matrix.conan_package_manager }}
@@ -419,9 +459,16 @@ jobs:
           -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
-          -DCONAN_HOST_PROFILE="${{ matrix.conan_profile }}" `
-          -DCONAN_BUILD_PROFILE="${{ matrix.conan_profile }}"
-        ninja supercell-wx wxtest
+          -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
+          -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
+        ninja supercell-wx
+
+    - name: Build Supercell Wx (Test)
+      if: ${{ matrix.conan_build_profile == matrix.conan_host_profile }}
+      shell: pwsh
+      run: |
+        cd build
+        ninja wxtest
 
     - name: Separate Debug Symbols (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -512,7 +559,8 @@ jobs:
         cpack
         & "${{ github.workspace }}/source/tools/build-windows-nsis-bootstrapper.ps1" `
           -BuildDir "${{ github.workspace }}/build" `
-          -SourceDir "${{ github.workspace }}/source"
+          -SourceDir "${{ github.workspace }}/source" `
+          -Arch "${{ matrix.vs_arch }}"
 
     - name: Upload Installer (Windows)
       if: ${{ startsWith(matrix.os, 'windows') }}
@@ -618,6 +666,7 @@ jobs:
         path: ${{ github.workspace }}/build/supercell-wx-*.dmg*
 
     - name: Test Supercell Wx
+      if: ${{ matrix.conan_build_profile == matrix.conan_host_profile }}
       working-directory: ${{ github.workspace }}/build
       env:
         MAPBOX_API_KEY:   ${{ secrets.MAPBOX_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,14 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
           -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
           -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
-        ninja supercell-wx wxtest
+        ninja supercell-wx
+
+    - name: Build Supercell Wx (Test)
+      if: ${{ matrix.conan_build_profile == matrix.conan_host_profile }}
+      shell: pwsh
+      run: |
+        cd build
+        ninja wxtest
 
     - name: Separate Debug Symbols (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.conan2
-        key: build-${{ matrix.conan_host_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
+        key: build-${{ matrix.conan_host_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/${{ matrix.conan_build_profile }}', './source/tools/conan/profiles/${{ matrix.conan_host_profile }}') }}
 
         # Confirm this section
     - name: Install Conan Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             vs_version: 18
             qt_version: 6.11.1
             qt_arch_aqt: win64_msvc2022_arm64_cross_compiled
-            qt_arch_dir: win64_msvc2022_arm64
+            qt_arch_dir: msvc2022_arm64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
@@ -361,9 +361,12 @@ jobs:
         $vsDevCmd = Join-Path $vsPath "Common7\Tools\VsDevCmd.bat"
         if (-not (Test-Path $vsDevCmd)) { throw "VsDevCmd not found at $vsDevCmd" }
 
-        $arch = if ("${{ matrix.vs_arch }}" -eq "x64") { "amd64" } else { "${{ matrix.vs_arch }}" }
+        # GitHub-hosted Windows images are x64. ARM64 is produced with the
+        # x64-hosted cross compiler (Hostx64\arm64), not HostARM64\ARM64.
+        $targetArch = if ("${{ matrix.vs_arch }}" -eq "x64") { "amd64" } else { "${{ matrix.vs_arch }}" }
+        $hostArch = if ("${{ matrix.vs_arch }}" -eq "arm64") { "amd64" } else { $targetArch }
 
-        cmd.exe /d /s /c """$vsDevCmd"" -arch=$arch -host_arch=$arch && set" |
+        cmd.exe /d /s /c """$vsDevCmd"" -arch=$targetArch -host_arch=$hostArch && set" |
           ForEach-Object {
             if ($_ -match "^(.*?)=(.*)$") {
               "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -415,9 +418,15 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.conan2
-        key: build-v2-${{ matrix.conan_host_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/${{ matrix.conan_build_profile }}', './source/tools/conan/profiles/${{ matrix.conan_host_profile }}') }}
+        key: >-
+          build-v2-${{ matrix.conan_host_profile }}-${{
+            hashFiles(
+              './source/conanfile.py',
+              format('./source/tools/conan/profiles/{0}', matrix.conan_build_profile),
+              format('./source/tools/conan/profiles/{0}', matrix.conan_host_profile)
+            )
+          }}
 
-        # Confirm this section
     - name: Install Conan Packages
       id: conan-install
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,26 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-windows_msvc2022_x64
+            conan_build_profile: scwx-windows_msvc2022_x64
+            conan_host_profile: scwx-windows_msvc2022_x64
             appimage_arch: ''
             artifact_suffix: windows-x64
           - name: windows_msvc2022_arm64
-            os: windows-11-arm
+            os: windows-2022
             build_type: Release
             env_cc: ''
             env_cxx: ''
             compiler: msvc
-            msvc_arch: arm64
+            msvc_arch: amd64_arm64
             msvc_version: 2022
             qt_version: 6.8.3
-            qt_arch_aqt: win64_msvc2022_arm64
+            qt_arch_aqt: win64_msvc2022_arm64_cross_compiled
             qt_arch_dir: win64_msvc2022_arm64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-windows_msvc2022_armv8
+            conan_build_profile: scwx-windows_msvc2022_x64
+            conan_host_profile: scwx-windows_msvc2022_armv8
             appimage_arch: ''
             artifact_suffix: windows-arm64
           - name: linux_gcc_x64
@@ -70,7 +72,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-11
+            conan_build_profile: scwx-linux_gcc-11
+            conan_host_profile: scwx-linux_gcc-11
             appimage_arch: x86_64
             artifact_suffix: linux-x64
             compiler_packages: ''
@@ -88,7 +91,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-17
+            conan_build_profile: scwx-linux_clang-17
+            conan_host_profile: scwx-linux_clang-17
             appimage_arch: x86_64
             artifact_suffix: linux-clang-x64
             compiler_packages: clang-17
@@ -106,7 +110,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_gcc-11_armv8
+            conan_build_profile: scwx-linux_gcc-11_armv8
+            conan_host_profile: scwx-linux_gcc-11_armv8
             appimage_arch: aarch64
             artifact_suffix: linux-arm64
             compiler_packages: g++-11
@@ -210,13 +215,17 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.conan2
-        key: build-${{ matrix.conan_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
+        key: build-${{ matrix.conan_host_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
 
+        # Confirm this section
     - name: Install Conan Packages
       shell: pwsh
       run: |
         conan config install `
-          ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
+          ./source/tools/conan/profiles/${{ matrix.conan_build_profile }} `
+          -tf profiles
+        conan config install `
+          ./source/tools/conan/profiles/${{ matrix.conan_host_profile }} `
           -tf profiles
         mkdir build
         cd build
@@ -224,7 +233,8 @@ jobs:
         conan install ../source/ `
           --remote conancenter `
           --build missing `
-          --profile:all ${{ matrix.conan_profile }} `
+          --profile:build ${{ matrix.conan_build_profile }} `
+          --profile:host ${{ matrix.conan_host_profile }} `
           --settings:all build_type=${{ matrix.build_type }} `
           --output-folder ./conan/ `
           ${{ matrix.conan_package_manager }}
@@ -238,8 +248,8 @@ jobs:
           -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
-          -DCONAN_HOST_PROFILE="${{ matrix.conan_profile }}" `
-          -DCONAN_BUILD_PROFILE="${{ matrix.conan_profile }}"
+          -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
+          -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
         ninja supercell-wx wxtest
 
     - name: Separate Debug Symbols (Linux)
@@ -406,6 +416,7 @@ jobs:
         path: ${{ github.workspace }}/build/supercell-wx-*.dmg*
 
     - name: Test Supercell Wx
+      if: ${{ matrix.conan_build_profile == matrix.conan_host_profile }}
       working-directory: ${{ github.workspace }}/build
       env:
         MAPBOX_API_KEY:   ${{ secrets.MAPBOX_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,23 @@ jobs:
             conan_profile: scwx-windows_msvc2022_x64
             appimage_arch: ''
             artifact_suffix: windows-x64
+          - name: windows_msvc2022_arm64
+            os: windows-11-arm
+            build_type: Release
+            env_cc: ''
+            env_cxx: ''
+            compiler: msvc
+            msvc_arch: arm64
+            msvc_version: 2022
+            qt_version: 6.8.3
+            qt_arch_aqt: win64_msvc2022_arm64
+            qt_arch_dir: win64_msvc2022_arm64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: ''
+            conan_profile: scwx-windows_msvc2022_armv8
+            appimage_arch: ''
+            artifact_suffix: windows-arm64
           - name: linux_gcc_x64
             os: ubuntu-22.04
             build_type: Release
@@ -266,14 +283,14 @@ jobs:
         tar -czf supercell-wx-${{ matrix.artifact_suffix }}.tar.gz supercell-wx/
 
     - name: Upload Artifacts (Windows)
-      if: matrix.os == 'windows-2022'
+      if: ${{ startsWith(matrix.os, 'windows') }}
       uses: actions/upload-artifact@v4
       with:
         name: supercell-wx-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/supercell-wx/
 
     - name: Upload Debug Artifacts (Windows)
-      if: matrix.os == 'windows-2022'
+      if: ${{ startsWith(matrix.os, 'windows') }}
       uses: actions/upload-artifact@v4
       with:
         name: supercell-wx-debug-${{ matrix.artifact_suffix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-macos_clang-18
+            conan_build_profile: scwx-macos_clang-18
+            conan_host_profile: scwx-macos_clang-18
             appimage_arch: ''
             artifact_suffix: macos-x64
           - name: macos_clang18_arm64
@@ -142,7 +143,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_profile: scwx-macos_clang-18_armv8
+            conan_build_profile: scwx-macos_clang-18_armv8
+            conan_host_profile: scwx-macos_clang-18_armv8
             appimage_arch: ''
             artifact_suffix: macos-arm64
     name: ${{ matrix.name }}

--- a/.github/workflows/sign-windows-packages.yml
+++ b/.github/workflows/sign-windows-packages.yml
@@ -39,7 +39,7 @@ jobs:
             vs_version: 18
             qt_version: 6.11.1
             qt_arch_aqt: win64_msvc2022_arm64_cross_compiled
-            qt_arch_dir: win64_msvc2022_arm64
+            qt_arch_dir: msvc2022_arm64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             conan_build_profile: scwx-windows_vs2026_x64
             conan_host_profile: scwx-windows_vs2026_armv8
@@ -91,9 +91,12 @@ jobs:
         $vsDevCmd = Join-Path $vsPath "Common7\Tools\VsDevCmd.bat"
         if (-not (Test-Path $vsDevCmd)) { throw "VsDevCmd not found at $vsDevCmd" }
 
-        $arch = if ("${{ matrix.vs_arch }}" -eq "x64") { "amd64" } else { "${{ matrix.vs_arch }}" }
+        # GitHub-hosted Windows images are x64. ARM64 is produced with the
+        # x64-hosted cross compiler (Hostx64\arm64), not HostARM64\ARM64.
+        $targetArch = if ("${{ matrix.vs_arch }}" -eq "x64") { "amd64" } else { "${{ matrix.vs_arch }}" }
+        $hostArch = if ("${{ matrix.vs_arch }}" -eq "arm64") { "amd64" } else { $targetArch }
 
-        cmd.exe /d /s /c """$vsDevCmd"" -arch=$arch -host_arch=$arch && set" |
+        cmd.exe /d /s /c """$vsDevCmd"" -arch=$targetArch -host_arch=$hostArch && set" |
           ForEach-Object {
             if ($_ -match "^(.*?)=(.*)$") {
               "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -142,7 +145,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
           -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
           -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
-        ninja supercell-wx wxtest
+        ninja supercell-wx
 
     - name: Install Supercell Wx
       shell: pwsh

--- a/.github/workflows/sign-windows-packages.yml
+++ b/.github/workflows/sign-windows-packages.yml
@@ -24,13 +24,31 @@ jobs:
             qt_arch_aqt: win64_msvc2022_64
             qt_arch_dir: msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
-            conan_profile: scwx-windows_vs2026_x64
+            conan_build_profile: scwx-windows_vs2026_x64
+            conan_host_profile: scwx-windows_vs2026_x64
             windows_artifact_name: supercell-wx-windows-vs2026-x64
             signed_windows_artifact_name: supercell-wx-signed-windows-vs2026-x64
             unsigned_installer_artifact_name: supercell-wx-installer-unsigned-windows-vs2026-x64
             signed_installer_artifact_name: supercell-wx-installer-signed-windows-vs2026-x64
             unsigned_bootstrap_artifact_name: supercell-wx-bootstrap-unsigned-windows-vs2026-x64
             signed_bootstrap_artifact_name: supercell-wx-bootstrap-signed-windows-vs2026-x64
+          - name: windows_vs2026_arm64
+            os: windows-2025-vs2026
+            build_type: Release
+            vs_arch: arm64
+            vs_version: 18
+            qt_version: 6.11.1
+            qt_arch_aqt: win64_msvc2022_arm64_cross_compiled
+            qt_arch_dir: win64_msvc2022_arm64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            conan_build_profile: scwx-windows_vs2026_x64
+            conan_host_profile: scwx-windows_vs2026_armv8
+            windows_artifact_name: supercell-wx-windows-vs2026-arm64
+            signed_windows_artifact_name: supercell-wx-signed-windows-vs2026-arm64
+            unsigned_installer_artifact_name: supercell-wx-installer-unsigned-windows-vs2026-arm64
+            signed_installer_artifact_name: supercell-wx-installer-signed-windows-vs2026-arm64
+            unsigned_bootstrap_artifact_name: supercell-wx-bootstrap-unsigned-windows-vs2026-arm64
+            signed_bootstrap_artifact_name: supercell-wx-bootstrap-signed-windows-vs2026-arm64
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
@@ -96,7 +114,10 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $PSNativeCommandUseErrorActionPreference = $true
         conan config install `
-          ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
+          ./source/tools/conan/profiles/${{ matrix.conan_build_profile }} `
+          -tf profiles
+        conan config install `
+          ./source/tools/conan/profiles/${{ matrix.conan_host_profile }} `
           -tf profiles
         mkdir build
         cd build
@@ -104,7 +125,8 @@ jobs:
         conan install ../source/ `
           --remote conancenter `
           --build missing `
-          --profile:all ${{ matrix.conan_profile }} `
+          --profile:build ${{ matrix.conan_build_profile }} `
+          --profile:host ${{ matrix.conan_host_profile }} `
           --settings:all build_type=${{ matrix.build_type }} `
           --output-folder ./conan/
         conan cache clean
@@ -118,8 +140,8 @@ jobs:
           -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
-          -DCONAN_HOST_PROFILE="${{ matrix.conan_profile }}" `
-          -DCONAN_BUILD_PROFILE="${{ matrix.conan_profile }}"
+          -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
+          -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
         ninja supercell-wx wxtest
 
     - name: Install Supercell Wx
@@ -170,8 +192,8 @@ jobs:
           -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
           -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake" `
           -DCMAKE_INSTALL_PREFIX="${{ env.SIGNED_ARTIFACTS_DIR }}" `
-          -DCONAN_HOST_PROFILE="${{ matrix.conan_profile }}" `
-          -DCONAN_BUILD_PROFILE="${{ matrix.conan_profile }}" `
+          -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
+          -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}" `
           -DSCWX_WINDOWS_PACKAGE_INSTALL_ROOT="${{ env.SIGNED_ARTIFACTS_DIR }}"
 
     - name: Install NSIS (Windows)
@@ -224,6 +246,7 @@ jobs:
         & "${{ github.workspace }}/source/tools/build-windows-nsis-bootstrapper.ps1" `
           -BuildDir "${{ github.workspace }}/build" `
           -SourceDir "${{ github.workspace }}/source" `
+          -Arch "${{ matrix.vs_arch }}" `
           -MsiPath $signedMsi
 
     - name: Upload Unsigned Bootstrap (Windows)

--- a/scwx-qt/nsis/supercell-wx.nsi
+++ b/scwx-qt/nsis/supercell-wx.nsi
@@ -7,6 +7,7 @@
 ; Built after cpack by tools/build-windows-nsis-bootstrapper.ps1.
 ; Required defines:
 ;   SCWX_VERSION
+;   SCWX_ARCH            (x64 or arm64)
 ;   SCWX_NSIS_PLUGINDIR  (data/nsis/plugins/x86-unicode - ShellExecAsUser.dll)
 ; Optional defines (defaults assume staged files in the makensis working directory):
 ;   SCWX_OUTFILE, SCWX_MSI (source path), SCWX_MSI_FILE (embedded name),
@@ -17,17 +18,27 @@
   !error "SCWX_VERSION must be defined (e.g. makensis /DSCWX_VERSION=x.y.z)"
 !endif
 
+!ifndef SCWX_ARCH
+  !error "SCWX_ARCH must be defined (x64 or arm64)"
+!endif
+!if "${SCWX_ARCH}" != "x64"
+  !if "${SCWX_ARCH}" != "arm64"
+    !error "SCWX_ARCH must be x64 or arm64"
+  !endif
+!endif
+
 !ifndef SCWX_OUTFILE
-  !define SCWX_OUTFILE "supercell-wx-v${SCWX_VERSION}-windows-x64.exe"
+  !define SCWX_OUTFILE "supercell-wx-v${SCWX_VERSION}-windows-${SCWX_ARCH}.exe"
 !endif
 !ifndef SCWX_MSI_FILE
-  !define SCWX_MSI_FILE "supercell-wx-v${SCWX_VERSION}-windows-x64.msi"
+  !define SCWX_MSI_FILE "supercell-wx-v${SCWX_VERSION}-windows-${SCWX_ARCH}.msi"
 !endif
 !ifndef SCWX_MSI
   !define SCWX_MSI "${SCWX_MSI_FILE}"
 !endif
+!define SCWX_VC_REDIST_FILE "VC_redist.${SCWX_ARCH}.exe"
 !ifndef SCWX_VC_REDIST
-  !define SCWX_VC_REDIST "VC_redist.x64.exe"
+  !define SCWX_VC_REDIST "${SCWX_VC_REDIST_FILE}"
 !endif
 !ifndef SCWX_LICENSE
   !define SCWX_LICENSE "License.rtf"
@@ -137,19 +148,26 @@ FunctionEnd
 Section "Install"
   StrCpy $RedistRebootRequired 0
 
-  ${IfNot} ${RunningX64}
-    Push "Supercell Wx requires 64-bit Windows."
+!if "${SCWX_ARCH}" == "arm64"
+  ${IfNot} ${IsNativeARM64}
+    Push "This installer requires 64-bit ARM Windows."
     Call Bootstrapper_Fail
   ${EndIf}
+!else
+  ${IfNot} ${IsNativeAMD64}
+    Push "This installer requires 64-bit Intel/AMD Windows."
+    Call Bootstrapper_Fail
+  ${EndIf}
+!endif
 
   InitPluginsDir
   SetOutPath "$PLUGINSDIR"
 
-  File "/oname=VC_redist.x64.exe" "${SCWX_VC_REDIST}"
+  File "/oname=${SCWX_VC_REDIST_FILE}" "${SCWX_VC_REDIST}"
   File "/oname=${SCWX_MSI_FILE}" "${SCWX_MSI}"
 
-  DetailPrint "Installing Microsoft Visual C++ Redistributable (x64)..."
-  ExecWait '"$PLUGINSDIR\VC_redist.x64.exe" /install /quiet /norestart' $0
+  DetailPrint "Installing Microsoft Visual C++ Redistributable (${SCWX_ARCH})..."
+  ExecWait '"$PLUGINSDIR\${SCWX_VC_REDIST_FILE}" /install /quiet /norestart' $0
 
   ; Accept 0 (success), 1638 (newer already installed), 3010 (reboot needed).
   ${If} $0 == 3010

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -1026,7 +1026,7 @@ set(SCWX_WINDOWS_PACKAGE_INSTALL_ROOT "" CACHE PATH
     "Existing installed Supercell Wx tree to package for Windows")
 
 if (MSVC)
-    set(CPACK_PACKAGE_FILE_NAME           "supercell-wx-v${SCWX_VERSION}-windows-x64")
+    set(CPACK_PACKAGE_FILE_NAME           "supercell-wx-v${SCWX_VERSION}-windows")
     set(CPACK_PACKAGE_INSTALL_DIRECTORY   "Supercell Wx")
     set(CPACK_PACKAGE_ICON                "${CMAKE_CURRENT_SOURCE_DIR}/res/icons/scwx-256.ico")
     set(CPACK_GENERATOR                   WIX)

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -932,12 +932,23 @@ if (LINUX)
     set_target_properties(supercell-wx PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 endif()
 
-install(TARGETS supercell-wx
-                MLNQtCore # QMapLibre::Core
+# install(TARGETS RUNTIME_DEPENDENCIES) is rejected when CMAKE_CROSSCOMPILING.
+# Qt's Windows ARM64 toolchain sets that on x64 hosts; copy imported runtime
+# DLLs instead. windeployqt still deploys Qt.
+if (NOT CMAKE_CROSSCOMPILING)
+    set(_scwx_runtime_dependencies
         RUNTIME_DEPENDENCIES
           PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-" "qt6"
           POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
                                "^(/usr)?/lib/.*\\.so(\\..*)?"
+    )
+else()
+    set(_scwx_runtime_dependencies)
+endif()
+
+install(TARGETS supercell-wx
+                MLNQtCore # QMapLibre::Core
+        ${_scwx_runtime_dependencies}
         RUNTIME
           COMPONENT supercell-wx
         BUNDLE
@@ -951,6 +962,28 @@ install(TARGETS supercell-wx
           DESTINATION Frameworks
           COMPONENT supercell-wx
           OPTIONAL)
+
+if (WIN32 AND CMAKE_CROSSCOMPILING)
+    install(CODE "
+        set(_scwx_runtime_dlls
+            \"$<TARGET_RUNTIME_DLLS:supercell-wx>\"
+            \"$<TARGET_RUNTIME_DLLS:MLNQtCore>\")
+        list(REMOVE_DUPLICATES _scwx_runtime_dlls)
+        foreach(_scwx_dll IN LISTS _scwx_runtime_dlls)
+            if(_scwx_dll STREQUAL \"\")
+                continue()
+            endif()
+            get_filename_component(_scwx_dll_name \"\${_scwx_dll}\" NAME)
+            if(_scwx_dll_name MATCHES \"^[Qq]t6\" OR
+               _scwx_dll_name MATCHES \"^(api-ms-|ext-ms-)\")
+                continue()
+            endif()
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\"
+                 TYPE SHARED_LIBRARY
+                 FILES \"\${_scwx_dll}\")
+        endforeach()
+        " COMPONENT supercell-wx)
+endif()
 
 scwx_windeployqt_qtpaths_options(SCWX_DEPLOY_TOOL_OPTIONS)
 

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -867,7 +867,7 @@ set(CPACK_PACKAGE_CHECKSUM      SHA256)
 set(CPACK_RESOURCE_FILE_LICENSE "${SCWX_DIR}/LICENSE.txt")
 
 if (MSVC)
-    set(CPACK_PACKAGE_FILE_NAME           "supercell-wx-v${SCWX_VERSION}-windows-x64")
+    set(CPACK_PACKAGE_FILE_NAME           "supercell-wx-v${SCWX_VERSION}-windows")
     set(CPACK_PACKAGE_INSTALL_DIRECTORY   "Supercell Wx")
     set(CPACK_PACKAGE_ICON                "${CMAKE_CURRENT_SOURCE_DIR}/res/icons/scwx-256.ico")
     set(CPACK_GENERATOR                   WIX)

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -964,10 +964,16 @@ install(TARGETS supercell-wx
           OPTIONAL)
 
 if (WIN32 AND CMAKE_CROSSCOMPILING)
+    # TARGET_RUNTIME_DLLS only lists direct link dependencies. Transitive
+    # runtime DLLs (e.g. iconv-2.dll via fontconfig) are staged next to the
+    # executable by conanfile.py generate() but are omitted from install
+    # without RUNTIME_DEPENDENCIES (unsupported when cross-compiling).
     install(CODE "
         set(_scwx_runtime_dlls
             \"$<TARGET_RUNTIME_DLLS:supercell-wx>\"
             \"$<TARGET_RUNTIME_DLLS:MLNQtCore>\")
+        file(GLOB _scwx_staged_dlls \"$<TARGET_FILE_DIR:supercell-wx>/*.dll\")
+        list(APPEND _scwx_runtime_dlls \${_scwx_staged_dlls})
         list(REMOVE_DUPLICATES _scwx_runtime_dlls)
         foreach(_scwx_dll IN LISTS _scwx_runtime_dlls)
             if(_scwx_dll STREQUAL \"\")

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -911,12 +911,17 @@ target_link_libraries(supercell-wx PRIVATE scwx-qt
                                            wxdata)
 
 if (WIN32)
-    # Deploy Qt to target directory (CRT comes from the NSIS bootstrapper / system redist)
+    scwx_windeployqt_qtpaths_options(_qtpaths_opts)
+
+    set(SCWX_WINDEPLOYQT_OPTIONS --no-translations
+                                 --no-compiler-runtime # (CRT comes from the NSIS bootstrapper / system redist)
+                                 ${_qtpaths_opts})
+
+    # Deploy Qt to target directory 
     add_custom_command(TARGET supercell-wx
                        POST_BUILD
                        COMMAND "${WINDEPLOYQT_EXECUTABLE}"
-                           --no-translations
-                           --no-compiler-runtime
+                           ${SCWX_WINDEPLOYQT_OPTIONS}
                            $<TARGET_FILE:supercell-wx>
                        COMMENT "Running windeployqt for supercell-wx...")
 endif()
@@ -947,6 +952,8 @@ install(TARGETS supercell-wx
           COMPONENT supercell-wx
           OPTIONAL)
 
+scwx_windeployqt_qtpaths_options(SCWX_DEPLOY_TOOL_OPTIONS)
+
 # NO_TRANSLATIONS is needed for Qt 6.5.0 (will be fixed in 6.5.1)
 # https://bugreports.qt.io/browse/QTBUG-112204
 # NO_COMPILER_RUNTIME: VC++ redistributable is installed by the NSIS bootstrapper
@@ -954,13 +961,15 @@ qt_generate_deploy_app_script(TARGET MLNQtCore # QMapLibre::Core
                               OUTPUT_SCRIPT deploy_script_qmaplibre_core
                               NO_TRANSLATIONS
                               NO_COMPILER_RUNTIME
-                              NO_UNSUPPORTED_PLATFORM_ERROR)
+                              NO_UNSUPPORTED_PLATFORM_ERROR
+                              DEPLOY_TOOL_OPTIONS ${SCWX_DEPLOY_TOOL_OPTIONS})
 
 qt_generate_deploy_app_script(TARGET supercell-wx
                               OUTPUT_SCRIPT deploy_script_scwx
                               NO_TRANSLATIONS
                               NO_COMPILER_RUNTIME
-                              NO_UNSUPPORTED_PLATFORM_ERROR)
+                              NO_UNSUPPORTED_PLATFORM_ERROR
+                              DEPLOY_TOOL_OPTIONS ${SCWX_DEPLOY_TOOL_OPTIONS})
 
 install(SCRIPT ${deploy_script_qmaplibre_core}
         COMPONENT supercell-wx)
@@ -1026,7 +1035,13 @@ set(SCWX_WINDOWS_PACKAGE_INSTALL_ROOT "" CACHE PATH
     "Existing installed Supercell Wx tree to package for Windows")
 
 if (MSVC)
-    set(CPACK_PACKAGE_FILE_NAME           "supercell-wx-v${SCWX_VERSION}-windows")
+    if (CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64" OR
+        CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+        set(CPACK_PACKAGE_FILE_NAME "supercell-wx-v${SCWX_VERSION}-windows-arm64")
+    else()
+        set(CPACK_PACKAGE_FILE_NAME "supercell-wx-v${SCWX_VERSION}-windows-x64")
+    endif()
+
     set(CPACK_PACKAGE_INSTALL_DIRECTORY   "Supercell Wx")
     set(CPACK_PACKAGE_ICON                "${CMAKE_CURRENT_SOURCE_DIR}/res/icons/scwx-256.ico")
     set(CPACK_GENERATOR                   WIX)

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -133,12 +133,19 @@ target_link_libraries(wxtest GTest::gtest
                              wxdata)
 
 if (WIN32)
+    scwx_windeployqt_qtpaths_options(_qtpaths_opts)
+
+    set(SCWX_WINDEPLOYQT_OPTIONS --no-translations
+                                 --no-compiler-runtime # (CRT comes from the NSIS bootstrapper / system redist)
+                                 ${_qtpaths_opts})
+
     # Deploy Qt before gtest_discover_tests POST_BUILD runs wxtest.exe (needs
     # Qt DLLs beside the binary on Windows).
     add_custom_command(TARGET wxtest
                        POST_BUILD
                        COMMAND "${WINDEPLOYQT_EXECUTABLE}"
-                           --no-translations $<TARGET_FILE:wxtest>
+                               ${SCWX_WINDEPLOYQT_OPTIONS}
+                               $<TARGET_FILE:wxtest>
                        COMMENT "Running windeployqt for wxtest...")
 endif()
 

--- a/tools/build-windows-nsis-bootstrapper.ps1
+++ b/tools/build-windows-nsis-bootstrapper.ps1
@@ -4,8 +4,8 @@
   Builds the Supercell Wx NSIS bootstrapper (.exe) after cpack.
 
 .DESCRIPTION
-  Locates the CPack MSI and repo LICENSE.txt, stages VC_redist.x64.exe and MUI
-  assets, then runs makensis to produce supercell-wx-v{version}-windows-x64.exe
+  Locates the CPack MSI and repo LICENSE.txt, stages VC_redist.{arch}.exe and MUI
+  assets, then runs makensis to produce supercell-wx-v{version}-windows-{arch}.exe
   alongside the MSI.
 #>
 [CmdletBinding()]
@@ -17,6 +17,8 @@ param(
     [string] $SourceDir,
 
     [string] $Version = '',
+
+    [string] $Arch = '',
 
     [string] $MsiPath = '',
 
@@ -54,7 +56,18 @@ if (-not $Version) {
     $Version = $match.Matches[0].Groups[1].Value
 }
 
-$packageStem = "supercell-wx-v$Version-windows-x64"
+if (-not $Arch) {
+    $Arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        'arm64'
+    } else {
+        'x64'
+    }
+}
+if ($Arch -notin @('x64', 'arm64')) {
+    throw "Arch must be x64 or arm64, got: $Arch"
+}
+
+$packageStem = "supercell-wx-v$Version-windows-${Arch}"
 
 if (-not $MsiPath) {
     $MsiPath = Join-Path $BuildDir "$packageStem.msi"
@@ -70,7 +83,7 @@ if (-not $VcRedistPath) {
     if (-not $env:VCToolsRedistDir) {
         throw 'VCToolsRedistDir is not set; run from a VS developer environment or pass -VcRedistPath'
     }
-    $VcRedistPath = Join-Path $env:VCToolsRedistDir 'VC_redist.x64.exe'
+    $VcRedistPath = Join-Path $env:VCToolsRedistDir "VC_redist.${Arch}.exe"
 }
 $VcRedistPath = Resolve-ExistingPath $VcRedistPath 'VC++ redistributable'
 
@@ -110,7 +123,7 @@ New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
 
 $msiFileName = "$packageStem.msi"
 $msiStaging = Join-Path $stagingDir $msiFileName
-$redistStaging = Join-Path $stagingDir 'VC_redist.x64.exe'
+$redistStaging = Join-Path $stagingDir "VC_redist.${Arch}.exe"
 $licenseStaging = Join-Path $stagingDir 'LICENSE.txt'
 $iconStaging = Join-Path $stagingDir 'scwx-256.ico'
 $headerStaging = Join-Path $stagingDir 'scwx-header.bmp'
@@ -126,6 +139,7 @@ Copy-Item -LiteralPath $welcomeBmp -Destination $welcomeStaging -Force
 
 Write-Host "Building NSIS bootstrapper:"
 Write-Host "  Version:  $Version"
+Write-Host "  Arch:     $Arch"
 Write-Host "  MSI:      $msiStaging"
 Write-Host "  License:  $licenseStaging"
 Write-Host "  VCRedist: $redistStaging"
@@ -138,6 +152,7 @@ Push-Location $stagingDir
 try {
     & $makensis -NOCD `
         "-DSCWX_VERSION=$Version" `
+        "-DSCWX_ARCH=$Arch" `
         "-DSCWX_OUTFILE=$outputExe" `
         "-DSCWX_MSI=$msiStaging" `
         "-DSCWX_MSI_FILE=$msiFileName" `

--- a/tools/conan/profiles/scwx-windows_msvc2022_armv8
+++ b/tools/conan/profiles/scwx-windows_msvc2022_armv8
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=msvc
+compiler.cppstd=20
+compiler.runtime=dynamic
+compiler.version=194
+os=Windows

--- a/tools/conan/profiles/scwx-windows_vs2022_armv8
+++ b/tools/conan/profiles/scwx-windows_vs2022_armv8
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=msvc
+compiler.cppstd=20
+compiler.runtime=dynamic
+compiler.version=194
+os=Windows

--- a/tools/conan/profiles/scwx-windows_vs2026_armv8
+++ b/tools/conan/profiles/scwx-windows_vs2026_armv8
@@ -1,0 +1,11 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=msvc
+compiler.cppstd=20
+compiler.runtime=dynamic
+compiler.version=195
+os=Windows
+
+[tool_requires]
+cmake/[>=4.2.0]

--- a/tools/configure-environment.bat
+++ b/tools/configure-environment.bat
@@ -27,10 +27,12 @@ pip install --upgrade -r "%script_dir%\..\requirements.txt"
 @conan profile detect -e
 
 :: Conan profiles
-@set profile_count=2
+@set profile_count=4
 @set /a last_profile=profile_count - 1
 @set conan_profile[0]=scwx-windows_vs2022_x64
 @set conan_profile[1]=scwx-windows_vs2026_x64
+@set conan_profile[2]=scwx-windows_vs2022_armv8
+@set conan_profile[3]=scwx-windows_vs2026_armv8
 
 :: Install Conan profiles
 @for /L %%i in (0,1,!last_profile!) do @(

--- a/tools/lib/run-cmake-configure.bat
+++ b/tools/lib/run-cmake-configure.bat
@@ -1,18 +1,34 @@
 @set script_dir=%~dp0
 
+:: If conan_build_profile is not set, use the same as conan_profile
+if "%conan_build_profile%" == "" (
+    set conan_build_profile=%conan_profile%
+)
+
 @set cmake_args=-B "%build_dir%" -S "%script_dir%\..\.." ^
     -G "%generator%" ^
     -DCMAKE_PREFIX_PATH="%qt_base%/%qt_version%/%qt_arch%" ^
     -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="%script_dir%\..\..\external\cmake-conan\conan_provider.cmake" ^
     -DCONAN_HOST_PROFILE=%conan_profile% ^
-    -DCONAN_BUILD_PROFILE=%conan_profile% ^
+    -DCONAN_BUILD_PROFILE=%conan_build_profile% ^
     -DSCWX_VIRTUAL_ENV=%venv_path% ^
     -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+
+:: Cross-builds (Windows ARM64) need x64 host tools for moc/rcc/uic.
+:: scwx_config.cmake reads these from the environment before project().
+@if defined qt_host_arch (
+    set "QT_HOST_PATH=%qt_base%/%qt_version%/%qt_host_arch%"
+    set "QT_ROOT_DIR=%qt_base%/%qt_version%/%qt_arch%"
+    set cmake_args=%cmake_args% ^
+        -DQT_HOST_PATH="%qt_base%/%qt_version%/%qt_host_arch%" ^
+        -DQT_ROOT_DIR="%qt_base%/%qt_version%/%qt_arch%"
+)
 
 @if defined build_type (
     set cmake_args=%cmake_args% ^
         -DCMAKE_BUILD_TYPE=%build_type% ^
-        -DCMAKE_CONFIGURATION_TYPES=%build_type%
+        -DCMAKE_CONFIGURATION_TYPES=%build_type% ^
+        -DCONAN_INSTALL_BUILD_CONFIGURATIONS=%build_type%
 ) else (
     :: CMAKE_BUILD_TYPE isn't used to build, but is required by the Conan CMakeDeps generator
     set cmake_args=%cmake_args% ^

--- a/tools/lib/run-cmake-configure.bat
+++ b/tools/lib/run-cmake-configure.bat
@@ -24,6 +24,12 @@ if "%conan_build_profile%" == "" (
         -DQT_ROOT_DIR="%qt_base%/%qt_version%/%qt_arch%"
 )
 
+:: Visual Studio defaults to the host architecture. Pass -A so the generator
+:: platform is ARM64 on first configure, before scwx_config.cmake runs.
+@if defined vs_platform (
+    set cmake_args=%cmake_args% -A %vs_platform%
+)
+
 @if defined build_type (
     set cmake_args=%cmake_args% ^
         -DCMAKE_BUILD_TYPE=%build_type% ^

--- a/tools/lib/run-cmake-configure.sh
+++ b/tools/lib/run-cmake-configure.sh
@@ -18,6 +18,7 @@ if [[ -n "${build_type}" ]]; then
     cmake_args+=(
         -DCMAKE_BUILD_TYPE="${build_type}"
         -DCMAKE_CONFIGURATION_TYPES="${build_type}"
+        -DCONAN_INSTALL_BUILD_CONFIGURATIONS="${build_type}"
         -DCMAKE_INSTALL_PREFIX="${build_dir}/${build_type}/supercell-wx"
     )
 else

--- a/tools/lib/setup-conan.bat
+++ b/tools/lib/setup-conan.bat
@@ -6,10 +6,16 @@ conan profile detect -e
 :: Install selected Conan profile
 conan config install "%script_dir%\..\conan\profiles\%conan_profile%" -tf profiles
 
+:: If conan_build_profile is not set, use the same as conan_profile
+if "%conan_build_profile%" == "" (
+    set conan_build_profile=%conan_profile%
+)
+
 :: Install Conan packages
 conan install "%script_dir%\..\.." ^
     --remote conancenter ^
     --build missing ^
-    --profile:all %conan_profile% ^
+    --profile:build %conan_build_profile% ^
+    --profile:host %conan_profile% ^
     --settings:all build_type=%build_type% ^
     --output-folder "%build_dir%\conan"

--- a/tools/scwx_config.cmake
+++ b/tools/scwx_config.cmake
@@ -1,3 +1,42 @@
+# Windows ARM64 Qt is a cross-build: libraries live in the target prefix (QT_ROOT_DIR)
+# while moc/rcc/qtpaths/windeployqt must come from the x64 host prefix (QT_HOST_PATH).
+# Qt 6.10+ ships Qt6*Tools CMake packages in the target prefix that point at
+# target-arch binaries (and renamed qtpaths.bat to host-qtpaths.bat). Force host
+# tools and Qt's toolchain before project() so find_package(Qt6) does not load
+# those target tool packages.
+if(WIN32 AND NOT CMAKE_TOOLCHAIN_FILE)
+    set(_scwx_qt_host "$ENV{QT_HOST_PATH}")
+    set(_scwx_qt_root "$ENV{QT_ROOT_DIR}")
+    if(_scwx_qt_host AND _scwx_qt_root)
+        set(_scwx_qt_tc "${_scwx_qt_root}/lib/cmake/Qt6/qt.toolchain.cmake")
+        if(EXISTS "${_scwx_qt_tc}")
+            set(CMAKE_TOOLCHAIN_FILE "${_scwx_qt_tc}" CACHE FILEPATH
+                "Qt cross-compile toolchain")
+            message(STATUS "Using Qt cross-compile toolchain: ${_scwx_qt_tc}")
+            message(STATUS "Using host Qt tools from: ${_scwx_qt_host}")
+        endif()
+        file(GLOB _scwx_host_tools_dirs "${_scwx_qt_host}/lib/cmake/Qt6*Tools")
+        foreach(_scwx_tools_dir IN LISTS _scwx_host_tools_dirs)
+            get_filename_component(_scwx_tools_name "${_scwx_tools_dir}" NAME)
+            if(_scwx_tools_name MATCHES "UiTools$"
+               OR _scwx_tools_name MATCHES "ShaderTools$"
+               OR _scwx_tools_name STREQUAL "Qt6Tools")
+                continue()
+            endif()
+            if(NOT DEFINED ${_scwx_tools_name}_DIR)
+                set(${_scwx_tools_name}_DIR "${_scwx_tools_dir}" CACHE PATH
+                    "Host Qt tools package")
+            endif()
+        endforeach()
+        unset(_scwx_host_tools_dirs)
+        unset(_scwx_tools_dir)
+        unset(_scwx_tools_name)
+        unset(_scwx_qt_tc)
+    endif()
+    unset(_scwx_qt_host)
+    unset(_scwx_qt_root)
+endif()
+
 macro(scwx_output_dirs_setup)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR}/Release/bin)
@@ -59,14 +98,27 @@ endmacro()
 
 # Host windeployqt must query the *target* Qt prefix when QT_HOST_PATH is set
 # (Windows ARM64 cross-builds). Empty on native/non-Windows.
+# Qt 6.8 used qtpaths.bat; 6.10+ renamed the x64 wrapper to host-qtpaths.bat
+# (qtpaths.exe in the same directory is the ARM64 binary and will not run on
+# an x64 host). Prefer the host wrapper.
 function(scwx_windeployqt_qtpaths_options out_var)
     set(_opts)
     if (WIN32 AND DEFINED QT_HOST_PATH AND DEFINED Qt6_DIR)
         get_filename_component(_prefix "${Qt6_DIR}/../../.." ABSOLUTE)
-        set(_qtpaths "${_prefix}/bin/qtpaths.bat")
-        if (NOT EXISTS "${_qtpaths}")
-            message(FATAL_ERROR "Qt paths file not found: ${_qtpaths}")
+        set(_qtpaths "")
+        foreach(_candidate IN ITEMS
+                host-qtpaths.bat host-qtpaths6.bat qtpaths.bat qtpaths6.bat)
+            if (EXISTS "${_prefix}/bin/${_candidate}")
+                set(_qtpaths "${_prefix}/bin/${_candidate}")
+                break()
+            endif()
+        endforeach()
+        if (NOT _qtpaths)
+            message(FATAL_ERROR
+                "Qt paths helper not found under ${_prefix}/bin "
+                "(tried host-qtpaths.bat, qtpaths.bat)")
         endif()
+        message(STATUS "windeployqt --qtpaths ${_qtpaths}")
         list(APPEND _opts --qtpaths "${_qtpaths}")
     endif()
     set(${out_var} ${_opts} PARENT_SCOPE)

--- a/tools/scwx_config.cmake
+++ b/tools/scwx_config.cmake
@@ -56,3 +56,18 @@ macro(scwx_python_setup)
                         RESULT_VARIABLE PIP_RESULT)
     endif()
 endmacro()
+
+# Host windeployqt must query the *target* Qt prefix when QT_HOST_PATH is set
+# (Windows ARM64 cross-builds). Empty on native/non-Windows.
+function(scwx_windeployqt_qtpaths_options out_var)
+    set(_opts)
+    if (WIN32 AND DEFINED QT_HOST_PATH AND DEFINED Qt6_DIR)
+        get_filename_component(_prefix "${Qt6_DIR}/../../.." ABSOLUTE)
+        set(_qtpaths "${_prefix}/bin/qtpaths.bat")
+        if (NOT EXISTS "${_qtpaths}")
+            message(FATAL_ERROR "Qt paths file not found: ${_qtpaths}")
+        endif()
+        list(APPEND _opts --qtpaths "${_qtpaths}")
+    endif()
+    set(${out_var} ${_opts} PARENT_SCOPE)
+endfunction()

--- a/tools/scwx_config.cmake
+++ b/tools/scwx_config.cmake
@@ -15,6 +15,15 @@ if(WIN32 AND NOT CMAKE_TOOLCHAIN_FILE)
             message(STATUS "Using Qt cross-compile toolchain: ${_scwx_qt_tc}")
             message(STATUS "Using host Qt tools from: ${_scwx_qt_host}")
         endif()
+        # Qt's toolchain sets CMAKE_SYSTEM_PROCESSOR=arm64 but does not select
+        # the Visual Studio platform. Without ARM64, try_compile uses x64 cl.
+        if(CMAKE_GENERATOR MATCHES "Visual Studio" AND
+           _scwx_qt_root MATCHES "[Aa][Rr][Mm]64" AND
+           NOT CMAKE_GENERATOR_PLATFORM)
+            set(CMAKE_GENERATOR_PLATFORM ARM64 CACHE STRING
+                "Visual Studio target platform")
+            message(STATUS "Using Visual Studio platform ARM64")
+        endif()
         file(GLOB _scwx_host_tools_dirs "${_scwx_qt_host}/lib/cmake/Qt6*Tools")
         foreach(_scwx_tools_dir IN LISTS _scwx_host_tools_dirs)
             get_filename_component(_scwx_tools_name "${_scwx_tools_dir}" NAME)
@@ -120,6 +129,21 @@ function(scwx_windeployqt_qtpaths_options out_var)
         endif()
         message(STATUS "windeployqt --qtpaths ${_qtpaths}")
         list(APPEND _opts --qtpaths "${_qtpaths}")
+
+        # Target-prefix windeployqt.exe is ARM64 and will not run on an x64 host.
+        set(_host_wdq "")
+        foreach(_candidate IN ITEMS windeployqt.exe windeployqt6.exe)
+            if (EXISTS "${QT_HOST_PATH}/bin/${_candidate}")
+                set(_host_wdq "${QT_HOST_PATH}/bin/${_candidate}")
+                break()
+            endif()
+        endforeach()
+        if (NOT _host_wdq)
+            message(FATAL_ERROR
+                "Host windeployqt not found under ${QT_HOST_PATH}/bin")
+        endif()
+        message(STATUS "Using host windeployqt: ${_host_wdq}")
+        set(WINDEPLOYQT_EXECUTABLE "${_host_wdq}" PARENT_SCOPE)
     endif()
     set(${out_var} ${_opts} PARENT_SCOPE)
 endfunction()

--- a/tools/setup-windows-vs2026-arm64-debug.bat
+++ b/tools/setup-windows-vs2026-arm64-debug.bat
@@ -1,0 +1,29 @@
+@set script_dir=%~dp0
+
+:: Configure variables for cross-compilation
+@set build_dir=%script_dir%\..\build-debug-vs2026-arm64
+@set build_type=Debug
+@set conan_profile=scwx-windows_vs2026_armv8
+@set conan_build_profile=scwx-windows_vs2026_x64
+@set generator=Visual Studio 18 2026
+@set qt_base=C:/Qt
+@set qt_arch=msvc2022_arm64
+@set qt_host_arch=msvc2022_64
+@set venv_path=%script_dir%\..\.venv
+
+:: Assign user-specified build directory
+@if not "%~1"=="" set build_dir=%~f1
+
+:: Assign user-specified Python Virtual Environment
+@if not "%~2"=="" (
+    if /i "%~2"=="none" (
+        set venv_path=
+    ) else (
+        set venv_path=%~f2
+    )
+)
+
+:: Perform common setup
+@call %script_dir%\lib\setup-common.bat
+
+@pause

--- a/tools/setup-windows-vs2026-arm64-debug.bat
+++ b/tools/setup-windows-vs2026-arm64-debug.bat
@@ -6,6 +6,7 @@
 @set conan_profile=scwx-windows_vs2026_armv8
 @set conan_build_profile=scwx-windows_vs2026_x64
 @set generator=Visual Studio 18 2026
+@set vs_platform=ARM64
 @set qt_base=C:/Qt
 @set qt_arch=msvc2022_arm64
 @set qt_host_arch=msvc2022_64

--- a/tools/setup-windows-vs2026-arm64-multi.bat
+++ b/tools/setup-windows-vs2026-arm64-multi.bat
@@ -1,0 +1,28 @@
+@set script_dir=%~dp0
+
+:: Configure variables for cross-compilation
+@set build_dir=%script_dir%\..\build-vs2026-arm64
+@set conan_profile=scwx-windows_vs2026_armv8
+@set conan_build_profile=scwx-windows_vs2026_x64
+@set generator=Visual Studio 18 2026
+@set qt_base=C:/Qt
+@set qt_arch=msvc2022_arm64
+@set qt_host_arch=msvc2022_64
+@set venv_path=%script_dir%\..\.venv
+
+:: Assign user-specified build directory
+@if not "%~1"=="" set build_dir=%~f1
+
+:: Assign user-specified Python Virtual Environment
+@if not "%~2"=="" (
+    if /i "%~2"=="none" (
+        set venv_path=
+    ) else (
+        set venv_path=%~f2
+    )
+)
+
+:: Perform common setup
+@call %script_dir%\lib\setup-common.bat
+
+@pause

--- a/tools/setup-windows-vs2026-arm64-multi.bat
+++ b/tools/setup-windows-vs2026-arm64-multi.bat
@@ -5,6 +5,7 @@
 @set conan_profile=scwx-windows_vs2026_armv8
 @set conan_build_profile=scwx-windows_vs2026_x64
 @set generator=Visual Studio 18 2026
+@set vs_platform=ARM64
 @set qt_base=C:/Qt
 @set qt_arch=msvc2022_arm64
 @set qt_host_arch=msvc2022_64

--- a/tools/setup-windows-vs2026-arm64-release.bat
+++ b/tools/setup-windows-vs2026-arm64-release.bat
@@ -1,0 +1,29 @@
+@set script_dir=%~dp0
+
+:: Configure variables for cross-compilation
+@set build_dir=%script_dir%\..\build-release-vs2026-arm64
+@set build_type=Release
+@set conan_profile=scwx-windows_vs2026_armv8
+@set conan_build_profile=scwx-windows_vs2026_x64
+@set generator=Visual Studio 18 2026
+@set qt_base=C:/Qt
+@set qt_arch=msvc2022_arm64
+@set qt_host_arch=msvc2022_64
+@set venv_path=%script_dir%\..\.venv
+
+:: Assign user-specified build directory
+@if not "%~1"=="" set build_dir=%~f1
+
+:: Assign user-specified Python Virtual Environment
+@if not "%~2"=="" (
+    if /i "%~2"=="none" (
+        set venv_path=
+    ) else (
+        set venv_path=%~f2
+    )
+)
+
+:: Perform common setup
+@call %script_dir%\lib\setup-common.bat
+
+@pause

--- a/tools/setup-windows-vs2026-arm64-release.bat
+++ b/tools/setup-windows-vs2026-arm64-release.bat
@@ -6,6 +6,7 @@
 @set conan_profile=scwx-windows_vs2026_armv8
 @set conan_build_profile=scwx-windows_vs2026_x64
 @set generator=Visual Studio 18 2026
+@set vs_platform=ARM64
 @set qt_base=C:/Qt
 @set qt_arch=msvc2022_arm64
 @set qt_host_arch=msvc2022_64


### PR DESCRIPTION
Currently cannot native compile due to no Strawberry Perl support for Arm.

~~Currently cannot cross compile due to https://github.com/conan-io/conan-center-index/issues/14279~~

Current state:
- Cross compile is successful
- cmake install / Qt deployment does not work, because it tries to pull in x64 libraries instead of arm64 (Qt deployment tool is a host tool that doesn't grab the cross compiled libraries). A manual patch of the deployment fixes this
- The Supercell Wx setup dialog displays
- In a VMware Fusion environment, Windows 11 on Arm, Qt fails to create an OpenGL context. The main window is a blank white panel.
  - Functional on Surface Pro 11
  - Functional when disabling 3D acceleration

```
Failed to load opengl32sw (The specified module could not be found.)
QOpenGLWidget: Failed to create context
```

opengl32sw.dll, along with a couple other DLLs, are not available in the arm64 Qt release. It translates OpenGL calls when OpenGL support is lacking on the host system. Microsoft has an OpenGL compatibility pack to provide OpenGL 3.3 support, but installing this didn't seem to make a difference.