### PR TITLE
Fix map style reset to default when API key changes (#605)

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -11,3 +11,21 @@
 - Team initialized on 2026-04-04 under the Alien cast.
 - Parker owns scwx-qt, Qt managers, views, and rendering integration.
 - Use `Q_EMIT` for Qt signals in this repo.
+- When a map load fails due to an invalid API key, `SetMapStyle("None")` is called. When the API key later changes to a valid one, the style name "None" must be treated as "no valid style" — pass `""` to `ResolveMapStyleName` or `ResetMap` so the provider's default style is used instead of staying blank. (Issue #605)
+
+## Session History
+
+### 2026-04-04 — Fixed Map Style Reset on API Key Change (Issue #605)
+
+**Status:** ✅ Complete
+
+Fixed regression in `MapWidgetImpl::ConnectSignals()` where map remained blank after user corrected invalid API key.
+
+**Changes:**
+- Modified `mapbox_api_key` lambda to check if active style is "None" and reset to default
+- Modified `maptiler_api_key` lambda with same logic
+- File: `scwx-qt/source/scwx/qt/map/map_widget.cpp`
+
+**Decision:** Treat "None" as equivalent to empty style name, allowing provider defaults to apply. Merged to canonical decisions.md.
+
+**Commit:** `Fix map style reset to default when API key changes (#605)`

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,7 +2,17 @@
 
 ## Active Decisions
 
-No decisions recorded yet.
+### Treat "None" Style as Empty on API Key Change
+
+**Author:** Parker  
+**Date:** 2026-04-04  
+**Issue:** #605
+
+When a map fails to load due to an invalid API key, `SetMapStyle("None")` is called to signal no valid style is active. When the user later enters a valid API key, the `mapbox_api_key` and `maptiler_api_key` changed signals fire — but they were passing the literal style name `"None"` into `ResetMap` / `SetMapStyle`, leaving the map blank.
+
+**Decision:** In the API key changed signal lambdas inside `MapWidgetImpl::ConnectSignals()`, treat `"None"` as equivalent to an empty style name. Pass `""` to `ResetMap` (Mapbox path) and call `ResolveMapStyleName("")` (MapTiler path) so the provider's first/default style is used instead.
+
+**Rationale:** `ResolveMapStyleName("")` already handles the "no style requested" case by returning the first style for the current provider. This is the correct semantic: if the previous style was invalid (None), restoring a working API key should restore the default style rather than preserving the failed state.
 
 ## Governance
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -474,8 +474,9 @@ void MapWidgetImpl::ConnectSignals()
             {
                // Reset the map, since the API key is embedded in settings
                settings_.setApiKey(QString::fromStdString(event.newValue_));
-               ResetMap(currentStyle_ ? currentStyle_->name_ :
-                                        initialStyleName_);
+               const std::string& activeStyleName =
+                  currentStyle_ ? currentStyle_->name_ : initialStyleName_;
+               ResetMap(activeStyleName == "None" ? "" : activeStyleName);
             }
          }));
    connections_.emplace_back(
@@ -485,8 +486,11 @@ void MapWidgetImpl::ConnectSignals()
             if (context_->map_provider() == MapProvider::MapTiler)
             {
                // Reapply style instead of resetting the map
-               widget_->SetMapStyle(currentStyle_ ? currentStyle_->name_ :
-                                                    initialStyleName_,
+               const std::string& activeStyleName =
+                  currentStyle_ ? currentStyle_->name_ : initialStyleName_;
+               widget_->SetMapStyle(activeStyleName == "None" ?
+                                       ResolveMapStyleName("") :
+                                       activeStyleName,
                                     true);
             }
          }));


### PR DESCRIPTION
When a map fails to load due to an invalid API key, the map style falls back to "None". When the user subsequently enters a valid API key, the API key changed signal now checks if the active style is "None" and resets to the provider's default style instead of keeping the blank map.