### PR TITLE
Add support statement for NixOS 25.05+ to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supercell Wx supports the following 64-bit operating systems:
   - Fedora Linux 34+
   - openSUSE Tumbleweed
   - Ubuntu 22.04+
+  - NixOS 25.05+
   - Most distributions supporting the GCC Standard C++ Library 11+
  
 ## Linux Dependencies


### PR DESCRIPTION
Supercell Wx was added to [nixpkgs](https://github.com/NixOS/nixpkgs) some time ago, but is now part of an official NixOS release with [25.05](https://github.com/NixOS/nixpkgs/tree/25.05l). This PR updates the README to reflect this.