### PR TITLE
cmake: use generic Cmake FindOpenGL for GLU

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -41,7 +41,7 @@ class SupercellWxConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux":
-            self.requires("mesa-glu/9.0.3")
+            self.requires("opengl/system")
             self.requires("onetbb/2022.3.0")
 
         # Force dependency graph (fontconfig) to use a newer version of freetype

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,6 +42,7 @@ class SupercellWxConan(ConanFile):
     def requirements(self):
         if self.settings.os == "Linux":
             self.requires("opengl/system")
+            self.requires("glu/system")
             self.requires("onetbb/2022.3.0")
 
         # Force dependency graph (fontconfig) to use a newer version of freetype

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -18,7 +18,7 @@ find_package(Fontconfig)
 find_package(geographiclib)
 find_package(geos)
 find_package(glm)
-find_package(OpenGL)
+find_package(OpenGL REQUIRED)
 find_package(Python COMPONENTS Interpreter)
 find_package(SQLite3)
 
@@ -779,13 +779,6 @@ if (LINUX)
     target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::WaylandClient)
 endif()
 
-if (LINUX)
-    find_package(mesa-glu REQUIRED)
-    target_link_libraries(scwx-qt PUBLIC mesa-glu::mesa-glu)
-else()
-    target_link_libraries(scwx-qt PUBLIC OpenGL::GLU)
-endif()
-
 target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Qt${QT_VERSION_MAJOR}::OpenGLWidgets
                                      Qt${QT_VERSION_MAJOR}::Multimedia
@@ -796,6 +789,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      Boost::timer
                                      Boost::atomic
                                      QMapLibre::Core
+                                     OpenGL::GLU
                                      $<$<CXX_COMPILER_ID:MSVC>:opengl32>
                                      $<$<CXX_COMPILER_ID:MSVC>:SetupAPI>
                                      Fontconfig::Fontconfig


### PR DESCRIPTION
I stumbled across this issue while working on: https://github.com/NixOS/nixpkgs/pull/454201

In the Nixpkgs package for `supercell-wx` we eschew the conan support and use dependencies packaged by the rest of Nixpkgs, which are usually brought in nicely in CMake by `find_package` as long as the upstream package itself provides CMake support.

In the case of `mesa-glu`, the upstream package only provides support for `pkg-config`. The conan package `mesa-glu` appears to provide its own CMake support, so using `find_package(mesa-glu)` binds `supercell-wx` to that particular conan package to acquire `GLU`.

However, the CMake documentation [states](https://cmake.org/cmake/help/latest/module/FindOpenGL.html#linux-specific) that `find_package(OpenGL)` should expose the `OpenGL::GLU` target if it is available, and this is already used earlier in `scwx-qt/scwx-qt.cmake`. This seems to abstract over this whole process and works nicely for Nixpkgs. We currently vendor a patch to do this but I wanted to open the discussion in case it might be desirable to allow `supercell-wx` to consume other implementations of GLU (since that would also be enabled by this, I think). I don't actually know if this change is compatible with the current dependency on the conan provided `mesa-glu`, though, as I am on NixOS. I also don't know how the Windows support would be affected given the conditional link against `opengl32`.