### PR TITLE
Fix Linux setup script name in AGENTS; ignore aqtinstall.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _deps
 
 # Specific excludes for Supercell Wx
 tools/lib/user-setup.sh
+aqtinstall.log
 
 # CodeQL
 _codeql_detected_source_root

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ _deps
 
 # Specific excludes for Supercell Wx
 tools/lib/user-setup.sh
-aqtinstall.log
 
 # CodeQL
 _codeql_detected_source_root
@@ -35,3 +34,6 @@ _codeql_detected_source_root
 
 # Squad: SubSquad activation file (local to this machine)
 .squad-workstream
+
+# aqtinstall
+aqtinstall.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The project uses **Conan 2** for C++ dependency management. CMake integrates Con
 .\tools\setup-windows-vs2026-x64-release.bat [BUILD_DIR] [VENV_PATH]
 
 # Linux
-./tools/setup-linux-gcc-release.sh [BUILD_DIR] [CONAN_PROFILE] [VENV_PATH] [ASAN_ENABLE]
+./tools/setup-linux-ninja-release.sh [BUILD_DIR] [CONAN_PROFILE] [VENV_PATH] [ASAN_ENABLE]
 ```
 
 **Manual CMake configuration:**


### PR DESCRIPTION
AGENTS.md now points to tools/setup-linux-ninja-release.sh (the script that exists). .gitignore lists aqtinstall.log so local aqt runs do not dirty the tree.