### PR TITLE
Modernize UI with dark theme, Mapbox default, alert focus and detail …

### DIFF
--- a/scwx-qt/res/qss/modern.qss
+++ b/scwx-qt/res/qss/modern.qss
@@ -1,0 +1,695 @@
+/* =========================================================
+   Supercell Wx - Modern Dark Theme
+   ========================================================= */
+
+/* ----- Global ----- */
+QWidget {
+    background-color: #12121e;
+    color: #dde1f0;
+    font-size: 13px;
+}
+
+QMainWindow {
+    background-color: #0c0c16;
+}
+
+QMainWindow::separator {
+    background-color: #1e1e36;
+    width: 4px;
+    height: 4px;
+}
+
+QMainWindow::separator:hover {
+    background-color: #0078d4;
+}
+
+/* ----- Menu Bar ----- */
+QMenuBar {
+    background-color: #0c0c16;
+    color: #dde1f0;
+    border-bottom: 1px solid #1e1e36;
+    padding: 2px;
+}
+
+QMenuBar::item {
+    background-color: transparent;
+    padding: 4px 10px;
+    border-radius: 3px;
+}
+
+QMenuBar::item:selected {
+    background-color: #1e1e36;
+}
+
+QMenuBar::item:pressed {
+    background-color: #0078d4;
+}
+
+QMenu {
+    background-color: #16162a;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    padding: 4px 0px;
+}
+
+QMenu::item {
+    padding: 6px 24px 6px 12px;
+}
+
+QMenu::item:selected {
+    background-color: #0078d4;
+    color: #ffffff;
+}
+
+QMenu::separator {
+    height: 1px;
+    background: #2a2a46;
+    margin: 4px 8px;
+}
+
+/* ----- Tool Bar ----- */
+QToolBar {
+    background-color: #12121e;
+    border-bottom: 1px solid #1e1e36;
+    spacing: 4px;
+    padding: 2px;
+}
+
+QToolBar::separator {
+    background-color: #2a2a46;
+    width: 1px;
+    margin: 4px 2px;
+}
+
+/* ----- Dock Widgets ----- */
+QDockWidget {
+    titlebar-close-icon: none;
+    titlebar-normal-icon: none;
+    color: #dde1f0;
+}
+
+QDockWidget::title {
+    background-color: #16162a;
+    color: #a0a8c8;
+    padding: 5px 8px;
+    font-weight: bold;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border-bottom: 1px solid #2a2a46;
+}
+
+QDockWidget::close-button,
+QDockWidget::float-button {
+    border: none;
+    background: transparent;
+    padding: 1px;
+}
+
+QDockWidget::close-button:hover,
+QDockWidget::float-button:hover {
+    background-color: #2a2a46;
+    border-radius: 3px;
+}
+
+/* ----- Scroll Area ----- */
+QScrollArea {
+    border: none;
+    background-color: transparent;
+}
+
+QScrollArea > QWidget > QWidget {
+    background-color: transparent;
+}
+
+/* ----- Tree / List / Table Views ----- */
+QTreeView,
+QListView,
+QTableView {
+    background-color: #16162a;
+    alternate-background-color: #1a1a30;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    gridline-color: #2a2a46;
+    selection-background-color: #0078d4;
+    selection-color: #ffffff;
+    outline: 0;
+}
+
+QTreeView::item,
+QListView::item,
+QTableView::item {
+    padding: 3px 4px;
+    border: none;
+}
+
+QTreeView::item:hover,
+QListView::item:hover {
+    background-color: #212138;
+}
+
+QTreeView::item:selected,
+QListView::item:selected {
+    background-color: #0078d4;
+    color: #ffffff;
+}
+
+QTreeView::branch {
+    background-color: transparent;
+}
+
+/* ----- Header View ----- */
+QHeaderView {
+    background-color: #12121e;
+    border: none;
+}
+
+QHeaderView::section {
+    background-color: #12121e;
+    color: #8890b0;
+    border: none;
+    border-right: 1px solid #2a2a46;
+    border-bottom: 2px solid #2a2a46;
+    padding: 5px 8px;
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+QHeaderView::section:hover {
+    background-color: #1a1a30;
+    color: #dde1f0;
+}
+
+QHeaderView::section:pressed {
+    background-color: #0078d4;
+    color: #ffffff;
+}
+
+QHeaderView::section:last {
+    border-right: none;
+}
+
+/* ----- Buttons ----- */
+QPushButton {
+    background-color: #1e3a6e;
+    color: #dde1f0;
+    border: 1px solid #2a4a8e;
+    border-radius: 5px;
+    padding: 6px 16px;
+    font-weight: 600;
+    min-height: 24px;
+}
+
+QPushButton:hover {
+    background-color: #0078d4;
+    border-color: #0078d4;
+    color: #ffffff;
+}
+
+QPushButton:pressed {
+    background-color: #005ba1;
+    border-color: #005ba1;
+}
+
+QPushButton:disabled {
+    background-color: #1a1a2e;
+    border-color: #2a2a46;
+    color: #4a4a6a;
+}
+
+QPushButton:default {
+    border-color: #0078d4;
+}
+
+/* ----- Tool Buttons ----- */
+QToolButton {
+    background-color: transparent;
+    color: #dde1f0;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 4px;
+    min-width: 22px;
+    min-height: 22px;
+}
+
+QToolButton:hover {
+    background-color: #1e1e36;
+    border-color: #2a2a46;
+}
+
+QToolButton:pressed {
+    background-color: #0078d4;
+    border-color: #0078d4;
+}
+
+QToolButton:checked {
+    background-color: #1e3a6e;
+    border-color: #0078d4;
+}
+
+QToolButton::menu-button {
+    border: none;
+    width: 14px;
+}
+
+/* ----- Line Edit ----- */
+QLineEdit {
+    background-color: #1a1a30;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    padding: 5px 8px;
+    selection-background-color: #0078d4;
+}
+
+QLineEdit:focus {
+    border-color: #0078d4;
+    background-color: #1e1e38;
+}
+
+QLineEdit:disabled {
+    background-color: #14141e;
+    color: #4a4a6a;
+    border-color: #1e1e36;
+}
+
+/* ----- Combo Box ----- */
+QComboBox {
+    background-color: #1a1a30;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    padding: 5px 8px;
+    min-height: 24px;
+    selection-background-color: #0078d4;
+}
+
+QComboBox:hover {
+    border-color: #0078d4;
+}
+
+QComboBox:focus {
+    border-color: #0078d4;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 20px;
+    subcontrol-origin: padding;
+    subcontrol-position: right center;
+}
+
+QComboBox QAbstractItemView {
+    background-color: #16162a;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    selection-background-color: #0078d4;
+    selection-color: #ffffff;
+    outline: 0;
+}
+
+/* ----- Spin Box ----- */
+QSpinBox,
+QDoubleSpinBox {
+    background-color: #1a1a30;
+    color: #dde1f0;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    padding: 4px 8px;
+    min-height: 24px;
+}
+
+QSpinBox:focus,
+QDoubleSpinBox:focus {
+    border-color: #0078d4;
+}
+
+QSpinBox::up-button,
+QDoubleSpinBox::up-button,
+QSpinBox::down-button,
+QDoubleSpinBox::down-button {
+    background-color: #2a2a46;
+    border: none;
+    width: 16px;
+}
+
+QSpinBox::up-button:hover,
+QDoubleSpinBox::up-button:hover,
+QSpinBox::down-button:hover,
+QDoubleSpinBox::down-button:hover {
+    background-color: #0078d4;
+}
+
+/* ----- Check Box ----- */
+QCheckBox {
+    color: #dde1f0;
+    spacing: 8px;
+}
+
+QCheckBox::indicator {
+    width: 16px;
+    height: 16px;
+    border: 2px solid #3a3a5e;
+    border-radius: 3px;
+    background-color: #1a1a30;
+}
+
+QCheckBox::indicator:hover {
+    border-color: #0078d4;
+}
+
+QCheckBox::indicator:checked {
+    background-color: #0078d4;
+    border-color: #0078d4;
+}
+
+QCheckBox::indicator:checked:hover {
+    background-color: #106ebe;
+}
+
+/* ----- Radio Button ----- */
+QRadioButton {
+    color: #dde1f0;
+    spacing: 8px;
+}
+
+QRadioButton::indicator {
+    width: 16px;
+    height: 16px;
+    border: 2px solid #3a3a5e;
+    border-radius: 8px;
+    background-color: #1a1a30;
+}
+
+QRadioButton::indicator:checked {
+    background-color: #0078d4;
+    border-color: #0078d4;
+}
+
+/* ----- Group Box ----- */
+QGroupBox {
+    border: 1px solid #2a2a46;
+    border-radius: 6px;
+    margin-top: 12px;
+    padding-top: 8px;
+    font-weight: bold;
+    color: #8890b0;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 10px;
+    padding: 0 6px;
+    background-color: #12121e;
+}
+
+/* ----- Tab Widget ----- */
+QTabWidget::pane {
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    background-color: #16162a;
+}
+
+QTabBar::tab {
+    background-color: #12121e;
+    color: #8890b0;
+    border: 1px solid #2a2a46;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+
+QTabBar::tab:selected {
+    background-color: #16162a;
+    color: #dde1f0;
+    border-bottom: 2px solid #0078d4;
+}
+
+QTabBar::tab:hover:!selected {
+    background-color: #1a1a30;
+    color: #dde1f0;
+}
+
+/* ----- Scroll Bars ----- */
+QScrollBar:vertical {
+    background-color: #12121e;
+    width: 8px;
+    border: none;
+    border-radius: 4px;
+}
+
+QScrollBar::handle:vertical {
+    background-color: #2e2e50;
+    border-radius: 4px;
+    min-height: 30px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: #0078d4;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical,
+QScrollBar::add-page:vertical,
+QScrollBar::sub-page:vertical {
+    background: none;
+    border: none;
+}
+
+QScrollBar:horizontal {
+    background-color: #12121e;
+    height: 8px;
+    border: none;
+    border-radius: 4px;
+}
+
+QScrollBar::handle:horizontal {
+    background-color: #2e2e50;
+    border-radius: 4px;
+    min-width: 30px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background-color: #0078d4;
+}
+
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal {
+    background: none;
+    border: none;
+}
+
+/* ----- Status Bar ----- */
+QStatusBar {
+    background-color: #0c0c16;
+    color: #8890b0;
+    border-top: 1px solid #1e1e36;
+}
+
+QStatusBar::item {
+    border: none;
+}
+
+QStatusBar QLabel {
+    color: #8890b0;
+    padding: 2px 4px;
+}
+
+/* ----- Labels ----- */
+QLabel {
+    color: #dde1f0;
+    background-color: transparent;
+}
+
+/* ----- Splitter ----- */
+QSplitter::handle {
+    background-color: #1e1e36;
+}
+
+QSplitter::handle:hover {
+    background-color: #0078d4;
+}
+
+QSplitter::handle:horizontal {
+    width: 3px;
+}
+
+QSplitter::handle:vertical {
+    height: 3px;
+}
+
+/* ----- Dialog ----- */
+QDialog {
+    background-color: #12121e;
+}
+
+QDialogButtonBox > QPushButton {
+    min-width: 80px;
+}
+
+/* ----- Text Browser / Plain Text ----- */
+QTextBrowser,
+QPlainTextEdit,
+QTextEdit {
+    background-color: #0c0c16;
+    color: #c8d0e8;
+    border: 1px solid #2a2a46;
+    border-radius: 4px;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 12px;
+    selection-background-color: #0078d4;
+    padding: 4px;
+}
+
+/* ----- Frame ----- */
+QFrame[frameShape="4"],
+QFrame[frameShape="5"] {
+    color: #2a2a46;
+}
+
+/* ----- Alert Card Styling ----- */
+QFrame#alertCardFrame {
+    background-color: #16162a;
+    border: 2px solid #2a2a46;
+    border-radius: 8px;
+}
+
+QFrame#alertHeaderFrame {
+    border-radius: 6px 6px 0px 0px;
+    min-height: 80px;
+}
+
+QLabel#alertTypeLabel {
+    font-size: 20px;
+    font-weight: bold;
+    color: #ffffff;
+    background-color: transparent;
+}
+
+QLabel#alertSubtitleLabel {
+    font-size: 12px;
+    color: rgba(255,255,255,200);
+    background-color: transparent;
+}
+
+QFrame#alertBadgesFrame {
+    background-color: transparent;
+}
+
+/* PDS badge */
+QLabel#pdsLabel {
+    background-color: #8b00c8;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+/* Emergency badge */
+QLabel#emergencyLabel {
+    background-color: #cc0000;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+/* Observed badge */
+QLabel#observedLabel {
+    background-color: #1a6b2a;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+/* Radar Indicated badge */
+QLabel#radarIndicatedLabel {
+    background-color: #1a3a6b;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+/* Tornado Possible badge */
+QLabel#tornadoPossibleLabel {
+    background-color: #8b4500;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+}
+
+QFrame#alertInfoFrame {
+    background-color: #1a1a30;
+    border-radius: 0px 0px 6px 6px;
+}
+
+QLabel.alertFieldLabel {
+    color: #7888a8;
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+QLabel.alertFieldValue {
+    color: #dde1f0;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+/* ----- Mapbox API Key Bar ----- */
+QFrame#mapboxKeyBar {
+    background-color: #1a1500;
+    border-bottom: 1px solid #3d3000;
+    min-height: 36px;
+    max-height: 36px;
+}
+
+QFrame#mapboxKeyBar QLabel {
+    color: #f0c040;
+    font-weight: bold;
+}
+
+QFrame#mapboxKeyBar QPushButton {
+    background-color: #0078d4;
+    color: #ffffff;
+    border: none;
+    border-radius: 3px;
+    padding: 4px 10px;
+    font-size: 12px;
+    min-height: 20px;
+}
+
+QFrame#mapboxKeyBar QPushButton:hover {
+    background-color: #106ebe;
+}
+
+/* Screenshot button */
+QPushButton#screenshotButton {
+    background-color: #1a5c2e;
+    border-color: #2a8c46;
+    color: #ffffff;
+}
+
+QPushButton#screenshotButton:hover {
+    background-color: #207838;
+}

