### PR TITLE
Use macOS wheel gestures for map panning

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1649,6 +1649,20 @@ void MapWidget::mouseMoveEvent(QMouseEvent* ev)
 
 void MapWidget::wheelEvent(QWheelEvent* ev)
 {
+#if defined(__APPLE__)
+   // On macOS, trackpad scrolling should pan the map. Pinch remains the only
+   // preferred zoom gesture. If no pixel delta is available, fall back to the
+   // existing wheel zoom behavior below.
+   if (!ev->pixelDelta().isNull())
+   {
+      QPoint pixelDelta = ev->pixelDelta();
+      p->map_->moveBy(QPointF {static_cast<qreal>(pixelDelta.x()),
+                               static_cast<qreal>(pixelDelta.y())});
+      ev->accept();
+      return;
+   }
+#endif
+
    if (ev->angleDelta().y() == 0)
    {
       return;

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1655,9 +1655,7 @@ void MapWidget::wheelEvent(QWheelEvent* ev)
    // existing wheel zoom behavior below.
    if (!ev->pixelDelta().isNull())
    {
-      QPoint pixelDelta = ev->pixelDelta();
-      p->map_->moveBy(QPointF {static_cast<qreal>(pixelDelta.x()),
-                               static_cast<qreal>(pixelDelta.y())});
+      p->map_->moveBy(QPointF(ev->pixelDelta()));
       ev->accept();
       return;
    }


### PR DESCRIPTION
## Summary
On macOS, use `QWheelEvent::pixelDelta()` to pan the map instead of treating high-resolution trackpad scroll input like mouse-wheel zoom.

If no pixel delta is available, fall back to the existing `angleDelta()` zoom path so external mouse wheels keep their current behavior.

## Why
Two-finger trackpad movement on macOS is normally interpreted as panning scrollable content. For the map widget, that behavior feels more native than zooming on the same gesture.

## Change
- macOS only
- In `MapWidget::wheelEvent()`, detect non-null `pixelDelta()`
- Pan with `map_->moveBy(...)`
- Preserve the existing wheel zoom logic as the fallback path
- Keep pinch zoom behavior unchanged

## Testing
Manual testing on macOS:
- Two-finger trackpad movement pans the map
- Pinch gesture still zooms
- Mouse-wheel input still falls back to the existing zoom behavior

## Tests
No automated test was added. `CONTRIBUTING.md` asks for tests for bug fixes and features, but this repo does not currently have a widget-event or gesture test harness around `MapWidget` / `QOpenGLWidget`, so this change was validated manually on macOS.