### PR TITLE
Elevation cuts needs protected by mutex

### DIFF
--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -8,6 +8,9 @@
 #include <scwx/util/threads.hpp>
 #include <scwx/util/time.hpp>
 
+#include <atomic>
+#include <mutex>
+
 #include <boost/range/irange.hpp>
 #include <boost/timer/timer.hpp>
 
@@ -160,10 +163,12 @@ public:
 
    float                    latitude_;
    float                    longitude_;
-   float                    elevationCut_;
+   std::atomic<float>       elevationCut_;
    std::vector<float>       elevationCuts_;
    units::kilometers<float> range_;
    uint16_t                 vcp_;
+
+   std::mutex elevationCutsMutex_ {};
 
    std::chrono::system_clock::time_point sweepTime_;
 
@@ -368,6 +373,7 @@ std::string Level2ProductView::GetRadarProductName() const
 
 std::vector<float> Level2ProductView::GetElevationCuts() const
 {
+   const std::unique_lock lock {p->elevationCutsMutex_};
    return p->elevationCuts_;
 }
 
@@ -565,10 +571,16 @@ void Level2ProductView::ComputeSweep()
    std::shared_ptr<wsr88d::rda::ElevationScan> radarData;
    std::chrono::system_clock::time_point       requestedTime {selected_time()};
    types::RadarProductLoadStatus               loadStatus {};
+
+   std::vector<float> newElevationCuts {};
    std::tie(
-      radarData, p->elevationCut_, p->elevationCuts_, std::ignore, loadStatus) =
+      radarData, p->elevationCut_, newElevationCuts, std::ignore, loadStatus) =
       radarProductManager->GetLevel2Data(
          p->dataBlockType_, p->selectedElevation_, requestedTime);
+
+   std::unique_lock elevationCutsLock {p->elevationCutsMutex_};
+   p->elevationCuts_ = newElevationCuts;
+   elevationCutsLock.unlock();
 
    set_load_status(loadStatus);
 


### PR DESCRIPTION
- If elevation cuts is read while GetLevel2Data is being called from ComputeSweep, the application will crash.
- Additionally, the elevationCut_ variable should probably be made atomic.