### PR TITLE
Location Marker Hotkey Label

### DIFF
--- a/scwx-qt/source/scwx/qt/ui/marker_settings_widget.ui
+++ b/scwx-qt/source/scwx/qt/ui/marker_settings_widget.ui
@@ -14,6 +14,33 @@
    <string>Frame</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="hotkeyLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+      </font>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::TextFormat::PlainText</enum>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTreeView" name="markerView">
      <property name="alternatingRowColors">
@@ -34,7 +61,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>6</number>
       </property>
       <property name="rightMargin">
        <number>0</number>


### PR DESCRIPTION
The ability to add and edit location markers using hotkeys is not readily visible to the user.  Add a label to the location marker settings widget to indicate the existence of hotkeys for adding/editing location markers.
<img width="715" height="633" alt="image" src="https://github.com/user-attachments/assets/7237e30d-0a23-4efa-b5b3-84c0306eed12" />
