### PR TITLE
Disable Wayland platform plugin on Nvidia

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main.cpp
+++ b/scwx-qt/source/scwx/qt/main/main.cpp
@@ -258,11 +258,11 @@ OverrideDefaultStyle([[maybe_unused]] const std::vector<std::string>& args)
 #endif
 }
 
-constexpr std::string NVIDIA_ID = "0x10de";
-static void           OverridePlatform()
+static void OverridePlatform()
 {
 #if defined(__linux__)
-   namespace fs = std::filesystem;
+   static const std::string NVIDIA_ID = "0x10de";
+   namespace fs                       = std::filesystem;
    for (const auto& entry : fs::directory_iterator("/sys/class/drm"))
    {
       if (!entry.is_directory() ||

--- a/scwx-qt/source/scwx/qt/main/main.cpp
+++ b/scwx-qt/source/scwx/qt/main/main.cpp
@@ -19,6 +19,8 @@
 #include <scwx/util/logger.hpp>
 #include <scwx/util/threads.hpp>
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -42,6 +44,7 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 
 static void ConfigureTheme(const std::vector<std::string>& args);
 static void OverrideDefaultStyle(const std::vector<std::string>& args);
+static void OverridePlatform();
 
 int main(int argc, char* argv[])
 {
@@ -51,6 +54,8 @@ int main(int argc, char* argv[])
    {
       args.push_back(argv[i]);
    }
+
+   OverridePlatform();
 
    // Initialize logger
    auto& logManager = scwx::qt::manager::LogManager::Instance();
@@ -249,6 +254,35 @@ OverrideDefaultStyle([[maybe_unused]] const std::vector<std::string>& args)
    if (!hasStyleArgument)
    {
       QApplication::setStyle("windowsvista");
+   }
+#endif
+}
+
+constexpr std::string NVIDIA_ID = "0x10de";
+static void           OverridePlatform()
+{
+#if defined(__linux__)
+   namespace fs = std::filesystem;
+   for (const auto& entry : fs::directory_iterator("/sys/class/drm"))
+   {
+      if (!entry.is_directory() ||
+          !entry.path().filename().string().starts_with("card"))
+      {
+         continue;
+      }
+
+      auto          vendorPath = entry.path() / "device" / "vendor";
+      std::ifstream vendorFile(vendorPath);
+      std::string   vendor;
+      if (vendorFile && std::getline(vendorFile, vendor))
+      {
+         if (vendor == NVIDIA_ID)
+         {
+            // Force xcb on NVIDIA
+            setenv("QT_QPA_PLATFORM", "xcb", 1);
+            return;
+         }
+      }
    }
 #endif
 }


### PR DESCRIPTION
If any GPU is Nvidia (and [I think] has drivers loaded), then this should revert it back to XWayland to avoid crashes.