--- a/scwx-qt/scwx-qt.qrc
+++ b/scwx-qt/scwx-qt.qrc
@@ -64,6 +64,7 @@
         <file>res/icons/font-awesome-6/stop-solid.svg</file>
         <file>res/icons/font-awesome-6/tent-solid.svg</file>
         <file>res/icons/font-awesome-6/volume-high-solid.svg</file>
+        <file>res/qss/modern.qss</file>
         <file>res/palettes/wct/CC.pal</file>
         <file>res/palettes/wct/Default16.pal</file>
         <file>res/palettes/wct/DOD_DSD.pal</file>

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -49,9 +49,15 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <QDesktopServices>
+#include <QFile>
+#include <QFrame>
+#include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QFileDialog>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QSplitter>
 #include <QStandardPaths>
 #include <QTimer>
@@ -145,7 +151,9 @@ public:
    }
 
    void AddRadarSitePreset(const std::string& id);
+   void ApplyModernStylesheet();
    void AsyncSetup();
+   void ConfigureMapboxKeyBar();
    void ConfigureMapLayout();
    void ConfigureMapStyles();
    void ConfigureUiSettings();
@@ -193,6 +201,7 @@ public:
 
    QLabel* coordinateLabel_ {nullptr};
    QLabel* timeLabel_ {nullptr};
