### PR TITLE
Switch alert clicks to mouse button release

### DIFF
--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -883,7 +883,7 @@ void AlertLayer::Impl::HandleGeoLinesEvent(
 
    switch (ev->type())
    {
-   case QEvent::Type::MouseButtonPress:
+   case QEvent::Type::MouseButtonRelease:
    {
       auto it = segmentsByLine_.find(di);
       if (it != segmentsByLine_.cend())


### PR DESCRIPTION
When moving the map it is easy to accidentally click an alert, causing the alert window to pop, interrupting the movement. This changes the alert click action to mouse release. Intentionally clicking an alert feels mostly the same. Accidentally triggering the alert window is rarer, and when it does happen, does not interrupt the intended movement. Given the small difference when intentionally using this feature, I did not add this as a setting. That can be changed if there is a reason to have it on mouse release.

Based on feedback in Discord. https://discord.com/channels/1021112836316995715/1381499185425154068