### PR TITLE
Persist per-product threshold settings

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -19,6 +19,7 @@
 #include <scwx/qt/model/radar_site_model.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/settings/map_settings.hpp>
+#include <scwx/qt/settings/product_settings.hpp>
 #include <scwx/qt/settings/ui_settings.hpp>
 #include <scwx/qt/ui/about_dialog.hpp>
 #include <scwx/qt/ui/alert_dock_widget.hpp>
@@ -128,6 +129,7 @@ public:
                            common::RadarProductGroup group,
                            const std::string&        productName,
                            int16_t                   productCode);
+   void ApplyStoredColorTableThreshold(map::MapWidget* mapWidget);
    void SetActiveMap(map::MapWidget* mapWidget);
    void UpdateAvailableLevel3Products();
    void UpdateElevationSelection(float elevation);
@@ -1272,26 +1274,36 @@ void MainWindowImpl::ConnectOtherSignals()
            &ui::Level2SettingsWidget::ElevationSelected,
            mainWindow_,
            [&](float elevation) { SelectElevation(activeMap_, elevation); });
-   connect(level2SettingsWidget_,
-           &ui::Level2SettingsWidget::ThresholdChanged,
-           mainWindow_,
-           [&](std::optional<float> threshold)
-           {
-              if (activeMap_ != nullptr)
-              {
-                 activeMap_->SetColorTableThreshold(threshold);
-              }
-           });
-   connect(level3SettingsWidget_,
-           &ui::Level3SettingsWidget::ThresholdChanged,
-           mainWindow_,
-           [&](std::optional<float> threshold)
-           {
-              if (activeMap_ != nullptr)
-              {
-                 activeMap_->SetColorTableThreshold(threshold);
-              }
-           });
+   connect(
+      level2SettingsWidget_,
+      &ui::Level2SettingsWidget::ThresholdChanged,
+      mainWindow_,
+      [&](std::optional<float> threshold)
+      {
+         if (activeMap_ != nullptr)
+         {
+            settings::ProductSettings::Instance().set_color_table_threshold(
+               activeMap_->GetRadarProductGroup(),
+               activeMap_->GetRadarProductName(),
+               threshold);
+            activeMap_->SetColorTableThreshold(threshold);
+         }
+      });
+   connect(
+      level3SettingsWidget_,
+      &ui::Level3SettingsWidget::ThresholdChanged,
+      mainWindow_,
+      [&](std::optional<float> threshold)
+      {
+         if (activeMap_ != nullptr)
+         {
+            settings::ProductSettings::Instance().set_color_table_threshold(
+               activeMap_->GetRadarProductGroup(),
+               activeMap_->GetRadarProductName(),
+               threshold);
+            activeMap_->SetColorTableThreshold(threshold);
+         }
+      });
    connect(mainWindow_,
            &MainWindow::ActiveMapMoved,
            alertDockWidget_,
@@ -1631,6 +1643,24 @@ void MainWindowImpl::SelectRadarProduct(map::MapWidget*           mapWidget,
 
    mapWidget->SelectRadarProduct(
       group, productName, productCode, selectedTime_);
+   ApplyStoredColorTableThreshold(mapWidget);
+
+   if (mapWidget == activeMap_)
+   {
+      UpdateRadarProductSettings();
+   }
+}
+
+void MainWindowImpl::ApplyStoredColorTableThreshold(map::MapWidget* mapWidget)
+{
+   if (mapWidget == nullptr)
+   {
+      return;
+   }
+
+   mapWidget->SetColorTableThreshold(
+      settings::ProductSettings::Instance().color_table_threshold(
+         mapWidget->GetRadarProductGroup(), mapWidget->GetRadarProductName()));
 }
 
 void MainWindowImpl::SetActiveMap(map::MapWidget* mapWidget)
@@ -1699,6 +1729,8 @@ void MainWindowImpl::UpdateRadarProductSelection(
 
 void MainWindowImpl::UpdateRadarProductSettings()
 {
+   ApplyStoredColorTableThreshold(activeMap_);
+
    if (activeMap_->GetRadarProductGroup() == common::RadarProductGroup::Level2)
    {
       level2SettingsWidget_->setEnabled(true);

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -1658,9 +1658,16 @@ void MainWindowImpl::ApplyStoredColorTableThreshold(map::MapWidget* mapWidget)
       return;
    }
 
-   mapWidget->SetColorTableThreshold(
+   const auto threshold =
       settings::ProductSettings::Instance().color_table_threshold(
-         mapWidget->GetRadarProductGroup(), mapWidget->GetRadarProductName()));
+         mapWidget->GetRadarProductGroup(), mapWidget->GetRadarProductName());
+
+   if (mapWidget->GetColorTableThreshold() == threshold)
+   {
+      return;
+   }
+
+   mapWidget->SetColorTableThreshold(threshold);
 }
 
 void MainWindowImpl::SetActiveMap(map::MapWidget* mapWidget)

--- a/scwx-qt/source/scwx/qt/settings/product_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/product_settings.cpp
@@ -1,16 +1,44 @@
 #include <scwx/qt/settings/product_settings.hpp>
 #include <scwx/qt/settings/settings_container.hpp>
+#include <scwx/common/products.hpp>
+#include <scwx/util/logger.hpp>
 
+#include <cmath>
+#include <functional>
+#include <map>
 #include <string>
 
 namespace scwx::qt::settings
 {
 
 static const std::string logPrefix_ = "scwx::qt::settings::product_settings";
+static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
+
+static const std::string kThresholdsName_ {"thresholds"};
+static const std::string kEnabledName_ {"enabled"};
+static const std::string kValueName_ {"value"};
 
 class ProductSettings::Impl
 {
 public:
+   struct ThresholdData
+   {
+      ThresholdData()
+      {
+         enabled_.SetDefault(false);
+         value_.SetDefault(0.0);
+         value_.SetValidator([](double value) { return std::isfinite(value); });
+      }
+
+      SettingsVariable<bool>   enabled_ {kEnabledName_};
+      SettingsVariable<double> value_ {kValueName_};
+
+      friend bool operator==(const ThresholdData& lhs, const ThresholdData& rhs)
+      {
+         return lhs.enabled_ == rhs.enabled_ && lhs.value_ == rhs.value_;
+      }
+   };
+
    explicit Impl()
    {
       // SetDefault, SetMinimum and SetMaximum are descriptive
@@ -27,10 +55,71 @@ public:
    Impl(const Impl&&)            = delete;
    Impl& operator=(const Impl&&) = delete;
 
+   static std::string NormalizeProductName(common::RadarProductGroup group,
+                                           const std::string& productName)
+   {
+      if (group == common::RadarProductGroup::Level3)
+      {
+         const std::string normalizedProduct =
+            common::GetLevel3ProductByAwipsId(productName);
+
+         if (normalizedProduct != "?")
+         {
+            return normalizedProduct;
+         }
+      }
+
+      return productName;
+   }
+
+   std::string ThresholdKey(common::RadarProductGroup group,
+                            const std::string&        productName) const
+   {
+      if (group == common::RadarProductGroup::Unknown || productName.empty())
+      {
+         return {};
+      }
+
+      return common::GetRadarProductGroupName(group) + ":" +
+             NormalizeProductName(group, productName);
+   }
+
+   ThresholdData& GetOrCreateThresholdData(const std::string& key)
+   {
+      return thresholdData_.try_emplace(key).first->second;
+   }
+
+   std::optional<std::reference_wrapper<ThresholdData>>
+   FindThresholdData(const std::string& key)
+   {
+      auto it = thresholdData_.find(key);
+
+      if (it == thresholdData_.end())
+      {
+         return std::nullopt;
+      }
+
+      return std::ref(it->second);
+   }
+
+   std::optional<std::reference_wrapper<const ThresholdData>>
+   FindThresholdData(const std::string& key) const
+   {
+      auto it = thresholdData_.find(key);
+
+      if (it == thresholdData_.end())
+      {
+         return std::nullopt;
+      }
+
+      return std::cref(it->second);
+   }
+
    SettingsVariable<bool> showSmoothedRangeFolding_ {
       "show_smoothed_range_folding"};
    SettingsVariable<bool> stiForecastEnabled_ {"sti_forecast_enabled"};
    SettingsVariable<bool> stiPastEnabled_ {"sti_past_enabled"};
+   std::map<std::string, ThresholdData> thresholdData_ {};
 };
 
 ProductSettings::ProductSettings() :
@@ -62,6 +151,56 @@ SettingsVariable<bool>& ProductSettings::sti_past_enabled()
    return p->stiPastEnabled_;
 }
 
+std::optional<float>
+ProductSettings::color_table_threshold(common::RadarProductGroup group,
+                                       const std::string& productName) const
+{
+   const std::string thresholdKey = p->ThresholdKey(group, productName);
+
+   if (thresholdKey.empty())
+   {
+      return std::nullopt;
+   }
+
+   auto thresholdData = p->FindThresholdData(thresholdKey);
+
+   if (!thresholdData.has_value() ||
+       !thresholdData->get().enabled_.GetStagedOrValue())
+   {
+      return std::nullopt;
+   }
+
+   return static_cast<float>(thresholdData->get().value_.GetStagedOrValue());
+}
+
+void ProductSettings::set_color_table_threshold(common::RadarProductGroup group,
+                                                const std::string& productName,
+                                                std::optional<float> threshold)
+{
+   const std::string thresholdKey = p->ThresholdKey(group, productName);
+
+   if (thresholdKey.empty())
+   {
+      return;
+   }
+
+   if (threshold.has_value())
+   {
+      auto& thresholdData = p->GetOrCreateThresholdData(thresholdKey);
+      thresholdData.value_.StageValue(*threshold);
+      thresholdData.enabled_.StageValue(true);
+   }
+   else
+   {
+      auto thresholdData = p->FindThresholdData(thresholdKey);
+
+      if (thresholdData.has_value())
+      {
+         thresholdData->get().enabled_.StageValue(false);
+      }
+   }
+}
+
 bool ProductSettings::Shutdown()
 {
    bool dataChanged = false;
@@ -70,7 +209,96 @@ bool ProductSettings::Shutdown()
    dataChanged |= p->stiForecastEnabled_.Commit();
    dataChanged |= p->stiPastEnabled_.Commit();
 
+   for (auto& thresholdEntry : p->thresholdData_)
+   {
+      auto& thresholdData = thresholdEntry.second;
+
+      dataChanged |= thresholdData.enabled_.Commit();
+      dataChanged |= thresholdData.value_.Commit();
+   }
+
    return dataChanged;
+}
+
+bool ProductSettings::ReadJson(const boost::json::object& json)
+{
+   bool validated = SettingsCategory::ReadJson(json);
+
+   p->thresholdData_.clear();
+
+   const boost::json::value* value = json.if_contains(name());
+
+   if (value != nullptr && value->is_object())
+   {
+      const boost::json::object& object = value->as_object();
+      const boost::json::value*  thresholdsValue =
+         object.if_contains(kThresholdsName_);
+
+      if (thresholdsValue != nullptr && thresholdsValue->is_object())
+      {
+         const boost::json::object& thresholdsObject =
+            thresholdsValue->as_object();
+
+         for (const auto& thresholdEntry : thresholdsObject)
+         {
+            if (!thresholdEntry.value().is_object())
+            {
+               logger_->warn(
+                  "Invalid json for threshold key {}, ignoring entry",
+                  thresholdEntry.key());
+               validated = false;
+               continue;
+            }
+
+            auto& thresholdData =
+               p->GetOrCreateThresholdData(std::string(thresholdEntry.key()));
+            const boost::json::object& thresholdObject =
+               thresholdEntry.value().as_object();
+
+            validated &= thresholdData.enabled_.ReadValue(thresholdObject);
+            validated &= thresholdData.value_.ReadValue(thresholdObject);
+         }
+      }
+      else
+      {
+         if (thresholdsValue == nullptr)
+         {
+            logger_->debug("Key {}.{} is not present, resetting to defaults",
+                           name(),
+                           kThresholdsName_);
+         }
+         else
+         {
+            logger_->warn("Invalid json for key {}.{}, resetting to defaults",
+                          name(),
+                          kThresholdsName_);
+         }
+
+         validated = false;
+      }
+   }
+
+   return validated;
+}
+
+void ProductSettings::WriteJson(boost::json::object& json) const
+{
+   SettingsCategory::WriteJson(json);
+
+   boost::json::object thresholdsObject;
+
+   for (const auto& thresholdEntry : p->thresholdData_)
+   {
+      boost::json::object thresholdObject;
+
+      thresholdEntry.second.enabled_.WriteValue(thresholdObject);
+      thresholdEntry.second.value_.WriteValue(thresholdObject);
+
+      thresholdsObject.insert_or_assign(thresholdEntry.first, thresholdObject);
+   }
+
+   boost::json::object& object = json.at(name()).as_object();
+   object.insert_or_assign(kThresholdsName_, thresholdsObject);
 }
 
 ProductSettings& ProductSettings::Instance()
@@ -84,7 +312,8 @@ bool operator==(const ProductSettings& lhs, const ProductSettings& rhs)
    return (lhs.p->showSmoothedRangeFolding_ ==
               rhs.p->showSmoothedRangeFolding_ &&
            lhs.p->stiForecastEnabled_ == rhs.p->stiForecastEnabled_ &&
-           lhs.p->stiPastEnabled_ == rhs.p->stiPastEnabled_);
+           lhs.p->stiPastEnabled_ == rhs.p->stiPastEnabled_ &&
+           lhs.p->thresholdData_ == rhs.p->thresholdData_);
 }
 
 } // namespace scwx::qt::settings

