### PR TITLE
Fix macOS pinch zoom anchor in multi-pane layouts

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -664,8 +664,16 @@ void MapWidgetImpl::HandlePinchGesture(QPinchGesture* gesture)
 {
    if (gesture->changeFlags() & QPinchGesture::ChangeFlag::ScaleFactorChanged)
    {
+#ifdef Q_OS_MACOS
+      // The macOS native pinch recognizer stores centerPoint() in
+      // widget-local coordinates.
+      map_->scaleBy(gesture->scaleFactor(), gesture->centerPoint());
+#else
+      // The generic pinch recognizer stores centerPoint() in global
+      // coordinates, so convert it to widget-local coordinates first.
       map_->scaleBy(gesture->scaleFactor(),
                     widget_->mapFromGlobal(gesture->centerPoint()));
+#endif
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -664,7 +664,7 @@ void MapWidgetImpl::HandlePinchGesture(QPinchGesture* gesture)
 {
    if (gesture->changeFlags() & QPinchGesture::ChangeFlag::ScaleFactorChanged)
    {
-#ifdef Q_OS_MACOS
+#if defined(__APPLE__)
       // The macOS native pinch recognizer stores centerPoint() in
       // widget-local coordinates.
       map_->scaleBy(gesture->scaleFactor(), gesture->centerPoint());


### PR DESCRIPTION
## Summary
Fix pinch zoom anchoring when multiple grid panes are visible on macOS without regressing the generic pinch path on other platforms.

## Root Cause
Qt uses different pinch recognizers by platform:
- On macOS, `QMacPinchGestureRecognizer` stores `QPinchGesture::centerPoint()` in widget-local coordinates.
- On non-macOS platforms, the generic `QPinchGestureRecognizer` stores `centerPoint()` in global coordinates.

The previous code always called `widget_->mapFromGlobal(gesture->centerPoint())`.
That was correct for the generic recognizer, but on macOS it double-mapped an already-local point, shifting the zoom anchor by the pane's screen offset. In a multi-pane layout this caused pinch zoom in the right pane to pull left.

## Change
- On macOS, pass `gesture->centerPoint()` directly to `map_->scaleBy()`.
- On other platforms, preserve the existing `mapFromGlobal()` conversion.

## Testing
- Manual test on macOS
- 2-pane layout
- Pinch zoom in left pane: correct
- Pinch zoom in right pane: now anchors correctly instead of drifting left
- Rebuilt locally with `cmake --build build-macos-arm64 --config Release --target supercell-wx -j8`

## Notes
I did not add automated coverage for this change. The repo has GTest coverage but no existing GUI gesture test harness for `MapWidget` / `QOpenGLWidget` pinch input, so adding one here would be disproportionately large relative to the fix.