+   QFrame* mapboxKeyBar_ {nullptr};
 
    ui::AlertDockWidget*              alertDockWidget_ {};
    ui::AnimationDockWidget*          animationDockWidget_ {};
@@ -258,7 +267,13 @@ MainWindow::MainWindow(QWidget* parent) :
 {
    ui->setupUi(this);
 
+   // Apply modern dark theme stylesheet
+   p->ApplyModernStylesheet();
+
    p->InitializeLayerDisplayActions();
+
+   // Show Mapbox API key bar if key is not configured
+   p->ConfigureMapboxKeyBar();
 
    // Assign the bottom left corner to the left dock widget
    setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
@@ -1240,6 +1255,26 @@ void MainWindowImpl::ConnectOtherSignals()
          UpdateRadarSite();
       },
       Qt::QueuedConnection);
+   connect(alertDockWidget_,
+           &ui::AlertDockWidget::FocusAlertOnMap,
+           this,
+           [this](const types::TextEventKey& key)
+           {
+              for (map::MapWidget* map : maps_)
+              {
+                 map->FocusAlert(key);
+              }
+           });
+   connect(alertDockWidget_,
+           &ui::AlertDockWidget::UnfocusAlertOnMap,
+           this,
+           [this]()
+           {
+              for (map::MapWidget* map : maps_)
+              {
+                 map->UnfocusAlert();
+              }
+           });
    connect(mainWindow_,
            &MainWindow::ActiveMapMoved,
            radarSiteDialog_,
@@ -1701,6 +1736,73 @@ void MainWindowImpl::UpdateVcp()
       mainWindow_->ui->vcpLabel->setVisible(false);
       mainWindow_->ui->vcpValueLabel->setVisible(false);
       mainWindow_->ui->vcpDescriptionLabel->setVisible(false);
+   }
+}
+
+void MainWindowImpl::ApplyModernStylesheet()
+{
+   QFile qssFile(":/res/qss/modern.qss");
+   if (qssFile.open(QFile::ReadOnly | QFile::Text))
+   {
+      QString stylesheet = QString::fromUtf8(qssFile.readAll());
+      qApp->setStyleSheet(stylesheet);
+   }
+}
+
+void MainWindowImpl::ConfigureMapboxKeyBar()
+{
+   auto& generalSettings = settings::GeneralSettings::Instance();
+   auto  mapProvider =
+      map::GetMapProvider(generalSettings.map_provider().GetValue());
+
+   if (mapProvider == map::MapProvider::Mapbox)
+   {
+      std::string apiKey = generalSettings.mapbox_api_key().GetValue();
+
+      if (apiKey.empty() || apiKey == "?")
+      {
+         if (mapboxKeyBar_ == nullptr)
+         {
+            mapboxKeyBar_ = new QFrame(mainWindow_);
+            mapboxKeyBar_->setObjectName("mapboxKeyBar");
+
+            auto* layout = new QHBoxLayout(mapboxKeyBar_);
+            layout->setContentsMargins(8, 6, 8, 6);
+
+            auto* icon = new QLabel("⚠");
+            icon->setStyleSheet("color: #ffaa00; font-size: 14px;");
+            layout->addWidget(icon);
+
+            auto* label = new QLabel(
+               "Mapbox API key is not configured. "
+               "Enter your key in Settings → Map to enable the map.");
+            label->setStyleSheet("color: #ffcc66;");
+            layout->addWidget(label, 1);
+
+            auto* configureButton = new QPushButton("Configure");
+            configureButton->setObjectName("mapboxConfigureButton");
+            connect(configureButton,
+                    &QPushButton::clicked,
+                    mainWindow_,
+                    [this]()
+                    {
+                       mainWindow_->on_actionSettings_triggered();
+                    });
+            layout->addWidget(configureButton);
+
+            // Insert at top of central widget area via status bar
+            mainWindow_->statusBar()->addPermanentWidget(mapboxKeyBar_, 1);
+         }
+         mapboxKeyBar_->setVisible(true);
+      }
+      else if (mapboxKeyBar_ != nullptr)
+      {
+         mapboxKeyBar_->setVisible(false);
+      }
+   }
+   else if (mapboxKeyBar_ != nullptr)
+   {
+      mapboxKeyBar_->setVisible(false);
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/alert_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.cpp
@@ -248,6 +248,8 @@ public:
    std::string                                      tooltip_ {};
 
    std::vector<boost::signals2::scoped_connection> connections_ {};
+
+   std::optional<types::TextEventKey> focusedKey_ {};
 };
 
 AlertLayer::AlertLayer(const std::shared_ptr<gl::GlContext>& glContext,
@@ -319,6 +321,53 @@ void AlertLayer::Deinitialize()
    logger_->debug("Deinitialize: {}", awips::GetPhenomenonText(p->phenomenon_));
 
    DrawLayer::Deinitialize();
+}
+
+void AlertLayer::FocusAlert(const types::TextEventKey& key)
+{
+   p->focusedKey_ = key;
+
+   std::unique_lock lock {p->linesMutex_};
+   for (auto& [segRec, lines] : p->linesBySegment_)
+   {
+      bool focused = (segRec->key_ == key);
+      bool alertActive = (segRec->segment_->header_.has_value() &&
+                          !segRec->segment_->header_->vtecString_.empty() &&
+                          segRec->segment_->header_->vtecString_.front()
+                                .pVtec_.action() !=
+                             awips::PVtec::Action::Canceled);
+      auto& geoLines = p->geoLines_.at(alertActive);
+      for (auto& di : lines)
+      {
+         geoLines->SetLineVisible(di, focused);
+      }
+   }
+   lock.unlock();
+
+   Q_EMIT NeedsRendering();
+}
+
+void AlertLayer::UnfocusAlert()
+{
+   p->focusedKey_ = {};
+
+   std::unique_lock lock {p->linesMutex_};
+   for (auto& [segRec, lines] : p->linesBySegment_)
+   {
+      bool alertActive = (segRec->segment_->header_.has_value() &&
+                          !segRec->segment_->header_->vtecString_.empty() &&
+                          segRec->segment_->header_->vtecString_.front()
+                                .pVtec_.action() !=
+                             awips::PVtec::Action::Canceled);
+      auto& geoLines = p->geoLines_.at(alertActive);
+      for (auto& di : lines)
+      {
+         geoLines->SetLineVisible(di, true);
+      }
+   }
+   lock.unlock();
+
+   Q_EMIT NeedsRendering();
 }
 
 bool IsAlertActive(const std::shared_ptr<const awips::Segment>& segment)

--- a/scwx-qt/source/scwx/qt/map/alert_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/alert_layer.hpp
@@ -27,6 +27,18 @@ public:
 
    static void InitializeHandler();
 
+   /**
+    * @brief Focus a specific alert on the map, hiding all others on this layer.
+    *
+    * @param [in] key Alert key to focus
+    */
+   void FocusAlert(const types::TextEventKey& key);
+
+   /**
+    * @brief Remove alert focus, showing all alerts on this layer.
+    */
+   void UnfocusAlert();
+
 signals:
    void AlertSelected(const types::TextEventKey& key);
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -211,6 +211,7 @@ public:
    std::list<std::string>          layerList_;
 
    std::vector<std::shared_ptr<GenericLayer>> genericLayers_ {};
+   std::vector<std::shared_ptr<AlertLayer>>   alertLayers_ {};
 
    const std::vector<MapStyle> emptyStyles_ {};
    std::vector<MapStyle>       customStyles_ {
@@ -844,6 +845,22 @@ void MapWidget::ScreenCapture(types::CaptureType captureType)
       this, static_cast<void (QWidget::*)()>(&QWidget::update));
 }
 