--- a/scwx-qt/source/scwx/qt/settings/product_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/product_settings.cpp
@@ -72,8 +72,8 @@ public:
       return productName;
    }
 
-   std::string ThresholdKey(common::RadarProductGroup group,
-                            const std::string&        productName) const
+   static std::string ThresholdKey(common::RadarProductGroup group,
+                                   const std::string&        productName)
    {
       if (group == common::RadarProductGroup::Unknown || productName.empty())
       {
@@ -92,7 +92,7 @@ public:
    std::optional<std::reference_wrapper<ThresholdData>>
    FindThresholdData(const std::string& key)
    {
-      auto it = thresholdData_.find(key);
+      const auto it = thresholdData_.find(key);
 
       if (it == thresholdData_.end())
       {
@@ -102,10 +102,10 @@ public:
       return std::ref(it->second);
    }
 
-   std::optional<std::reference_wrapper<const ThresholdData>>
+   [[nodiscard]] std::optional<std::reference_wrapper<const ThresholdData>>
    FindThresholdData(const std::string& key) const
    {
-      auto it = thresholdData_.find(key);
+      const auto it = thresholdData_.find(key);
 
       if (it == thresholdData_.end())
       {
@@ -155,7 +155,7 @@ std::optional<float>
 ProductSettings::color_table_threshold(common::RadarProductGroup group,
                                        const std::string& productName) const
 {
-   const std::string thresholdKey = p->ThresholdKey(group, productName);
+   const std::string thresholdKey = Impl::ThresholdKey(group, productName);
 
    if (thresholdKey.empty())
    {

--- a/scwx-qt/source/scwx/qt/settings/product_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/product_settings.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <scwx/common/products.hpp>
 #include <scwx/qt/settings/settings_category.hpp>
 #include <scwx/qt/settings/settings_variable.hpp>
 
 #include <memory>
+#include <optional>
+#include <string>
 
 namespace scwx::qt::settings
 {
@@ -23,6 +26,15 @@ public:
    SettingsVariable<bool>& show_smoothed_range_folding();
    SettingsVariable<bool>& sti_forecast_enabled();
    SettingsVariable<bool>& sti_past_enabled();
+   std::optional<float>
+        color_table_threshold(common::RadarProductGroup group,
+                              const std::string&        productName) const;
+   void set_color_table_threshold(common::RadarProductGroup group,
+                                  const std::string&        productName,
+                                  std::optional<float>      threshold);
+
+   bool ReadJson(const boost::json::object& json) override;
+   void WriteJson(boost::json::object& json) const override;
 
    static ProductSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/settings/product_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/product_settings.hpp
@@ -26,7 +26,8 @@ public:
    SettingsVariable<bool>& show_smoothed_range_folding();
    SettingsVariable<bool>& sti_forecast_enabled();
    SettingsVariable<bool>& sti_past_enabled();
-   std::optional<float>
+
+   [[nodiscard]] std::optional<float>
         color_table_threshold(common::RadarProductGroup group,
                               const std::string&        productName) const;
    void set_color_table_threshold(common::RadarProductGroup group,


### PR DESCRIPTION
Store threshold enabled/value state in ProductSettings so each radar product restores its previous threshold when switching products and after restart. Apply stored thresholds when product selection changes, commit staged values during shutdown, and update the existing settings JSON fixtures for the new product.thresholds schema.