### PR TITLE
Level 2 AWS Bucket Name Update

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1272,6 +1272,11 @@ void RadarProductManagerImpl::PopulateLevel2ProductTimes(
                         level2ProductRecordMutex_,
                         time,
                         update);
+   PopulateProductTimes(level2ChunksProviderManager_,
+                        level2ProductRecords_,
+                        level2ProductRecordMutex_,
+                        time,
+                        update);
 }
 
 void RadarProductManagerImpl::PopulateLevel3ProductTimes(

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -118,7 +118,7 @@ public:
    void RefreshData();
    void RefreshDataSync();
 
-   boost::asio::thread_pool providerThreadPool_ {1u};
+   boost::asio::thread_pool providerThreadPool_ {2u};
 
    const std::string               radarId_;
    const common::RadarProductGroup group_;

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -55,6 +55,9 @@ public:
       animationTimer_.cancel();
       animationTimerLock.unlock();
 
+      selectThreadPool_.stop();
+      playThreadPool_.stop();
+
       selectThreadPool_.join();
       playThreadPool_.join();
    }

--- a/wxdata/source/scwx/provider/aws_level2_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_level2_data_provider.cpp
@@ -18,7 +18,7 @@ static const std::string logPrefix_ =
    "scwx::provider::aws_level2_data_provider";
 static const auto logger_ = util::Logger::Create(logPrefix_);
 
-static const std::string kDefaultBucketName_ = "noaa-nexrad-level2";
+static const std::string kDefaultBucketName_ = "unidata-nexrad-level2";
 static const std::string kDefaultRegion_     = "us-east-1";
 
 class AwsLevel2DataProvider::Impl


### PR DESCRIPTION
Level 2 stability fixes, including updating AWS bucket name:

> The NEXRAD Level II archive data is moving to a new bucket: unidata-nexrad-level2 and SNS topic: arn:aws:sns:us-east-1:684042711724:NewNEXRADLevel2Archive. The old bucket and SNS topic are now deprecated and will no longer be available starting September 1, 2025.

No PCN was given, and the change was unexpected. https://registry.opendata.aws/noaa-nexrad/

The change was noted on the Unidata blog in August: https://www.unidata.ucar.edu/blogs/news/entry/important-changes-to-noaa-nexrad