+void MapWidget::FocusAlert(const types::TextEventKey& key)
+{
+   for (auto& layer : p->alertLayers_)
+   {
+      layer->FocusAlert(key);
+   }
+}
+
+void MapWidget::UnfocusAlert()
+{
+   for (auto& layer : p->alertLayers_)
+   {
+      layer->UnfocusAlert();
+   }
+}
+
 void MapWidget::SelectElevation(float elevation)
 {
    auto radarProductView = p->context_->radar_product_view();
@@ -1237,6 +1254,7 @@ void MapWidgetImpl::AddLayers()
    }
    layerList_.clear();
    genericLayers_.clear();
+   alertLayers_.clear();
    placefileLayers_.clear();
 
    // Update custom layer list from model
@@ -1301,6 +1319,7 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
 
       std::shared_ptr<AlertLayer> alertLayer =
          std::make_shared<AlertLayer>(glContext_, phenomenon);
+      alertLayers_.push_back(alertLayer);
       AddLayer(fmt::format("alert.{}", awips::GetPhenomenonCode(phenomenon)),
                alertLayer,
                before);

--- a/scwx-qt/source/scwx/qt/map/map_widget.hpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.hpp
@@ -121,6 +121,18 @@ public:
     * @param [in] updateRadarSite Whether to update the selected radar site to
     * the closest WSR-88D site. Default is false.
     */
