### PR TITLE
Fix level 2 settings big buttons

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -1549,8 +1549,9 @@ void MainWindowImpl::UpdateRadarProductSettings()
 {
    if (activeMap_->GetRadarProductGroup() == common::RadarProductGroup::Level2)
    {
-      level2SettingsWidget_->UpdateSettings(activeMap_);
       level2SettingsGroup_->setVisible(true);
+      // This should be done after setting visible for correct sizing
+      level2SettingsWidget_->UpdateSettings(activeMap_);
    }
    else
    {


### PR DESCRIPTION
The level 2 settings widget elevation buttons were being added when not visible. This was causing issues with the sizing of buttons when it went form having no buttons to having buttons. This is fixed by swapping the `setVisible` and `UpdateSettings` call when radar product selection occurs.