### PR TITLE
Add a Flatpak Builld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
                              wayland-protocols \
                              libwayland-dev \
                              libwayland-egl-backend-dev \
+                             flatpak \
+                             flatpak-builder \
                              ${{ matrix.compiler_packages }}
 
     - name: Setup Python Environment
@@ -261,7 +263,8 @@ jobs:
     - name: Build AppImage (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       env:
-        APPIMAGE_DIR: ${{ github.workspace }}/supercell-wx/
+        INSTALL_DIR: ${{ github.workspace }}/supercell-wx/
+        APPIMAGE_DIR: ${{ github.workspace }}/supercell-wx-appimage/
         LDAI_UPDATE_INFORMATION: gh-releases-zsync|dpaulat|supercell-wx|latest|*${{ matrix.appimage_arch }}.AppImage.zsync
         LDAI_OUTPUT: supercell-wx-${{ env.SCWX_VERSION }}-${{ matrix.appimage_arch }}.AppImage
         LINUXDEPLOY_OUTPUT_APP_NAME: supercell-wx
@@ -272,6 +275,7 @@ jobs:
         chmod +x linuxdeploy-${{ matrix.appimage_arch }}.AppImage
         cp "${{ github.workspace }}/source/scwx-qt/res/icons/scwx-256.png" supercell-wx.png
         cp "${{ github.workspace }}/source/scwx-qt/res/linux/supercell-wx.desktop" .
+        cp -r "${{ env.INSTALL_DIR }}" "${{ env.APPIMAGE_DIR }}"
         pushd "${{ env.APPIMAGE_DIR }}"
         mkdir -p usr/
         mv bin/ usr/
@@ -288,6 +292,38 @@ jobs:
       with:
         name: supercell-wx-appimage-${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/*-${{ matrix.appimage_arch }}.AppImage*
+
+    - name: Build FlatPak (Linux)
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      env:
+        INSTALL_DIR: ${{ github.workspace }}/supercell-wx/
+        FLATPAK_DIR: ${{ github.workspace }}/supercell-wx-flatpak/
+      shell: bash
+      run: |
+        cp -r ${{ env.INSTALL_DIR }} ${{ env.FLATPAK_DIR }}
+        # Copy krb5 libraries to flatpak
+        cp /usr/lib/*/libkrb5.so* \
+           /usr/lib/*/libkrb5support.so* \
+           /usr/lib/*/libgssapi_krb5.so* \
+           /usr/lib/*/libk5crypto.so* \
+           /usr/lib/*/libkeyutils.so* \
+           ${{ env.FLATPAK_DIR }}/lib
+
+        flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak-builder --force-clean \
+            --user \
+            --install-deps-from=flathub \
+            --repo=flatpak-repo \
+            --install flatpak-build \
+            ${{ github.workspace }}/source/tools/net.supercellwx.app.yml
+        flatpak build-bundle flatpak-repo supercell-wx.flatpak net.supercellwx.app
+
+    - name: Upload FlatPak (Linux)
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: supercell-wx-flatpak-${{ matrix.artifact_suffix }}
+        path: ${{ github.workspace }}/supercell-wx.flatpak
 
     - name: Test Supercell Wx
       working-directory: ${{ github.workspace }}/build

--- a/scwx-qt/res/linux/net.supercellwx.app.desktop
+++ b/scwx-qt/res/linux/net.supercellwx.app.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Supercell Wx
+Comment=Weather Radar and Data Viewer
+Exec=supercell-wx
+Icon=net.supercellwx.app.png
+Categories=Network;Science;

--- a/scwx-qt/source/scwx/qt/manager/log_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/log_manager.cpp
@@ -1,6 +1,8 @@
 #include <scwx/qt/manager/log_manager.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <cstdlib>
+#include <ctime>
 #include <filesystem>
 #include <map>
 #include <ranges>
@@ -57,6 +59,14 @@ void LogManager::InitializeLogFile()
       QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
          .toStdString();
    p->pid_     = boost::this_process::get_id();
+   if (p->pid_ == 2)
+   {
+      // The pid == 2 means that this is likely a flatpak. We assign a random
+      // number in this case to avoid overlap, scince it is always 2 in a
+      // flatpak
+      std::srand(std::time({}));
+      p->pid_ = std::rand();
+   }
    p->logFile_ = fmt::format("{}/supercell-wx.{}.log", p->logPath_, p->pid_);
 
    // Create log directory if it doesn't exist

--- a/tools/net.supercellwx.app.yml
+++ b/tools/net.supercellwx.app.yml
@@ -31,6 +31,8 @@ finish-args:
   - --socket=wayland
   # GPU acceleration if needed
   - --device=dri
+  # Needs access to serial port devices
+  - --device=serial
   # Needs to talk to the network:
   - --share=network
   # Needs to save files locally

--- a/tools/net.supercellwx.app.yml
+++ b/tools/net.supercellwx.app.yml
@@ -1,0 +1,37 @@
+id: net.supercellwx.app
+version: '0.4.9'
+runtime: "org.freedesktop.Platform"
+runtime-version: "23.08"
+sdk: "org.freedesktop.Sdk"
+command: supercell-wx
+modules:
+  - name: supercell-wx
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 net.supercellwx.app.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 scwx-256.png /app/share/icons/hicolor/256x256/apps/net.supercellwx.app.png
+      - install -Dm644 scwx-64.png /app/share/icons/hicolor/64x64/apps/net.supercellwx.app.png
+      - rm net.supercellwx.app.desktop scwx-256.png scwx-64.png
+      - cp -r * /app/
+    sources:
+      - type: dir
+        path: ../../supercell-wx-flatpak
+      - type: file
+        path: ../scwx-qt/res/linux/net.supercellwx.app.desktop
+      - type: file
+        path: ../scwx-qt/res/icons/scwx-256.png
+      - type: file
+        path: ../scwx-qt/res/icons/scwx-64.png
+
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=fallback-x11
+  # Wayland access
+  - --socket=wayland
+  # GPU acceleration if needed
+  - --device=dri
+  # Needs to talk to the network:
+  - --share=network
+  # Needs to save files locally
+  - --filesystem=xdg-documents

--- a/tools/net.supercellwx.app.yml
+++ b/tools/net.supercellwx.app.yml
@@ -30,9 +30,7 @@ finish-args:
   # Wayland access
   - --socket=wayland
   # GPU acceleration if needed
-  - --device=dri
-  # Needs access to serial port devices
-  - --device=serial
+  - --device=all
   # Needs to talk to the network:
   - --share=network
   # Needs to save files locally


### PR DESCRIPTION
This builds a Flatpak for Supercell Wx. It does not build in the Flatpak environment and instead uses the normal build files similar to how the AppImage was built. There are a few notes below.
Fix for #434

1. Settings files end up in a different location (`~/.var/app/net.supercellwx.app/data/Supercell\ Wx`) (may be worth documenting moving settings over, or adding the ability to export/import settings etc.)
1. The log files end up in a different location (`~/.var/app/net.supercellwx.app/data/Supercell\ Wx`)
1. It is always launched with PID 2 (Flatpaks run in containers), so the logs end up something like `supercell-wx.2.1.log`. 
1. I am not sure if there is a way to get crash dumps from the flatpak.
1. There is a manually generated list of library files that are being copied from the OS into the flatpak.
    1. Should these files be compiled instead of copied from the host OS?
    1. Is there an automated way of generating the list?  

## Installing
1. Download and unzip the zip for the correct build.
1. Install flatpak
```bash
$ sudo apt install flatpak
$ flatpak remote-add --if-not-exists [--user] flathub https://flathub.org/repo/flathub.flatpakrepo
$ flatpak install [--user] flathub org.freedesktop.Platform/x86_64/23.08
```
1. Install the Supercell Wx flatpak with `[sudo] flatpak install supercell-wx.flatpak`
1. Run with `flatpak run net.supercellwx.app` or from a flatpak plugin or launcher (`gnome-software-plugin-flatpak` or `kde-config-flatpak`)