+   /**
+    * @brief Focus a single alert on all map layers, hiding all others.
+    *
+    * @param [in] key Alert key to focus
+    */
+   void FocusAlert(const types::TextEventKey& key);
+
+   /**
+    * @brief Remove alert focus, showing all alerts.
+    */
+   void UnfocusAlert();
+
    void SetMapLocation(double latitude,
                        double longitude,
                        bool   updateRadarSite = false);

--- a/scwx-qt/source/scwx/qt/settings/general_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/general_settings.cpp
@@ -34,7 +34,7 @@ public:
       std::string defaultDefaultTimeZoneValue =
          types::GetDefaultTimeZoneName(types::DefaultTimeZone::Radar);
       std::string defaultMapProviderValue =
-         map::GetMapProviderName(map::MapProvider::MapTiler);
+         map::GetMapProviderName(map::MapProvider::Mapbox);
       std::string defaultPositioningPlugin =
          types::GetPositioningPluginName(types::PositioningPlugin::Default);
       std::string defaultThemeValue =

--- a/scwx-qt/source/scwx/qt/ui/alert_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dialog.cpp
@@ -1,10 +1,19 @@
 #include "alert_dialog.hpp"
 #include "ui_alert_dialog.h"
 
+#include <scwx/qt/config/county_database.hpp>
 #include <scwx/qt/manager/text_event_manager.hpp>
 #include <scwx/util/logger.hpp>
+#include <scwx/util/strings.hpp>
+#include <scwx/util/time.hpp>
 
 #include <QPushButton>
