### PR TITLE
Add wayland plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         sudo apt-get install doxygen \
                              libfuse2 \
                              ninja-build \
+                             wayland-protocols \
                              ${{ matrix.compiler_packages }}
 
     - name: Setup Python Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
                              libfuse2 \
                              ninja-build \
                              wayland-protocols \
+                             libwayland-dev \
+                             libwayland-egl-backend-dev \
                              ${{ matrix.compiler_packages }}
 
     - name: Setup Python Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
         cd plugins/
         mkdir -p sqldrivers/
         cp "${RUNNER_WORKSPACE}/Qt/${{ matrix.qt_version }}/${{ matrix.qt_arch_dir }}/plugins/sqldrivers/libqsqlite.so" sqldrivers/
+        mkdir -p platforms/
+        cp ${RUNNER_WORKSPACE}/Qt/${{ matrix.qt_version }}/${{ matrix.qt_arch_dir }}/plugins/platforms/libqwayland* platforms/
         cd ..
         popd
         tar -czf supercell-wx-${{ matrix.artifact_suffix }}.tar.gz supercell-wx/

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -65,6 +65,9 @@ jobs:
         sudo apt-get install doxygen \
                              libfuse2 \
                              ninja-build \
+                             wayland-protocols \
+                             libwayland-dev \
+                             libwayland-egl-backend-dev \
                              ${{ matrix.compiler_packages }}
 
     - name: Setup Python Environment

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -34,6 +34,7 @@ find_package(QT NAMES Qt6
                         Svg
                         Widgets
                         Sql
+                        WaylandClient
              REQUIRED)
 
 find_package(Qt${QT_VERSION_MAJOR}
@@ -48,6 +49,7 @@ find_package(Qt${QT_VERSION_MAJOR}
                         Svg
                         Widgets
                         Sql
+                        WaylandClient
              REQUIRED)
 
 set(SRC_EXE_MAIN source/scwx/qt/main/main.cpp)
@@ -696,6 +698,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::Positioning
                                      Qt${QT_VERSION_MAJOR}::SerialPort
                                      Qt${QT_VERSION_MAJOR}::Svg
+                                     Qt${QT_VERSION_MAJOR}::WaylandClient
                                      Boost::json
                                      Boost::timer
                                      Boost::atomic

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -34,7 +34,6 @@ find_package(QT NAMES Qt6
                         Svg
                         Widgets
                         Sql
-                        WaylandClient
              REQUIRED)
 
 find_package(Qt${QT_VERSION_MAJOR}
@@ -49,7 +48,6 @@ find_package(Qt${QT_VERSION_MAJOR}
                         Svg
                         Widgets
                         Sql
-                        WaylandClient
              REQUIRED)
 
 set(SRC_EXE_MAIN source/scwx/qt/main/main.cpp)
@@ -698,7 +696,6 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::Positioning
                                      Qt${QT_VERSION_MAJOR}::SerialPort
                                      Qt${QT_VERSION_MAJOR}::Svg
-                                     Qt${QT_VERSION_MAJOR}::WaylandClient
                                      Boost::json
                                      Boost::timer
                                      Boost::atomic

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -688,6 +688,16 @@ if (MSVC)
 else()
     target_compile_options(scwx-qt PRIVATE "$<$<CONFIG:Release>:-g>")
     target_compile_options(supercell-wx PRIVATE "$<$<CONFIG:Release>:-g>")
+
+    # Add wayland client packages
+    find_package(QT NAMES Qt6
+                 COMPONENTS WaylandClient
+                 REQUIRED)
+
+    find_package(Qt${QT_VERSION_MAJOR}
+                 COMPONENTS WaylandClient
+                 REQUIRED)
+    target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::WaylandClient)
 endif()
 
 target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets


### PR DESCRIPTION
Adds needed files for Supercell Wx to work natively on Wayland. This does not effect X11 support. I believe this removes the requirement for xcb-cursors on Wayland. Supercell Wx can be launched using xwayland using `-platform xcb` or `QPA_PLATFORM=xcb`. This works on both the executable and AppImage. 