### PR TITLE
Placefile Images with X/Y Coordinates

### DIFF
--- a/scwx-qt/gl/texture2d_array.vert
+++ b/scwx-qt/gl/texture2d_array.vert
@@ -8,6 +8,7 @@ layout (location = 2) in vec3  aTexCoord;
 layout (location = 3) in vec4  aModulate;
 layout (location = 4) in float aAngleDeg;
 layout (location = 5) in int   aDisplayed;
+layout (location = 6) in vec2  aAnchor;
 
 uniform mat4 uMVPMatrix;
 
@@ -40,9 +41,13 @@ void main()
    color          = aModulate;
 
    // Rotate clockwise
-   float angle  = aAngleDeg * DEG2RAD;
-   mat2  rotate = mat2(cos(angle), -sin(angle),
-                       sin(angle), cos(angle));
+   float angle   = aAngleDeg * DEG2RAD;
+   mat2  rotate  = mat2(cos(angle), -sin(angle),
+                        sin(angle), cos(angle));
+   vec2 pos      = aVertex + rotate * aXYOffset;
+   vec4 worldPos = uMVPMatrix * vec4(pos, 0.0f, 1.0f);
 
-   gl_Position = uMVPMatrix * vec4(aVertex + rotate * aXYOffset, 0.0f, 1.0f);
+   worldPos.xy += aAnchor;
+
+   gl_Position = worldPos;
 }

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -79,6 +79,7 @@ set(HDR_GL_DRAW source/scwx/qt/gl/draw/draw_item.hpp
                 source/scwx/qt/gl/draw/linked_vectors.hpp
                 source/scwx/qt/gl/draw/placefile_icons.hpp
                 source/scwx/qt/gl/draw/placefile_images.hpp
+                source/scwx/qt/gl/draw/placefile_images_xy.hpp
                 source/scwx/qt/gl/draw/placefile_lines.hpp
                 source/scwx/qt/gl/draw/placefile_polygons.hpp
                 source/scwx/qt/gl/draw/placefile_text.hpp
@@ -91,6 +92,7 @@ set(SRC_GL_DRAW source/scwx/qt/gl/draw/draw_item.cpp
                 source/scwx/qt/gl/draw/linked_vectors.cpp
                 source/scwx/qt/gl/draw/placefile_icons.cpp
                 source/scwx/qt/gl/draw/placefile_images.cpp
+                source/scwx/qt/gl/draw/placefile_images_xy.cpp
                 source/scwx/qt/gl/draw/placefile_lines.cpp
                 source/scwx/qt/gl/draw/placefile_polygons.cpp
                 source/scwx/qt/gl/draw/placefile_text.cpp
@@ -239,6 +241,7 @@ set(HDR_TYPES source/scwx/qt/types/alert_types.hpp
               source/scwx/qt/types/map_types.hpp
               source/scwx/qt/types/marker_types.hpp
               source/scwx/qt/types/media_types.hpp
+              source/scwx/qt/types/placefile_types.hpp
               source/scwx/qt/types/qt_types.hpp
               source/scwx/qt/types/radar_product_record.hpp
               source/scwx/qt/types/radar_product_types.hpp
@@ -257,6 +260,7 @@ set(SRC_TYPES source/scwx/qt/types/alert_types.cpp
               source/scwx/qt/types/location_types.cpp
               source/scwx/qt/types/map_types.cpp
               source/scwx/qt/types/media_types.cpp
+              source/scwx/qt/types/placefile_types.cpp
               source/scwx/qt/types/qt_types.cpp
               source/scwx/qt/types/radar_product_record.cpp
               source/scwx/qt/types/radar_site_types.cpp

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.cpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.cpp
@@ -1,4 +1,4 @@
-#include <scwx/qt/gl/draw/placefile_images.hpp>
+#include <scwx/qt/gl/draw/placefile_images_xy.hpp>
 #include <scwx/qt/types/placefile_types.hpp>
 #include <scwx/qt/util/maplibre.hpp>
 #include <scwx/qt/util/texture_atlas.hpp>
@@ -9,45 +9,34 @@
 #include <QUrl>
 #include <boost/unordered/unordered_flat_map.hpp>
 
-namespace scwx
-{
-namespace qt
-{
-namespace gl
-{
-namespace draw
+namespace scwx::qt::gl::draw
 {
 
-static const std::string logPrefix_ = "scwx::qt::gl::draw::placefile_images";
+static const std::string logPrefix_ = "scwx::qt::gl::draw::placefile_images_xy";
 static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 
-static constexpr std::size_t kNumRectangles        = 1;
-static constexpr std::size_t kNumTriangles         = kNumRectangles * 2;
-static constexpr std::size_t kVerticesPerTriangle  = 3;
-static constexpr std::size_t kVerticesPerRectangle = kVerticesPerTriangle * 2;
-static constexpr std::size_t kPointsPerVertex      = 8;
-static constexpr std::size_t kPointsPerTexCoord    = 3;
+static constexpr std::size_t kNumRectangles       = 1;
+static constexpr std::size_t kNumTriangles        = kNumRectangles * 2;
+static constexpr std::size_t kVerticesPerTriangle = 3;
+static constexpr std::size_t kPointsPerVertex     = 8;
+static constexpr std::size_t kPointsPerTexCoord   = 3;
 static constexpr std::size_t kImageBufferLength =
    kNumTriangles * kVerticesPerTriangle * kPointsPerVertex;
 static constexpr std::size_t kTextureBufferLength =
    kNumTriangles * kVerticesPerTriangle * kPointsPerTexCoord;
 
-// Threshold, start time, end time
-static constexpr std::size_t kIntegersPerVertex_ = 3;
-
-class PlacefileImages::Impl
+class PlacefileImagesXY::Impl
 {
 public:
-   explicit Impl(const std::shared_ptr<GlContext>& context) :
-       context_ {context},
-       shaderProgram_ {nullptr},
-       vao_ {GL_INVALID_INDEX},
-       vbo_ {GL_INVALID_INDEX},
-       numVertices_ {0}
+   explicit Impl(const std::shared_ptr<GlContext>& context) : context_ {context}
    {
    }
+   ~Impl() = default;
 
-   ~Impl() {}
+   Impl(const Impl&)             = delete;
+   Impl& operator=(const Impl&)  = delete;
+   Impl(const Impl&&)            = delete;
+   Impl& operator=(const Impl&&) = delete;
 
    void UpdateBuffers();
    void UpdateTextureBuffer();
@@ -58,9 +47,6 @@ public:
    std::string baseUrl_ {};
 
    bool dirty_ {false};
-   bool thresholded_ {false};
-
-   std::chrono::system_clock::time_point selectedTime_ {};
 
    std::mutex imageMutex_;
 
@@ -69,68 +55,45 @@ public:
    boost::unordered_flat_map<std::string, types::PlacefileImageInfo>
       newImageFiles_ {};
 
-   std::vector<std::shared_ptr<const gr::Placefile::ImageDrawItem>>
+   std::vector<std::shared_ptr<const gr::Placefile::ImageXYDrawItem>>
       currentImageList_ {};
-   std::vector<std::shared_ptr<const gr::Placefile::ImageDrawItem>>
+   std::vector<std::shared_ptr<const gr::Placefile::ImageXYDrawItem>>
       newImageList_ {};
 
    std::vector<float> currentImageBuffer_ {};
-   std::vector<GLint> currentIntegerBuffer_ {};
    std::vector<float> newImageBuffer_ {};
-   std::vector<GLint> newIntegerBuffer_ {};
 
    std::vector<float> textureBuffer_ {};
 
-   std::shared_ptr<ShaderProgram> shaderProgram_;
+   std::shared_ptr<ShaderProgram> shaderProgram_ {nullptr};
 
    GLint uMVPMatrixLocation_ {static_cast<GLint>(GL_INVALID_INDEX)};
-   GLint uMapMatrixLocation_ {static_cast<GLint>(GL_INVALID_INDEX)};
-   GLint uOriginLatLongLocation_ {static_cast<GLint>(GL_INVALID_INDEX)};
-   GLint uMapDistanceLocation_ {static_cast<GLint>(GL_INVALID_INDEX)};
-   GLint uSelectedTimeLocation_ {static_cast<GLint>(GL_INVALID_INDEX)};
 
-   GLuint                vao_;
-   std::array<GLuint, 3> vbo_;
+   GLuint                vao_ {GL_INVALID_INDEX};
+   std::array<GLuint, 2> vbo_ {GL_INVALID_INDEX};
 
-   GLsizei numVertices_;
+   GLsizei numVertices_ {0};
 };
 
-PlacefileImages::PlacefileImages(const std::shared_ptr<GlContext>& context) :
+PlacefileImagesXY::PlacefileImagesXY(
+   const std::shared_ptr<GlContext>& context) :
     DrawItem(), p(std::make_unique<Impl>(context))
 {
 }
-PlacefileImages::~PlacefileImages() = default;
+PlacefileImagesXY::~PlacefileImagesXY() = default;
 
-PlacefileImages::PlacefileImages(PlacefileImages&&) noexcept = default;
-PlacefileImages&
-PlacefileImages::operator=(PlacefileImages&&) noexcept = default;
+PlacefileImagesXY::PlacefileImagesXY(PlacefileImagesXY&&) noexcept = default;
+PlacefileImagesXY&
+PlacefileImagesXY::operator=(PlacefileImagesXY&&) noexcept = default;
 
-void PlacefileImages::set_selected_time(
-   std::chrono::system_clock::time_point selectedTime)
-{
-   p->selectedTime_ = selectedTime;
-}
-
-void PlacefileImages::set_thresholded(bool thresholded)
-{
-   p->thresholded_ = thresholded;
-}
-
-void PlacefileImages::Initialize()
+void PlacefileImagesXY::Initialize()
 {
    p->shaderProgram_ = p->context_->GetShaderProgram(
-      {{GL_VERTEX_SHADER, ":/gl/geo_texture2d.vert"},
+      {{GL_VERTEX_SHADER, ":/gl/texture2d_array.vert"},
        {GL_GEOMETRY_SHADER, ":/gl/threshold.geom"},
        {GL_FRAGMENT_SHADER, ":/gl/texture2d_array.frag"}});
 
    p->uMVPMatrixLocation_ = p->shaderProgram_->GetUniformLocation("uMVPMatrix");
-   p->uMapMatrixLocation_ = p->shaderProgram_->GetUniformLocation("uMapMatrix");
-   p->uOriginLatLongLocation_ =
-      p->shaderProgram_->GetUniformLocation("uOriginLatLong");
-   p->uMapDistanceLocation_ =
-      p->shaderProgram_->GetUniformLocation("uMapDistance");
-   p->uSelectedTimeLocation_ =
-      p->shaderProgram_->GetUniformLocation("uSelectedTime");
 
    glGenVertexArrays(1, &p->vao_);
    glGenBuffers(static_cast<GLsizei>(p->vbo_.size()), p->vbo_.data());
@@ -143,7 +106,7 @@ void PlacefileImages::Initialize()
    // NOLINTBEGIN(performance-no-int-to-ptr)
    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
 
-   // aLatLong
+   // aLatLong - TODO: aVertex
    glVertexAttribPointer(0,
                          2,
                          GL_FLOAT,
@@ -182,27 +145,8 @@ void PlacefileImages::Initialize()
                          static_cast<void*>(0));
    glEnableVertexAttribArray(2);
 
-   glBindBuffer(GL_ARRAY_BUFFER, p->vbo_[2]);
-   glBufferData(GL_ARRAY_BUFFER, 0u, nullptr, GL_DYNAMIC_DRAW);
-
-   // aThreshold
-   glVertexAttribIPointer(5, //
-                          1,
-                          GL_INT,
-                          kIntegersPerVertex_ * sizeof(GLint),
-                          static_cast<void*>(0));
-   glEnableVertexAttribArray(5);
-
-   // aTimeRange
-   glVertexAttribIPointer(6, //
-                          2,
-                          GL_INT,
-                          kIntegersPerVertex_ * sizeof(GLint),
-                          reinterpret_cast<void*>(1 * sizeof(GLint)));
-   glEnableVertexAttribArray(6);
-
    // aDisplayed
-   glVertexAttribI1i(7, 1);
+   glVertexAttribI1i(5, 1);
 
    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
    // NOLINTEND(performance-no-int-to-ptr)
@@ -211,7 +155,7 @@ void PlacefileImages::Initialize()
    p->dirty_ = true;
 }
 
-void PlacefileImages::Render(
+void PlacefileImagesXY::Render(
    const QMapLibre::CustomLayerRenderParameters& params,
    bool                                          textureAtlasChanged)
 {
@@ -224,32 +168,6 @@ void PlacefileImages::Render(
       p->Update(textureAtlasChanged);
       p->shaderProgram_->Use();
       UseRotationProjection(params, p->uMVPMatrixLocation_);
-      UseMapProjection(
-         params, p->uMapMatrixLocation_, p->uOriginLatLongLocation_);
-
-      if (p->thresholded_)
-      {
-         // If thresholding is enabled, set the map distance
-         units::length::nautical_miles<float> mapDistance =
-            util::maplibre::GetMapDistance(params);
-         glUniform1f(p->uMapDistanceLocation_, mapDistance.value());
-      }
-      else
-      {
-         // If thresholding is disabled, set the map distance to 0
-         glUniform1f(p->uMapDistanceLocation_, 0.0f);
-      }
-
-      // Selected time
-      std::chrono::system_clock::time_point selectedTime =
-         (p->selectedTime_ == std::chrono::system_clock::time_point {}) ?
-            scwx::util::time::now() :
-            p->selectedTime_;
-      glUniform1i(
-         p->uSelectedTimeLocation_,
-         static_cast<GLint>(std::chrono::duration_cast<std::chrono::minutes>(
-                               selectedTime.time_since_epoch())
-                               .count()));
 
       // Interpolate texture coordinates
       glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -260,7 +178,7 @@ void PlacefileImages::Render(
    }
 }
 
-void PlacefileImages::Deinitialize()
+void PlacefileImagesXY::Deinitialize()
 {
    glDeleteVertexArrays(1, &p->vao_);
    glDeleteBuffers(static_cast<GLsizei>(p->vbo_.size()), p->vbo_.data());
@@ -270,11 +188,10 @@ void PlacefileImages::Deinitialize()
    p->currentImageList_.clear();
    p->currentImageFiles_.clear();
    p->currentImageBuffer_.clear();
-   p->currentIntegerBuffer_.clear();
    p->textureBuffer_.clear();
 }
 
-void PlacefileImages::StartImages(const std::string& baseUrl)
+void PlacefileImagesXY::StartImagesXY(const std::string& baseUrl)
 {
    p->baseUrl_ = baseUrl;
 
@@ -282,11 +199,10 @@ void PlacefileImages::StartImages(const std::string& baseUrl)
    p->newImageList_.clear();
    p->newImageFiles_.clear();
    p->newImageBuffer_.clear();
-   p->newIntegerBuffer_.clear();
 }
 
-void PlacefileImages::AddImage(
-   const std::shared_ptr<gr::Placefile::ImageDrawItem>& di)
+void PlacefileImagesXY::AddImageXY(
+   const std::shared_ptr<gr::Placefile::ImageXYDrawItem>& di)
 {
    if (di != nullptr)
    {
@@ -294,7 +210,7 @@ void PlacefileImages::AddImage(
    }
 }
 
-void PlacefileImages::FinishImages()
+void PlacefileImagesXY::FinishImagesXY()
 {
    // Update buffers
    p->UpdateBuffers();
@@ -305,25 +221,20 @@ void PlacefileImages::FinishImages()
    p->currentImageList_.swap(p->newImageList_);
    p->currentImageFiles_.swap(p->newImageFiles_);
    p->currentImageBuffer_.swap(p->newImageBuffer_);
-   p->currentIntegerBuffer_.swap(p->newIntegerBuffer_);
 
    // Clear the new buffers
    p->newImageList_.clear();
    p->newImageFiles_.clear();
    p->newImageBuffer_.clear();
-   p->newIntegerBuffer_.clear();
 
    // Mark the draw item dirty
    p->dirty_ = true;
 }
 
-void PlacefileImages::Impl::UpdateBuffers()
+void PlacefileImagesXY::Impl::UpdateBuffers()
 {
    newImageBuffer_.clear();
    newImageBuffer_.reserve(newImageList_.size() * kImageBufferLength);
-   newIntegerBuffer_.clear();
-   newIntegerBuffer_.reserve(newImageList_.size() * kVerticesPerRectangle *
-                             kIntegersPerVertex_);
    newImageFiles_.clear();
 
    // Fixed modulate color
@@ -331,6 +242,9 @@ void PlacefileImages::Impl::UpdateBuffers()
    static const float mc1 = 1.0f;
    static const float mc2 = 1.0f;
    static const float mc3 = 1.0f;
+
+   static constexpr float xOffset = 0.0f;
+   static constexpr float yOffset = 0.0f;
 
    for (auto& di : newImageList_)
    {
@@ -340,43 +254,23 @@ void PlacefileImages::Impl::UpdateBuffers()
                              std::forward_as_tuple(types::PlacefileImageInfo {
                                 di->imageFile_, baseUrl_}));
 
-      // Threshold value
-      units::length::nautical_miles<double> threshold = di->threshold_;
-      GLint thresholdValue = static_cast<GLint>(std::round(threshold.value()));
-
-      // Start and end time
-      GLint startTime =
-         static_cast<GLint>(std::chrono::duration_cast<std::chrono::minutes>(
-                               di->startTime_.time_since_epoch())
-                               .count());
-      GLint endTime =
-         static_cast<GLint>(std::chrono::duration_cast<std::chrono::minutes>(
-                               di->endTime_.time_since_epoch())
-                               .count());
-
       // Limit processing to groups of 3 (triangles)
       std::size_t numElements = di->elements_.size() - di->elements_.size() % 3;
       for (std::size_t i = 0; i < numElements; ++i)
       {
          auto& element = di->elements_[i];
 
-         // Latitude and longitude coordinates in degrees
-         const float lat = static_cast<float>(element.latitude_);
-         const float lon = static_cast<float>(element.longitude_);
-
-         // Base X/Y offsets in pixels
-         const float x = static_cast<float>(element.x_);
-         const float y = static_cast<float>(element.y_);
+         // X and Y coordinates in pixels
+         const auto x = static_cast<float>(element.x_);
+         const auto y = static_cast<float>(element.y_);
 
          newImageBuffer_.insert(newImageBuffer_.end(),
-                                {lat, lon, x, y, mc0, mc1, mc2, mc3});
-         newIntegerBuffer_.insert(newIntegerBuffer_.end(),
-                                  {thresholdValue, startTime, endTime});
+                                {x, y, xOffset, yOffset, mc0, mc1, mc2, mc3});
       }
    }
 }
 
-void PlacefileImages::Impl::UpdateTextureBuffer()
+void PlacefileImagesXY::Impl::UpdateTextureBuffer()
 {
    textureBuffer_.clear();
    textureBuffer_.reserve(currentImageList_.size() * kTextureBufferLength);
@@ -391,7 +285,7 @@ void PlacefileImages::Impl::UpdateTextureBuffer()
             currentImageFiles_.cbegin()->second :
             it->second;
 
-      const float r = static_cast<float>(image.texture_.layerId_);
+      const auto r = static_cast<float>(image.texture_.layerId_);
 
       // Limit processing to groups of 3 (triangles)
       std::size_t numElements = di->elements_.size() - di->elements_.size() % 3;
@@ -400,17 +294,17 @@ void PlacefileImages::Impl::UpdateTextureBuffer()
          auto& element = di->elements_[i];
 
          // Texture coordinates
-         const float s =
-            image.texture_.sLeft_ + (image.scaledWidth_ * element.tu_);
-         const float t =
-            image.texture_.tTop_ + (image.scaledHeight_ * element.tv_);
+         const auto s = static_cast<float>(image.texture_.sLeft_ +
+                                           (image.scaledWidth_ * element.tu_));
+         const auto t = static_cast<float>(image.texture_.tTop_ +
+                                           (image.scaledHeight_ * element.tv_));
 
          textureBuffer_.insert(textureBuffer_.end(), {s, t, r});
       }
    }
 }
 
-void PlacefileImages::Impl::Update(bool textureAtlasChanged)
+void PlacefileImagesXY::Impl::Update(bool textureAtlasChanged)
 {
    // If the texture atlas has changed
    if (dirty_ || textureAtlasChanged)
@@ -444,14 +338,6 @@ void PlacefileImages::Impl::Update(bool textureAtlasChanged)
          currentImageBuffer_.data(),
          GL_DYNAMIC_DRAW);
 
-      // Buffer threshold data
-      glBindBuffer(GL_ARRAY_BUFFER, vbo_[2]);
-      glBufferData(
-         GL_ARRAY_BUFFER,
-         static_cast<GLsizeiptr>(sizeof(GLint) * currentIntegerBuffer_.size()),
-         currentIntegerBuffer_.data(),
-         GL_DYNAMIC_DRAW);
-
       numVertices_ =
          static_cast<GLsizei>(currentImageBuffer_.size() / kPointsPerVertex);
    }
@@ -459,7 +345,4 @@ void PlacefileImages::Impl::Update(bool textureAtlasChanged)
    dirty_ = false;
 }
 
-} // namespace draw
-} // namespace gl
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::gl::draw

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.hpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.hpp
@@ -11,7 +11,7 @@ class PlacefileImagesXY : public DrawItem
 {
 public:
    explicit PlacefileImagesXY(const std::shared_ptr<GlContext>& context);
-   ~PlacefileImagesXY();
+   ~PlacefileImagesXY() override;
 
    PlacefileImagesXY(const PlacefileImagesXY&)            = delete;
    PlacefileImagesXY& operator=(const PlacefileImagesXY&) = delete;

--- a/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.hpp
+++ b/scwx-qt/source/scwx/qt/gl/draw/placefile_images_xy.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <scwx/qt/gl/gl_context.hpp>
+#include <scwx/qt/gl/draw/draw_item.hpp>
+#include <scwx/gr/placefile.hpp>
+
+namespace scwx::qt::gl::draw
+{
+
+class PlacefileImagesXY : public DrawItem
+{
+public:
+   explicit PlacefileImagesXY(const std::shared_ptr<GlContext>& context);
+   ~PlacefileImagesXY();
+
+   PlacefileImagesXY(const PlacefileImagesXY&)            = delete;
+   PlacefileImagesXY& operator=(const PlacefileImagesXY&) = delete;
+
+   PlacefileImagesXY(PlacefileImagesXY&&) noexcept;
+   PlacefileImagesXY& operator=(PlacefileImagesXY&&) noexcept;
+
+   void Initialize() override;
+   void Render(const QMapLibre::CustomLayerRenderParameters& params,
+               bool textureAtlasChanged) override;
+   void Deinitialize() override;
+
+   /**
+    * Resets and prepares the draw item for adding a new set of images.
+    */
+   void StartImagesXY(const std::string& baseUrl);
+
+   /**
+    * Adds a placefile image to the internal draw list.
+    *
+    * @param [in] di Placefile image
+    */
+   void AddImageXY(const std::shared_ptr<gr::Placefile::ImageXYDrawItem>& di);
+
+   /**
+    * Finalizes the draw item after adding new images.
+    */
+   void FinishImagesXY();
+
+private:
+   class Impl;
+   std::unique_ptr<Impl> p;
+};
+
+} // namespace scwx::qt::gl::draw

--- a/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
@@ -837,9 +837,10 @@ PlacefileManager::Impl::LoadImageResources(
       switch (di->itemType_)
       {
       case gr::Placefile::ItemType::Image:
+      case gr::Placefile::ItemType::ImageXY:
       {
          const std::string& imageFile =
-            std::static_pointer_cast<gr::Placefile::ImageDrawItem>(di)
+            std::static_pointer_cast<gr::Placefile::ImageBaseDrawItem>(di)
                ->imageFile_;
 
          QString     filePath    = QString::fromStdString(imageFile);

--- a/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/placefile_layer.cpp
@@ -1,6 +1,7 @@
 #include <scwx/qt/map/placefile_layer.hpp>
 #include <scwx/qt/gl/draw/placefile_icons.hpp>
 #include <scwx/qt/gl/draw/placefile_images.hpp>
+#include <scwx/qt/gl/draw/placefile_images_xy.hpp>
 #include <scwx/qt/gl/draw/placefile_lines.hpp>
 #include <scwx/qt/gl/draw/placefile_polygons.hpp>
 #include <scwx/qt/gl/draw/placefile_triangles.hpp>
@@ -29,6 +30,8 @@ public:
        placefileIcons_ {std::make_shared<gl::draw::PlacefileIcons>(glContext)},
        placefileImages_ {
           std::make_shared<gl::draw::PlacefileImages>(glContext)},
+       placefileImagesXY_ {
+          std::make_shared<gl::draw::PlacefileImagesXY>(glContext)},
        placefileLines_ {std::make_shared<gl::draw::PlacefileLines>(glContext)},
        placefilePolygons_ {
           std::make_shared<gl::draw::PlacefilePolygons>(glContext)},
@@ -57,6 +60,7 @@ public:
 
    std::shared_ptr<gl::draw::PlacefileIcons>     placefileIcons_;
    std::shared_ptr<gl::draw::PlacefileImages>    placefileImages_;
+   std::shared_ptr<gl::draw::PlacefileImagesXY>  placefileImagesXY_;
    std::shared_ptr<gl::draw::PlacefileLines>     placefileLines_;
    std::shared_ptr<gl::draw::PlacefilePolygons>  placefilePolygons_;
    std::shared_ptr<gl::draw::PlacefileTriangles> placefileTriangles_;
@@ -71,6 +75,7 @@ PlacefileLayer::PlacefileLayer(const std::shared_ptr<gl::GlContext>& glContext,
     p(std::make_unique<PlacefileLayer::Impl>(this, glContext, placefileName))
 {
    AddDrawItem(p->placefileImages_);
+   AddDrawItem(p->placefileImagesXY_);
    AddDrawItem(p->placefilePolygons_);
    AddDrawItem(p->placefileTriangles_);
    AddDrawItem(p->placefileLines_);
@@ -202,6 +207,7 @@ void PlacefileLayer::Impl::ReloadDataSync()
    // Start draw items
    placefileIcons_->StartIcons();
    placefileImages_->StartImages(placefile->name());
+   placefileImagesXY_->StartImagesXY(placefile->name());
    placefileLines_->StartLines();
    placefilePolygons_->StartPolygons();
    placefileTriangles_->StartTriangles();
@@ -239,6 +245,11 @@ void PlacefileLayer::Impl::ReloadDataSync()
             std::static_pointer_cast<gr::Placefile::ImageDrawItem>(drawItem));
          break;
 
+      case gr::Placefile::ItemType::ImageXY:
+         placefileImagesXY_->AddImageXY(
+            std::static_pointer_cast<gr::Placefile::ImageXYDrawItem>(drawItem));
+         break;
+
       case gr::Placefile::ItemType::Triangles:
          placefileTriangles_->AddTriangles(
             std::static_pointer_cast<gr::Placefile::TrianglesDrawItem>(
@@ -253,6 +264,7 @@ void PlacefileLayer::Impl::ReloadDataSync()
    // Finish draw items
    placefileIcons_->FinishIcons();
    placefileImages_->FinishImages();
+   placefileImagesXY_->FinishImagesXY();
    placefileLines_->FinishLines();
    placefilePolygons_->FinishPolygons();
    placefileTriangles_->FinishTriangles();

--- a/scwx-qt/source/scwx/qt/types/capture_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/capture_types.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace scwx::qt::types

--- a/scwx-qt/source/scwx/qt/types/placefile_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/placefile_types.cpp
@@ -1,0 +1,28 @@
+#include <scwx/qt/types/placefile_types.hpp>
+
+#include <QDir>
+#include <QUrl>
+
+namespace scwx::qt::types
+{
+
+PlacefileImageInfo::PlacefileImageInfo(const std::string& imageFile,
+                                       const std::string& baseUrlString)
+{
+   // Resolve using base URL
+   const auto baseUrl =
+      QUrl::fromUserInput(QString::fromStdString(baseUrlString));
+   const auto relativeUrl =
+      QUrl(QDir::fromNativeSeparators(QString::fromStdString(imageFile)));
+   resolvedUrl_ = baseUrl.resolved(relativeUrl).toString().toStdString();
+}
+
+void PlacefileImageInfo::UpdateTextureInfo()
+{
+   texture_ = util::TextureAtlas::Instance().GetTextureAttributes(resolvedUrl_);
+
+   scaledWidth_  = texture_.sRight_ - texture_.sLeft_;
+   scaledHeight_ = texture_.tBottom_ - texture_.tTop_;
+}
+
+} // namespace scwx::qt::types

--- a/scwx-qt/source/scwx/qt/types/placefile_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/placefile_types.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+#include <scwx/qt/util/texture_atlas.hpp>
+
+namespace scwx::qt::types
+{
+
+struct PlacefileImageInfo
+{
+   PlacefileImageInfo(const std::string& imageFile,
+                      const std::string& baseUrlString);
+
+   void UpdateTextureInfo();
+
+   std::string             resolvedUrl_ {};
+   util::TextureAttributes texture_ {};
+   float                   scaledWidth_ {};
+   float                   scaledHeight_ {};
+};
+
+} // namespace scwx::qt::types

--- a/wxdata/include/scwx/gr/placefile.hpp
+++ b/wxdata/include/scwx/gr/placefile.hpp
@@ -177,6 +177,8 @@ public:
       {
          double x_ {};
          double y_ {};
+         double anchorX_ {};
+         double anchorY_ {};
          double tu_ {};
          double tv_ {};
       };

--- a/wxdata/include/scwx/gr/placefile.hpp
+++ b/wxdata/include/scwx/gr/placefile.hpp
@@ -13,9 +13,7 @@
 #include <units/angle.h>
 #include <units/length.h>
 
-namespace scwx
-{
-namespace gr
+namespace scwx::gr
 {
 
 /**
@@ -39,7 +37,7 @@ public:
    Placefile(Placefile&&) noexcept;
    Placefile& operator=(Placefile&&) noexcept;
 
-   enum class ItemType
+   enum class ItemType : std::uint8_t
    {
       Icon,
       Font,
@@ -47,6 +45,7 @@ public:
       Line,
       Triangles,
       Image,
+      ImageXY,
       Polygon,
       Unknown
    };
@@ -148,16 +147,34 @@ public:
       std::vector<Element> elements_ {};
    };
 
-   struct ImageDrawItem : DrawItem
+   struct ImageBaseDrawItem : DrawItem
+   {
+      std::string imageFile_ {};
+   };
+
+   struct ImageDrawItem : ImageBaseDrawItem
    {
       ImageDrawItem() { itemType_ = ItemType::Image; }
-
-      std::string imageFile_ {};
 
       struct Element
       {
          double latitude_ {};
          double longitude_ {};
+         double x_ {};
+         double y_ {};
+         double tu_ {};
+         double tv_ {};
+      };
+
+      std::vector<Element> elements_ {};
+   };
+
+   struct ImageXYDrawItem : ImageBaseDrawItem
+   {
+      ImageXYDrawItem() { itemType_ = ItemType::ImageXY; }
+
+      struct Element
+      {
          double x_ {};
          double y_ {};
          double tu_ {};
@@ -213,5 +230,4 @@ private:
    std::unique_ptr<Impl> p;
 };
 
-} // namespace gr
-} // namespace scwx
+} // namespace scwx::gr

--- a/wxdata/source/scwx/gr/placefile.cpp
+++ b/wxdata/source/scwx/gr/placefile.cpp
@@ -26,20 +26,19 @@
 
 using namespace units::literals;
 
-namespace scwx
-{
-namespace gr
+namespace scwx::gr
 {
 
 static const std::string logPrefix_ {"scwx::gr::placefile"};
 static const auto        logger_ = util::Logger::Create(logPrefix_);
 
-enum class DrawingStatement
+enum class DrawingStatement : std::uint8_t
 {
    Standard,
    Line,
    Triangles,
    Image,
+   ImageXY,
    Polygon
 };
 
@@ -210,6 +209,7 @@ std::shared_ptr<Placefile> Placefile::Load(const std::string& name,
             case DrawingStatement::Line:
             case DrawingStatement::Triangles:
             case DrawingStatement::Image:
+            case DrawingStatement::ImageXY:
             case DrawingStatement::Polygon:
                if (boost::istarts_with(line, "End:"))
                {
@@ -256,6 +256,7 @@ void Placefile::Impl::ProcessLine(const std::string& line)
    static const std::string imageKey_ {"Image:"};
    static const std::string polygonKey_ {"Polygon:"};
 
+   static const std::string scwxImageXYKey_ {"scwx-ImageXY:"};
    static const std::string scwxModulateIconKey_ {"scwx-ModulateIcon:"};
 
    currentStatement_ = DrawingStatement::Standard;
@@ -689,6 +690,38 @@ void Placefile::Impl::ProcessLine(const std::string& line)
          logger_->warn("Image statement malformed: {}", line);
       }
    }
+   else if (boost::istarts_with(line, scwxImageXYKey_))
+   {
+      // scwx-ImageXY: image_file
+      //    x, y, Tu [, Tv ]
+      //    ...
+      // End:
+      std::vector<std::string> tokenList =
+         util::ParseTokens(line, {" "}, scwxImageXYKey_.size());
+
+      currentStatement_ = DrawingStatement::ImageXY;
+
+      std::shared_ptr<ImageXYDrawItem> di = nullptr;
+
+      if (tokenList.size() >= 1)
+      {
+         di = std::make_shared<ImageXYDrawItem>();
+
+         di->threshold_ = threshold_;
+         di->startTime_ = startTime_;
+         di->endTime_   = endTime_;
+
+         TrimQuotes(tokenList[0]);
+         di->imageFile_.swap(tokenList[0]);
+
+         currentDrawItem_ = di;
+         drawItems_.emplace_back(std::move(di));
+      }
+      else
+      {
+         logger_->warn("Image statement malformed: {}", line);
+      }
+   }
    else if (boost::istarts_with(line, polygonKey_))
    {
       // Polygon:
@@ -823,6 +856,43 @@ void Placefile::Impl::ProcessElement(const std::string& line)
          logger_->warn("Image sub-statement malformed: {}", line);
       }
    }
+   else if (currentStatement_ == DrawingStatement::ImageXY)
+   {
+      // scwx-ImageXY: image_file
+      //    x, y, Tu [, Tv ]
+      //    ...
+      // End:
+      const std::vector<std::string> tokenList =
+         util::ParseTokens(line, {",", ",", ",", ","});
+
+      ImageXYDrawItem::Element element;
+
+      if (tokenList.size() >= 3)
+      {
+         element.x_  = std::stod(tokenList[0]);
+         element.y_  = std::stod(tokenList[1]);
+         element.tu_ = std::stod(tokenList[2]);
+      }
+
+      if (tokenList.size() >= 4)
+      {
+         element.tv_ = std::stod(tokenList[3]);
+      }
+      else
+      {
+         element.tv_ = element.tu_;
+      }
+
+      if (tokenList.size() >= 3)
+      {
+         std::static_pointer_cast<ImageXYDrawItem>(currentDrawItem_)
+            ->elements_.emplace_back(element);
+      }
+      else
+      {
+         logger_->warn("ImageXY sub-statement malformed: {}", line);
+      }
+   }
    else if (currentStatement_ == DrawingStatement::Polygon)
    {
       // Polygon:
@@ -906,7 +976,8 @@ void Placefile::Impl::ProcessElementEnd()
          std::transform(di->contours_[0].cbegin(),
                         di->contours_[0].cend(),
                         std::back_inserter(coordinates),
-                        [](auto& element) {
+                        [](auto& element)
+                        {
                            return common::Coordinate {element.latitude_,
                                                       element.longitude_};
                         });
@@ -964,5 +1035,4 @@ void Placefile::Impl::TrimQuotes(std::string& s)
    }
 }
 
-} // namespace gr
-} // namespace scwx
+} // namespace scwx::gr

--- a/wxdata/source/scwx/gr/placefile.cpp
+++ b/wxdata/source/scwx/gr/placefile.cpp
@@ -693,7 +693,7 @@ void Placefile::Impl::ProcessLine(const std::string& line)
    else if (boost::istarts_with(line, scwxImageXYKey_))
    {
       // scwx-ImageXY: image_file
-      //    x, y, Tu [, Tv ]
+      //    x, y, ax, ay, Tu [, Tv ]
       //    ...
       // End:
       std::vector<std::string> tokenList =
@@ -754,6 +754,8 @@ void Placefile::Impl::ProcessLine(const std::string& line)
 
 void Placefile::Impl::ProcessElement(const std::string& line)
 {
+   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+
    if (currentStatement_ == DrawingStatement::Line)
    {
       // Line: width, flags [, hover_text]
@@ -859,31 +861,33 @@ void Placefile::Impl::ProcessElement(const std::string& line)
    else if (currentStatement_ == DrawingStatement::ImageXY)
    {
       // scwx-ImageXY: image_file
-      //    x, y, Tu [, Tv ]
+      //    x, y, ax, ay, Tu [, Tv ]
       //    ...
       // End:
       const std::vector<std::string> tokenList =
-         util::ParseTokens(line, {",", ",", ",", ","});
+         util::ParseTokens(line, {",", ",", ",", ",", ",", ","});
 
       ImageXYDrawItem::Element element;
 
-      if (tokenList.size() >= 3)
+      if (tokenList.size() >= 5)
       {
-         element.x_  = std::stod(tokenList[0]);
-         element.y_  = std::stod(tokenList[1]);
-         element.tu_ = std::stod(tokenList[2]);
+         element.x_       = std::stod(tokenList[0]);
+         element.y_       = std::stod(tokenList[1]);
+         element.anchorX_ = std::stod(tokenList[2]);
+         element.anchorY_ = std::stod(tokenList[3]);
+         element.tu_      = std::stod(tokenList[4]);
       }
 
-      if (tokenList.size() >= 4)
+      if (tokenList.size() >= 6)
       {
-         element.tv_ = std::stod(tokenList[3]);
+         element.tv_ = std::stod(tokenList[5]);
       }
       else
       {
          element.tv_ = element.tu_;
       }
 
-      if (tokenList.size() >= 3)
+      if (tokenList.size() >= 5)
       {
          std::static_pointer_cast<ImageXYDrawItem>(currentDrawItem_)
             ->elements_.emplace_back(element);
@@ -952,6 +956,8 @@ void Placefile::Impl::ProcessElement(const std::string& line)
          logger_->warn("Polygon sub-statement malformed: {}", line);
       }
    }
+
+   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 }
 
 void Placefile::Impl::ProcessElementEnd()


### PR DESCRIPTION
Add a new Placefile extension to support static images overlaid on the map, `scwx-ImageXY`, similar to the existing `Image` statement.

**scwx-ImageXY: *image_file***
   **x, y, ax, ay, Tu [, Tv]**
**End:**

***image_file***
   image file for texture

***x, y***
   coordinates of the image in pixels
   0.0, 0.0 is the anchor point
   x values increase moving right
   y values increase moving up

***ax, ay***
   anchor point of the image in NDC coordinates
   -1.0, -1.0 is the bottom left
   1.0, 1.0 is the upper right

***Tu, Tv***
   coordinates of image for the vertex where
   0.0, 0.0 is the upper-left corner of the image
   1.0, 1.0 is the lower-right corner of the image

<img width="860" height="481" alt="image" src="https://github.com/user-attachments/assets/36fd4622-66f0-4a26-b5ec-9b7b5e845604" />

Sample Placefile:

```
Title: Sample Image XY
Refresh: 0
Threshold: 999

scwx-ImageXY: ul.png
   0,   0, -1.0, 1.0, 0.0, 0.0
  64,   0, -1.0, 1.0, 1.0, 0.0
  64, -64, -1.0, 1.0, 1.0, 1.0
   0,   0, -1.0, 1.0, 0.0, 0.0
   0, -64, -1.0, 1.0, 0.0, 1.0
  64, -64, -1.0, 1.0, 1.0, 1.0
End:

scwx-ImageXY: tc.png
 -32,   0, 0.0, 1.0, 0.0, 0.0
  32,   0, 0.0, 1.0, 1.0, 0.0
  32, -64, 0.0, 1.0, 1.0, 1.0
 -32,   0, 0.0, 1.0, 0.0, 0.0
 -32, -64, 0.0, 1.0, 0.0, 1.0
  32, -64, 0.0, 1.0, 1.0, 1.0
End:

scwx-ImageXY: tr.png
 -64,   0, 1.0, 1.0, 0.0, 0.0
   0,   0, 1.0, 1.0, 1.0, 0.0
   0, -64, 1.0, 1.0, 1.0, 1.0
 -64,   0, 1.0, 1.0, 0.0, 0.0
 -64, -64, 1.0, 1.0, 0.0, 1.0
   0, -64, 1.0, 1.0, 1.0, 1.0
End:

scwx-ImageXY: ml.png
   0,  32, -1.0, 0.0, 0.0, 0.0
  64,  32, -1.0, 0.0, 1.0, 0.0
  64, -32, -1.0, 0.0, 1.0, 1.0
   0,  32, -1.0, 0.0, 0.0, 0.0
   0, -32, -1.0, 0.0, 0.0, 1.0
  64, -32, -1.0, 0.0, 1.0, 1.0
End:

scwx-ImageXY: mc.png
 -32,  32, 0.0, 0.0, 0.0, 0.0
  32,  32, 0.0, 0.0, 1.0, 0.0
  32, -32, 0.0, 0.0, 1.0, 1.0
 -32,  32, 0.0, 0.0, 0.0, 0.0
 -32, -32, 0.0, 0.0, 0.0, 1.0
  32, -32, 0.0, 0.0, 1.0, 1.0
End:

scwx-ImageXY: mr.png
 -64,  32, 1.0, 0.0, 0.0, 0.0
   0,  32, 1.0, 0.0, 1.0, 0.0
   0, -32, 1.0, 0.0, 1.0, 1.0
 -64,  32, 1.0, 0.0, 0.0, 0.0
 -64, -32, 1.0, 0.0, 0.0, 1.0
   0, -32, 1.0, 0.0, 1.0, 1.0
End:

scwx-ImageXY: bl.png
   0,  64, -1.0, -1.0, 0.0, 0.0
  64,  64, -1.0, -1.0, 1.0, 0.0
  64,   0, -1.0, -1.0, 1.0, 1.0
   0,  64, -1.0, -1.0, 0.0, 0.0
   0,   0, -1.0, -1.0, 0.0, 1.0
  64,   0, -1.0, -1.0, 1.0, 1.0
End:

scwx-ImageXY: bc.png
 -32,  64, 0.0, -1.0, 0.0, 0.0
  32,  64, 0.0, -1.0, 1.0, 0.0
  32,   0, 0.0, -1.0, 1.0, 1.0
 -32,  64, 0.0, -1.0, 0.0, 0.0
 -32,   0, 0.0, -1.0, 0.0, 1.0
  32,   0, 0.0, -1.0, 1.0, 1.0
End:

scwx-ImageXY: br.png
 -64,  64, 1.0, -1.0, 0.0, 0.0
   0,  64, 1.0, -1.0, 1.0, 0.0
   0,   0, 1.0, -1.0, 1.0, 1.0
 -64,  64, 1.0, -1.0, 0.0, 0.0
 -64,   0, 1.0, -1.0, 0.0, 1.0
   0,   0, 1.0, -1.0, 1.0, 1.0
End:
```