+#include <QClipboard>
+#include <QApplication>
+#include <QColor>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QStandardPaths>
 
 namespace scwx
 {
@@ -15,6 +24,26 @@ namespace ui
 
 static const std::string logPrefix_ = "scwx::qt::ui::alert_dialog";
 static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
+
+// Phenomenon header background colors
+static QColor GetPhenomenonColor(awips::Phenomenon phenomenon)
+{
+   switch (phenomenon)
+   {
+   case awips::Phenomenon::Tornado:
+      return QColor(0xcc, 0x00, 0x00);
+   case awips::Phenomenon::SevereThunderstorm:
+      return QColor(0xcc, 0x77, 0x00);
+   case awips::Phenomenon::FlashFlood:
+      return QColor(0x00, 0x80, 0x00);
+   case awips::Phenomenon::Marine:
+      return QColor(0x22, 0x55, 0x99);
+   case awips::Phenomenon::SnowSquall:
+      return QColor(0x00, 0x66, 0x88);
+   default:
+      return QColor(0x33, 0x33, 0x55);
+   }
+}
 
 class AlertDialogImpl : public QObject
 {
@@ -34,6 +63,7 @@ public:
    void ConnectSignals();
    void SelectIndex(size_t newIndex);
    void UpdateAlertInfo();
+   void UpdateCardStyle();
 
    AlertDialog* self_;
 
@@ -51,16 +81,15 @@ AlertDialog::AlertDialog(QWidget* parent) :
     ui(new Ui::AlertDialog)
 {
    ui->setupUi(this);
+   setWindowTitle(tr("Alert Details"));
 
-   // Set monospace font for alert view
+   // Set monospace font for raw alert text
    QFont monospaceFont("?");
    monospaceFont.setStyleHint(QFont::StyleHint::TypeWriter);
-
    if (!monospaceFont.fixedPitch())
    {
       monospaceFont.setStyleHint(QFont::StyleHint::Monospace);
    }
-
    ui->alertText->setFont(monospaceFont);
 
    // Add Go button to button box
@@ -102,8 +131,6 @@ bool AlertDialog::SelectAlert(const types::TextEventKey& key)
 {
    p->key_ = key;
 
-   setWindowTitle(QString::fromStdString(key.ToFullString()));
-
    auto messages = p->textEventManager_->message_list(key);
    if (messages.empty())
    {
@@ -111,7 +138,6 @@ bool AlertDialog::SelectAlert(const types::TextEventKey& key)
    }
 
    p->SelectIndex(messages.size() - 1u);
-
    return true;
 }
 
@@ -139,31 +165,203 @@ void AlertDialogImpl::UpdateAlertInfo()
    auto   messages     = textEventManager_->message_list(key_);
    size_t messageCount = messages.size();
 
+   if (messageCount == 0u)
+   {
+      return;
+   }
+
    bool firstSelected = (currentIndex_ == 0u);
    bool lastSelected  = (currentIndex_ == messageCount - 1u);
 
    self_->ui->firstButton->setEnabled(!firstSelected);
    self_->ui->previousButton->setEnabled(!firstSelected);
-
    self_->ui->nextButton->setEnabled(!lastSelected);
    self_->ui->lastButton->setEnabled(!lastSelected);
 
    self_->ui->messageCountLabel->setText(
       QObject::tr("%1 of %2").arg(currentIndex_ + 1u).arg(messageCount));
 
-   // Update centroid
-   auto alertSegment = messages[currentIndex_]->segments().back();
-   if (alertSegment->codedLocation_.has_value())
+   // Get current message and its last segment
+   auto& message = messages[currentIndex_];
+   if (message->segment_count() == 0)
+   {
+      return;
+   }
+   auto segment = message->segments().back();
+
+   // Update centroid / Go button
+   if (segment->codedLocation_.has_value())
    {
       centroid_ =
-         common::GetCentroid(alertSegment->codedLocation_->coordinates());
+         common::GetCentroid(segment->codedLocation_->coordinates());
    }
    else
    {
       centroid_ = common::Coordinate {};
    }
-
    goButton_->setEnabled(centroid_ != common::Coordinate {});
+
+   // Phenomenon and significance
+   awips::Phenomenon   phenomenon   = key_.phenomenon_;
+   awips::Significance significance = key_.significance_;
+
+   QString phenomenonText =
+      QString::fromStdString(awips::GetPhenomenonText(phenomenon));
+   QString significanceText =
+      QString::fromStdString(awips::GetSignificanceText(significance));
+   QString alertType = phenomenonText + " " + significanceText;
+
+   // Window title
+   self_->setWindowTitle(alertType + " — " +
+                         QString::fromStdString(key_.officeId_));
+
+   // Header labels
+   self_->ui->alertTypeLabel->setText(alertType.toUpper());
+   self_->ui->alertSubtitleLabel->setText(
+      QObject::tr("Issued by NWS %1  |  ETN #%2")
+         .arg(QString::fromStdString(key_.officeId_))
+         .arg(key_.etn_));
+
+   // Header color
+   UpdateCardStyle();
+
+   // Threat category
+   awips::ibw::ThreatCategory threatCategory = segment->threatCategory_;
+
+   // Emergency = Catastrophic threat
+   bool isEmergency =
+      (threatCategory == awips::ibw::ThreatCategory::Catastrophic);
+
+   // PDS = Considerable+ threat for Tornado or FlashFlood, but not Emergency
+   bool isPds = false;
+   if (!isEmergency &&
+       threatCategory >= awips::ibw::ThreatCategory::Considerable)
+   {
+      if (phenomenon == awips::Phenomenon::Tornado ||
+          phenomenon == awips::Phenomenon::FlashFlood)
+      {
+         isPds = true;
+      }
+   }
+
+   // Badges
+   self_->ui->emergencyLabel->setVisible(isEmergency);
+   self_->ui->pdsLabel->setVisible(isPds);
+
+   // Observed vs Radar Indicated
+   const auto& ibwInfo   = awips::ibw::GetImpactBasedWarningInfo(phenomenon);
+   bool        observed  = segment->observed_;
+   self_->ui->observedLabel->setVisible(ibwInfo.hasObservedTag_ && observed);
+   self_->ui->radarIndicatedLabel->setVisible(ibwInfo.hasObservedTag_ &&
+                                              !observed);
+
+   // Tornado Possible
+   self_->ui->tornadoPossibleLabel->setVisible(segment->tornadoPossible_);
+
+   // Times
+   auto startTime = messages.front()->segment_event_begin(0);
+   std::chrono::system_clock::time_point endTime {};
+   if (!segment->header_->vtecString_.empty())
+   {
+      endTime = segment->header_->vtecString_[0].pVtec_.event_end();
+   }
+
+   const auto* tz      = scwx::util::time::current_time_zone();
+   auto        clockFmt = scwx::util::time::ClockFormat::Default;
+
+   self_->ui->issuedValueLabel->setText(
+      QString::fromStdString(scwx::util::TimeString(startTime, clockFmt, tz)));
+   self_->ui->expiresValueLabel->setText(
+      QString::fromStdString(scwx::util::TimeString(endTime, clockFmt, tz)));
+
+   // Areas affected
+   {
+      auto&  lastMsg  = messages.back();
+      size_t segCount = lastMsg->segment_count();
+      auto   lastSeg  = lastMsg->segment(segCount - 1);
+      auto   fipsIds  = lastSeg->header_->ugc_.fips_ids();
+      auto   states   = lastSeg->header_->ugc_.states();
+
+      std::vector<std::string> counties;
+      counties.reserve(fipsIds.size());
+      for (auto& id : fipsIds)
+      {
+         counties.push_back(config::CountyDatabase::GetCountyName(id));
+      }
+      std::sort(counties.begin(), counties.end());
+
+      QString stateStr =
+         QString::fromStdString(scwx::util::ToString(states));
+      QString countyStr =
+         QString::fromStdString(scwx::util::ToString(counties));
+
+      if (!stateStr.isEmpty() && !countyStr.isEmpty())
+      {
+         self_->ui->areasValueLabel->setText(stateStr + ": " + countyStr);
+      }
+      else if (!countyStr.isEmpty())
+      {
+         self_->ui->areasValueLabel->setText(countyStr);
+      }
+      else
+      {
+         self_->ui->areasValueLabel->setText("—");
+      }
+   }
+
+   // Hazard level
+   QString threatName;
+   if (isEmergency)
+   {
+      threatName = "Emergency";
+   }
+   else if (isPds)
+   {
+      threatName =
+         "PDS — " +
+         QString::fromStdString(
+            awips::ibw::GetThreatCategoryName(threatCategory));
+   }
+   else
+   {
+      threatName = QString::fromStdString(
+         awips::ibw::GetThreatCategoryName(threatCategory));
+   }
+   self_->ui->hazardValueLabel->setText(threatName);
+
+   // Event ID
+   self_->ui->eventValueLabel->setText(
+      QString("ETN %1 / %2")
+         .arg(key_.etn_)
+         .arg(QString::fromStdString(key_.officeId_)));
+
+   // Active status badge
+   if (segment->header_.has_value() && !segment->header_->vtecString_.empty())
+   {
+      auto action = segment->header_->vtecString_[0].pVtec_.action();
+      bool active = (action != awips::PVtec::Action::Canceled &&
+                     action != awips::PVtec::Action::Expired);
+      self_->ui->alertStatusLabel->setText(active ? "● ACTIVE" : "○ EXPIRED");
+      self_->ui->alertStatusLabel->setStyleSheet(
+         active ? "color: #44ff44; font-weight: bold;"
+                : "color: #888888; font-weight: bold;");
+   }
+}
+
+void AlertDialogImpl::UpdateCardStyle()
+{
+   awips::Phenomenon phenomenon  = key_.phenomenon_;
+   QColor            headerColor = GetPhenomenonColor(phenomenon);
+
+   QString headerStyle =
+      QString("QFrame#alertHeaderFrame { background-color: %1; }")
+         .arg(headerColor.name(QColor::HexRgb));
+   self_->ui->alertHeaderFrame->setStyleSheet(headerStyle);
+
+   QString badgesStyle =
+      QString("QFrame#alertBadgesFrame { background-color: %1; }")
+         .arg(headerColor.darker(170).name(QColor::HexRgb));
+   self_->ui->alertBadgesFrame->setStyleSheet(badgesStyle);
 }
 
 void AlertDialog::on_firstButton_clicked()
@@ -184,6 +382,46 @@ void AlertDialog::on_nextButton_clicked()
 void AlertDialog::on_lastButton_clicked()
 {
    p->SelectIndex(p->textEventManager_->message_count(p->key_) - 1u);
+}
+
+void AlertDialog::on_screenshotButton_clicked()
+{
+   // Grab just the alert card frame as a social media card
+   QPixmap pixmap = ui->alertCardFrame->grab();
+
+   if (pixmap.isNull())
+   {
+      logger_->warn("Failed to capture alert card pixmap");
+      return;
+   }
+
+   // Copy to clipboard immediately
+   QApplication::clipboard()->setPixmap(pixmap);
+
+   // Offer to save to a file
+   QString defaultName =
+      QString("alert_%1_%2.png")
+         .arg(QString::fromStdString(p->key_.officeId_))
+         .arg(p->key_.etn_);
+
+   QString picturesDir =
+      QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+
+   QString savePath = QFileDialog::getSaveFileName(
+      this,
+      tr("Save Alert Card"),
+      picturesDir + "/" + defaultName,
+      tr("PNG Image (*.png);;JPEG Image (*.jpg)"));
+
+   if (!savePath.isEmpty())
+   {
+      if (!pixmap.save(savePath))
+      {
+         QMessageBox::warning(this,
+                              tr("Save Failed"),
+                              tr("Could not save the alert card image."));
+      }
+   }
 }
 
 #include "alert_dialog.moc"

--- a/scwx-qt/source/scwx/qt/ui/alert_dialog.hpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dialog.hpp
@@ -34,6 +34,7 @@ public slots:
    void on_previousButton_clicked();
    void on_nextButton_clicked();
    void on_lastButton_clicked();
+   void on_screenshotButton_clicked();
 
 signals:
    void MoveMap(double latitude, double longitude);

--- a/scwx-qt/source/scwx/qt/ui/alert_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/alert_dialog.ui
@@ -6,24 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
-    <height>600</height>
+    <width>600</width>
+    <height>780</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Alert Details</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="outerLayout">
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>10</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>10</number>
+   </property>
+   <!-- Navigation row -->
    <item>
-    <widget class="QTextBrowser" name="alertText">
-     <property name="lineWrapMode">
-      <enum>QTextEdit::LineWrapMode::NoWrap</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <layout class="QHBoxLayout" name="horizontalLayout">
+    <widget class="QFrame" name="navFrame">
+     <layout class="QHBoxLayout" name="navLayout">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -65,6 +74,19 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="messageCountLabel">
+        <property name="text">
+         <string># of #</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="minimumWidth">
+         <number>60</number>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QToolButton" name="nextButton">
         <property name="toolTip">
          <string>Next</string>
@@ -93,20 +115,368 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="messageCountLabel">
-        <property name="text">
-         <string># of #</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="navSpacer">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="alertStatusLabel">
+        <property name="text">
+         <string></string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <!-- Social Media Card Frame (this is what gets screenshotted) -->
+   <item>
+    <widget class="QFrame" name="alertCardFrame">
+     <property name="frameShape">
+      <enum>QFrame::Shape::StyledPanel</enum>
+     </property>
+     <layout class="QVBoxLayout" name="cardLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <!-- Header section (colored by phenomenon) -->
+      <item>
+       <widget class="QFrame" name="alertHeaderFrame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <layout class="QVBoxLayout" name="headerLayout">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>16</number>
+         </property>
+         <property name="topMargin">
+          <number>14</number>
+         </property>
+         <property name="rightMargin">
+          <number>16</number>
+         </property>
+         <property name="bottomMargin">
+          <number>14</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="alertTypeLabel">
+           <property name="text">
+            <string>ALERT</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="alertSubtitleLabel">
+           <property name="text">
+            <string>Issued by NWS</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <!-- Badges row -->
+      <item>
+       <widget class="QFrame" name="alertBadgesFrame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <layout class="QHBoxLayout" name="badgesLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>12</number>
+         </property>
+         <property name="topMargin">
+          <number>8</number>
+         </property>
+         <property name="rightMargin">
+          <number>12</number>
+         </property>
+         <property name="bottomMargin">
+          <number>8</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="emergencyLabel">
+           <property name="text">
+            <string>EMERGENCY</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="pdsLabel">
+           <property name="text">
+            <string>PDS</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="observedLabel">
+           <property name="text">
+            <string>OBSERVED</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="radarIndicatedLabel">
+           <property name="text">
+            <string>RADAR INDICATED</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="tornadoPossibleLabel">
+           <property name="text">
+            <string>TORNADO POSSIBLE</string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="badgesSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <!-- Info grid section -->
+      <item>
+       <widget class="QFrame" name="alertInfoFrame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <layout class="QGridLayout" name="infoGridLayout">
+         <property name="leftMargin">
+          <number>16</number>
+         </property>
+         <property name="topMargin">
+          <number>12</number>
+         </property>
+         <property name="rightMargin">
+          <number>16</number>
+         </property>
+         <property name="bottomMargin">
+          <number>12</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>24</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>12</number>
+         </property>
+         <!-- Row 0: Issued / Expires -->
+         <item row="0" column="0">
+          <widget class="QLabel" name="issuedFieldLabel">
+           <property name="text">
+            <string>ISSUED</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="expiresFieldLabel">
+           <property name="text">
+            <string>EXPIRES</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="issuedValueLabel">
+           <property name="text">
+            <string>—</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldValue</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="expiresValueLabel">
+           <property name="text">
+            <string>—</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldValue</string>
+           </property>
+          </widget>
+         </item>
+         <!-- Row 2: Areas Affected -->
+         <item row="2" column="0" colspan="2">
+          <widget class="QLabel" name="areasFieldLabel">
+           <property name="text">
+            <string>AREAS AFFECTED</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <widget class="QLabel" name="areasValueLabel">
+           <property name="text">
+            <string>—</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldValue</string>
+           </property>
+          </widget>
+         </item>
+         <!-- Row 4: Hazards / Threat -->
+         <item row="4" column="0">
+          <widget class="QLabel" name="hazardFieldLabel">
+           <property name="text">
+            <string>HAZARD LEVEL</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="eventFieldLabel">
+           <property name="text">
+            <string>EVENT #</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="hazardValueLabel">
+           <property name="text">
+            <string>—</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldValue</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLabel" name="eventValueLabel">
+           <property name="text">
+            <string>—</string>
+           </property>
+           <property name="property" stdset="0">
+            <string notr="true">alertFieldValue</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <!-- Raw alert text -->
+   <item>
+    <widget class="QTextBrowser" name="alertText">
+     <property name="lineWrapMode">
+      <enum>QTextEdit::LineWrapMode::NoWrap</enum>
+     </property>
+    </widget>
+   </item>
+   <!-- Action buttons row -->
+   <item>
+    <widget class="QFrame" name="actionFrame">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
+     </property>
+     <layout class="QHBoxLayout" name="actionLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="screenshotButton">
+        <property name="objectName">
+         <string>screenshotButton</string>
+        </property>
+        <property name="text">
+         <string>📷  Share Card</string>
+        </property>
+        <property name="toolTip">
+         <string>Copy alert card to clipboard for social media sharing</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="actionSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
           <height>20</height>
          </size>
         </property>
@@ -131,22 +501,6 @@
   <include location="../../../../scwx-qt.qrc"/>
  </resources>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>AlertDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>

--- a/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dock_widget.cpp
@@ -167,11 +167,19 @@ void AlertDockWidgetImpl::ConnectSignals()
             selectedAlertCentroid_ = alertModel_->centroid(selectedAlertKey_);
             itemHasCoordinates =
                selectedAlertCentroid_ != common::Coordinate {};
+
+            // Focus this alert on the map, hiding all others
+            Q_EMIT self_->FocusAlertOnMap(selectedAlertKey_);
+            self_->ui->focusIndicatorFrame->setVisible(true);
          }
          else
          {
             selectedAlertKey_      = {};
             selectedAlertCentroid_ = {};
+
+            // Remove focus so all alerts are shown again
+            Q_EMIT self_->UnfocusAlertOnMap();
+            self_->ui->focusIndicatorFrame->setVisible(false);
          }
 
          self_->ui->alertViewButton->setEnabled(itemSelected);

--- a/scwx-qt/source/scwx/qt/ui/alert_dock_widget.hpp
+++ b/scwx-qt/source/scwx/qt/ui/alert_dock_widget.hpp
@@ -31,6 +31,8 @@ protected:
 
 signals:
    void MoveMap(double latitude, double longitude);
+   void FocusAlertOnMap(const types::TextEventKey& key);
+   void UnfocusAlertOnMap();
 
 public slots:
    void HandleMapUpdate(double latitude, double longitude);

--- a/scwx-qt/source/scwx/qt/ui/alert_dock_widget.ui
+++ b/scwx-qt/source/scwx/qt/ui/alert_dock_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>460</width>
     <height>300</height>
    </rect>
   </property>
@@ -15,6 +15,21 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>4</number>
+    </property>
+    <property name="leftMargin">
+     <number>4</number>
+    </property>
+    <property name="topMargin">
+     <number>4</number>
+    </property>
+    <property name="rightMargin">
+     <number>4</number>
+    </property>
+    <property name="bottomMargin">
+     <number>4</number>
+    </property>
     <item>
      <widget class="QTreeView" name="alertView">
       <property name="alternatingRowColors">
@@ -26,10 +41,46 @@
       <property name="sortingEnabled">
        <bool>true</bool>
       </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+      </property>
      </widget>
     </item>
+    <!-- Focus indicator bar (shown when an alert is selected/focused) -->
     <item>
-     <widget class="QFrame" name="frame_2">
+     <widget class="QFrame" name="focusIndicatorFrame">
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <layout class="QHBoxLayout" name="focusLayout">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="focusIndicatorLabel">
+         <property name="text">
+          <string>● Focused on map — click another row or press Esc to show all</string>
+         </property>
+         <property name="styleSheet">
+          <string>color: #44aaff; font-size: 11px;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <!-- Bottom controls -->
+    <item>
+     <widget class="QFrame" name="controlsFrame">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <property name="leftMargin">
         <number>0</number>
@@ -46,7 +97,7 @@
        <item>
         <widget class="QLineEdit" name="alertFilter">
          <property name="placeholderText">
-          <string>Filter</string>
+          <string>Filter alerts…</string>
          </property>
          <property name="clearButtonEnabled">
           <bool>true</bool>
@@ -60,7 +111,7 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>40</width>
+           <width>10</width>
            <height>20</height>
           </size>
          </property>
@@ -86,7 +137,10 @@
        <item>
         <widget class="QPushButton" name="alertViewButton">
          <property name="text">
-          <string>&amp;View</string>
+          <string>&amp;Details</string>
+         </property>
+         <property name="toolTip">
+          <string>View full alert details</string>
          </property>
         </widget>
        </item>
@@ -94,6 +148,9 @@
         <widget class="QPushButton" name="alertGoButton">
          <property name="text">
           <string>&amp;Go</string>
+         </property>
+         <property name="toolTip">
+          <string>Pan map to this alert</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
…card

- Switch default map provider from MapTiler to Mapbox in GeneralSettings
- Add comprehensive modern dark stylesheet (res/qss/modern.qss) applied at startup via ApplyModernStylesheet(); covers all major Qt widget classes plus custom object-name selectors for the alert card, badges, and key bar
- Add Mapbox API key notification bar (ConfigureMapboxKeyBar()) shown in the status bar area when Mapbox is selected but no key is configured, with a quick link to Settings
- Redesign AlertDialog as a structured "alert card" with a colored header (phenomenon-specific color), PDS/Emergency/Observed/Radar-indicated/Tornado Possible badge row, an info grid (issued, expires, areas affected, hazard level, event number), raw alert text, and a Share Card screenshot button that captures the card via QWidget::grab() and copies it to the clipboard (with optional file save)
- Add FocusAlert(key)/UnfocusAlert() to AlertLayer; iterates linesBySegment_ and calls SetLineVisible() to hide all polygons except the focused alert
- Expose FocusAlert/UnfocusAlert on MapWidget, iterating all AlertLayer instances
- Emit FocusAlertOnMap/UnfocusAlertOnMap signals from AlertDockWidget when the selection changes; show/hide a focus indicator bar inside the dock widget
- Wire focus signals in ConnectOtherSignals() so selection changes in the Alerts dock propagate to all map widgets
- Register res/qss/modern.qss in scwx-qt.qrc

https://claude.ai/code/session_012427xdYZKiNFTueCVwdJqP