### PR TITLE
Add manual threshold entry and colormap sync helpers

### DIFF
--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -311,6 +311,8 @@ set(HDR_UI source/scwx/qt/ui/about_dialog.hpp
            source/scwx/qt/ui/radar_site_dialog.hpp
            source/scwx/qt/ui/serial_port_dialog.hpp
            source/scwx/qt/ui/settings_dialog.hpp
+           source/scwx/qt/ui/threshold_line_edit_sync.hpp
+           source/scwx/qt/ui/threshold_value_utility.hpp
            source/scwx/qt/ui/update_dialog.hpp
            source/scwx/qt/ui/wfo_dialog.hpp)
 set(SRC_UI source/scwx/qt/ui/about_dialog.cpp

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -6,6 +6,7 @@
 #include <scwx/common/characters.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <execution>
 #include <limits>
@@ -399,6 +400,7 @@ void Level2SettingsWidgetImpl::UpdateThresholdValueDisplay(int  sliderValue,
                                         force_line_edit))
    {
       thresholdValueEdit_->setText(text);
+      thresholdValueEdit_->setModified(false);
    }
    thresholdUnitsLabel_->setText(
       QString::fromStdString(thresholdUnits_).trimmed());

--- a/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level2_settings_widget.cpp
@@ -1,6 +1,7 @@
-#include <qlabel.h>
 #include <scwx/qt/ui/level2_settings_widget.hpp>
 #include <scwx/qt/ui/flow_layout.hpp>
+#include <scwx/qt/ui/threshold_line_edit_sync.hpp>
+#include <scwx/qt/ui/threshold_value_utility.hpp>
 #include <scwx/qt/manager/hotkey_manager.hpp>
 #include <scwx/common/characters.hpp>
 #include <scwx/util/logger.hpp>
@@ -11,8 +12,13 @@
 
 #include <QCheckBox>
 #include <QEvent>
+#include <QFontMetrics>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QLocale>
+#include <QMetaObject>
 #include <QSlider>
 #include <QToolButton>
 
@@ -25,8 +31,6 @@ namespace ui
 
 static const std::string logPrefix_ = "scwx::qt::ui::level2_settings_widget";
 static const auto        logger_    = util::Logger::Create(logPrefix_);
-
-static constexpr int kSliderStepsPerUnit_ = 10;
 
 class Level2SettingsWidgetImpl : public QObject
 {
@@ -73,11 +77,23 @@ public:
       thresholdSlider_->setTickPosition(QSlider::TicksBelow);
       sliderLayout->addWidget(thresholdSlider_);
 
-      thresholdValueLabel_ = new QLabel("", sliderWidget);
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      thresholdValueLabel_->setMinimumWidth(60);
-      thresholdValueLabel_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-      sliderLayout->addWidget(thresholdValueLabel_);
+      thresholdValueEdit_ = new QLineEdit("", sliderWidget);
+      {
+         const QFontMetrics fm(thresholdValueEdit_->font());
+         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+         constexpr int kFramePad = 8;
+         thresholdValueEdit_->setFixedWidth(
+            fm.horizontalAdvance(QStringLiteral("-999.9")) + kFramePad);
+      }
+      thresholdValueEdit_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      thresholdValueEdit_->setEnabled(false);
+      sliderLayout->addWidget(thresholdValueEdit_);
+
+      thresholdUnitsLabel_ = new QLabel("", sliderWidget);
+      thresholdUnitsLabel_->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      sliderLayout->addWidget(thresholdUnitsLabel_);
+
+      thresholdValueEdit_->installEventFilter(this);
 
       thresholdLayout->addWidget(sliderWidget);
       layout_->addWidget(thresholdGroupBox_);
@@ -100,15 +116,24 @@ public:
                        &QSlider::valueChanged,
                        this,
                        &Level2SettingsWidgetImpl::HandleThresholdSliderChanged);
+
+      QObject::connect(thresholdValueEdit_,
+                       &QLineEdit::editingFinished,
+                       this,
+                       &Level2SettingsWidgetImpl::HandleThresholdEditFinished);
    }
    ~Level2SettingsWidgetImpl() = default;
+
+   bool eventFilter(QObject* watched, QEvent* event) override;
 
    void HandleHotkeyPressed(types::Hotkey hotkey, bool isAutoRepeat);
    void HandleThresholdToggled(bool checked);
    void HandleThresholdSliderChanged(int value);
+   void HandleThresholdEditFinished();
    void NormalizeElevationButtons();
    void SelectElevation(float elevation);
-   void UpdateThresholdLabel(int sliderValue);
+   void UpdateThresholdValueDisplay(int  sliderValue,
+                                    bool force_line_edit = false);
 
    [[nodiscard]] float SliderToPhysical(int sliderValue) const;
    [[nodiscard]] int   PhysicalToSlider(float physicalValue) const;
@@ -129,7 +154,8 @@ public:
    QGroupBox* thresholdGroupBox_ {};
    QCheckBox* thresholdCheckBox_ {};
    QSlider*   thresholdSlider_ {};
-   QLabel*    thresholdValueLabel_ {};
+   QLineEdit* thresholdValueEdit_ {};
+   QLabel*    thresholdUnitsLabel_ {};
 
    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
    float thresholdRangeMin_ {-32.0f};
@@ -276,9 +302,24 @@ void Level2SettingsWidgetImpl::SelectElevation(float elevation)
    Q_EMIT self_->ElevationSelected(elevation);
 }
 
+bool Level2SettingsWidgetImpl::eventFilter(QObject* watched, QEvent* event)
+{
+   if (watched == thresholdValueEdit_ && event->type() == QEvent::Type::FocusIn)
+   {
+      QMetaObject::invokeMethod(
+         thresholdValueEdit_,
+         [this]() { thresholdValueEdit_->selectAll(); },
+         Qt::QueuedConnection);
+   }
+   return QObject::eventFilter(watched, event);
+}
+
 void Level2SettingsWidgetImpl::HandleThresholdToggled(bool checked)
 {
    thresholdSlider_->setEnabled(checked);
+   thresholdValueEdit_->setEnabled(checked);
+
+   UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
 
    if (suppressThresholdSignal_)
    {
@@ -300,7 +341,7 @@ void Level2SettingsWidgetImpl::HandleThresholdToggled(bool checked)
 
 void Level2SettingsWidgetImpl::HandleThresholdSliderChanged(int value)
 {
-   UpdateThresholdLabel(value);
+   UpdateThresholdValueDisplay(value, true);
 
    if (suppressThresholdSignal_ || !thresholdCheckBox_->isChecked())
    {
@@ -310,24 +351,68 @@ void Level2SettingsWidgetImpl::HandleThresholdSliderChanged(int value)
    Q_EMIT self_->ThresholdChanged(SliderToPhysical(value));
 }
 
-void Level2SettingsWidgetImpl::UpdateThresholdLabel(int sliderValue)
+void Level2SettingsWidgetImpl::HandleThresholdEditFinished()
+{
+   if (suppressThresholdSignal_)
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   if (!thresholdCheckBox_->isChecked())
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   bool          ok = false;
+   const QString t  = thresholdValueEdit_->text().trimmed();
+   const float   v  = QLocale::system().toFloat(t, &ok);
+   if (!ok || !std::isfinite(v))
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   const float clamped = std::clamp(v, thresholdRangeMin_, thresholdRangeMax_);
+   const int   newSlider = PhysicalToSlider(clamped);
+
+   if (newSlider != thresholdSlider_->value())
+   {
+      thresholdSlider_->setValue(newSlider);
+   }
+   else
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+   }
+}
+
+void Level2SettingsWidgetImpl::UpdateThresholdValueDisplay(int  sliderValue,
+                                                           bool force_line_edit)
 {
    const float   physicalValue = SliderToPhysical(sliderValue);
-   const QString text          = QString::number(physicalValue, 'f', 1) + " " +
-                        QString::fromStdString(thresholdUnits_);
-   thresholdValueLabel_->setText(text);
+   const QString text = QLocale::system().toString(physicalValue, 'f', 1);
+   if (ShouldApplyThresholdLineEditText(*thresholdValueEdit_,
+                                        sliderValue,
+                                        thresholdRangeMin_,
+                                        thresholdRangeMax_,
+                                        force_line_edit))
+   {
+      thresholdValueEdit_->setText(text);
+   }
+   thresholdUnitsLabel_->setText(
+      QString::fromStdString(thresholdUnits_).trimmed());
 }
 
 float Level2SettingsWidgetImpl::SliderToPhysical(int sliderValue) const
 {
-   return thresholdRangeMin_ +
-          static_cast<float>(sliderValue) / kSliderStepsPerUnit_;
+   return ColorTableThresholdSliderToPhysical(sliderValue, thresholdRangeMin_);
 }
 
 int Level2SettingsWidgetImpl::PhysicalToSlider(float physicalValue) const
 {
-   return static_cast<int>(
-      std::round((physicalValue - thresholdRangeMin_) * kSliderStepsPerUnit_));
+   return ColorTableThresholdPhysicalToSlider(physicalValue,
+                                              thresholdRangeMin_);
 }
 
 void Level2SettingsWidget::UpdateElevationSelection(float elevation)
@@ -431,17 +516,34 @@ void Level2SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
 
    if (!validRange)
    {
+      p->suppressThresholdSignal_ = true;
+      if (std::isfinite(rangeMin) && std::isfinite(rangeMax))
+      {
+         p->thresholdRangeMin_ = rangeMin;
+         p->thresholdRangeMax_ = rangeMax;
+         p->thresholdUnits_    = units;
+      }
       if (threshold.has_value())
       {
-         p->suppressThresholdSignal_ = true;
          p->thresholdCheckBox_->setChecked(false);
          p->thresholdSlider_->setValue(0);
-         p->suppressThresholdSignal_ = false;
 
          activeMap->SetColorTableThreshold(std::nullopt);
       }
+      const bool force_line_edit =
+         threshold.has_value() ||
+         (std::isfinite(rangeMin) && std::isfinite(rangeMax));
+      p->UpdateThresholdValueDisplay(p->thresholdSlider_->value(),
+                                     force_line_edit);
+      p->suppressThresholdSignal_ = false;
       return;
    }
+
+   const int         slider_before  = p->thresholdSlider_->value();
+   const bool        checked_before = p->thresholdCheckBox_->isChecked();
+   const float       rmin_before    = p->thresholdRangeMin_;
+   const float       rmax_before    = p->thresholdRangeMax_;
+   const std::string units_before   = p->thresholdUnits_;
 
    p->suppressThresholdSignal_ = true;
 
@@ -454,12 +556,14 @@ void Level2SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
       p->thresholdUnits_    = units;
 
       const int sliderMin = 0;
-      const int sliderMax =
-         static_cast<int>((rangeMax - rangeMin) * kSliderStepsPerUnit_);
+      const int sliderMax = static_cast<int>(
+         (rangeMax - rangeMin) *
+         static_cast<float>(kColorTableThresholdSliderStepsPerUnit));
       p->thresholdSlider_->setRange(sliderMin, sliderMax);
 
       // Set tick interval: approximately 10 units per major tick
-      const int tickInterval = std::max(1, 10 * kSliderStepsPerUnit_);
+      const int tickInterval =
+         std::max(1, 10 * kColorTableThresholdSliderStepsPerUnit);
       p->thresholdSlider_->setTickInterval(tickInterval);
    }
 
@@ -482,7 +586,16 @@ void Level2SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
       p->thresholdSlider_->setValue(0);
    }
 
-   p->UpdateThresholdLabel(p->thresholdSlider_->value());
+   const bool range_or_units_changed =
+      (rmin_before != rangeMin || rmax_before != rangeMax ||
+       units_before != units);
+   const bool slider_changed = slider_before != p->thresholdSlider_->value();
+   const bool checkbox_changed =
+      checked_before != p->thresholdCheckBox_->isChecked();
+   const bool force_line_edit =
+      range_or_units_changed || slider_changed || checkbox_changed;
+   p->UpdateThresholdValueDisplay(p->thresholdSlider_->value(),
+                                  force_line_edit);
    p->suppressThresholdSignal_ = false;
 }
 

--- a/scwx-qt/source/scwx/qt/ui/level3_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level3_settings_widget.cpp
@@ -3,6 +3,7 @@
 #include <scwx/qt/ui/threshold_value_utility.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -223,6 +224,7 @@ void Level3SettingsWidgetImpl::UpdateThresholdValueDisplay(int  sliderValue,
                                         force_line_edit))
    {
       thresholdValueEdit_->setText(text);
+      thresholdValueEdit_->setModified(false);
    }
    thresholdUnitsLabel_->setText(
       QString::fromStdString(thresholdUnits_).trimmed());

--- a/scwx-qt/source/scwx/qt/ui/level3_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/level3_settings_widget.cpp
@@ -1,13 +1,20 @@
 #include <scwx/qt/ui/level3_settings_widget.hpp>
+#include <scwx/qt/ui/threshold_line_edit_sync.hpp>
+#include <scwx/qt/ui/threshold_value_utility.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <cmath>
 #include <limits>
 
 #include <QCheckBox>
+#include <QEvent>
+#include <QFontMetrics>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
+#include <QLocale>
+#include <QMetaObject>
 #include <QSlider>
 
 namespace scwx::qt::ui
@@ -15,8 +22,6 @@ namespace scwx::qt::ui
 
 static const std::string logPrefix_ = "scwx::qt::ui::level3_settings_widget";
 static const auto        logger_    = util::Logger::Create(logPrefix_);
-
-static constexpr int kSliderStepsPerUnit_ = 10;
 
 class Level3SettingsWidgetImpl : public QObject
 {
@@ -46,11 +51,23 @@ public:
       thresholdSlider_->setTickPosition(QSlider::TicksBelow);
       sliderLayout->addWidget(thresholdSlider_);
 
-      thresholdValueLabel_ = new QLabel("", sliderWidget);
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      thresholdValueLabel_->setMinimumWidth(60);
-      thresholdValueLabel_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-      sliderLayout->addWidget(thresholdValueLabel_);
+      thresholdValueEdit_ = new QLineEdit("", sliderWidget);
+      {
+         const QFontMetrics fm(thresholdValueEdit_->font());
+         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+         constexpr int kFramePad = 8;
+         thresholdValueEdit_->setFixedWidth(
+            fm.horizontalAdvance(QStringLiteral("-999.9")) + kFramePad);
+      }
+      thresholdValueEdit_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      thresholdValueEdit_->setEnabled(false);
+      sliderLayout->addWidget(thresholdValueEdit_);
+
+      thresholdUnitsLabel_ = new QLabel("", sliderWidget);
+      thresholdUnitsLabel_->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      sliderLayout->addWidget(thresholdUnitsLabel_);
+
+      thresholdValueEdit_->installEventFilter(this);
 
       thresholdLayout->addWidget(sliderWidget);
       layout_->addWidget(thresholdGroupBox_);
@@ -67,12 +84,21 @@ public:
                        &QSlider::valueChanged,
                        this,
                        &Level3SettingsWidgetImpl::HandleThresholdSliderChanged);
+
+      QObject::connect(thresholdValueEdit_,
+                       &QLineEdit::editingFinished,
+                       this,
+                       &Level3SettingsWidgetImpl::HandleThresholdEditFinished);
    }
    ~Level3SettingsWidgetImpl() override = default;
 
+   bool eventFilter(QObject* watched, QEvent* event) override;
+
    void HandleThresholdToggled(bool checked);
    void HandleThresholdSliderChanged(int value);
-   void UpdateThresholdLabel(int sliderValue);
+   void HandleThresholdEditFinished();
+   void UpdateThresholdValueDisplay(int  sliderValue,
+                                    bool force_line_edit = false);
 
    [[nodiscard]] float SliderToPhysical(int sliderValue) const;
    [[nodiscard]] int   PhysicalToSlider(float physicalValue) const;
@@ -83,7 +109,8 @@ public:
    QGroupBox* thresholdGroupBox_ {};
    QCheckBox* thresholdCheckBox_ {};
    QSlider*   thresholdSlider_ {};
-   QLabel*    thresholdValueLabel_ {};
+   QLineEdit* thresholdValueEdit_ {};
+   QLabel*    thresholdUnitsLabel_ {};
 
    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
    float thresholdRangeMin_ {-32.0f};
@@ -101,9 +128,24 @@ Level3SettingsWidget::Level3SettingsWidget(QWidget* parent) :
 
 Level3SettingsWidget::~Level3SettingsWidget() = default;
 
+bool Level3SettingsWidgetImpl::eventFilter(QObject* watched, QEvent* event)
+{
+   if (watched == thresholdValueEdit_ && event->type() == QEvent::Type::FocusIn)
+   {
+      QMetaObject::invokeMethod(
+         thresholdValueEdit_,
+         [this]() { thresholdValueEdit_->selectAll(); },
+         Qt::QueuedConnection);
+   }
+   return QObject::eventFilter(watched, event);
+}
+
 void Level3SettingsWidgetImpl::HandleThresholdToggled(bool checked)
 {
    thresholdSlider_->setEnabled(checked);
+   thresholdValueEdit_->setEnabled(checked);
+
+   UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
 
    if (suppressThresholdSignal_)
    {
@@ -123,7 +165,7 @@ void Level3SettingsWidgetImpl::HandleThresholdToggled(bool checked)
 
 void Level3SettingsWidgetImpl::HandleThresholdSliderChanged(int value)
 {
-   UpdateThresholdLabel(value);
+   UpdateThresholdValueDisplay(value, true);
 
    if (suppressThresholdSignal_ || !thresholdCheckBox_->isChecked())
    {
@@ -133,24 +175,68 @@ void Level3SettingsWidgetImpl::HandleThresholdSliderChanged(int value)
    Q_EMIT self_->ThresholdChanged(SliderToPhysical(value));
 }
 
-void Level3SettingsWidgetImpl::UpdateThresholdLabel(int sliderValue)
+void Level3SettingsWidgetImpl::HandleThresholdEditFinished()
+{
+   if (suppressThresholdSignal_)
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   if (!thresholdCheckBox_->isChecked())
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   bool          ok = false;
+   const QString t  = thresholdValueEdit_->text().trimmed();
+   const float   v  = QLocale::system().toFloat(t, &ok);
+   if (!ok || !std::isfinite(v))
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+      return;
+   }
+
+   const float clamped = std::clamp(v, thresholdRangeMin_, thresholdRangeMax_);
+   const int   newSlider = PhysicalToSlider(clamped);
+
+   if (newSlider != thresholdSlider_->value())
+   {
+      thresholdSlider_->setValue(newSlider);
+   }
+   else
+   {
+      UpdateThresholdValueDisplay(thresholdSlider_->value(), true);
+   }
+}
+
+void Level3SettingsWidgetImpl::UpdateThresholdValueDisplay(int  sliderValue,
+                                                           bool force_line_edit)
 {
    const float   physicalValue = SliderToPhysical(sliderValue);
-   const QString text          = QString::number(physicalValue, 'f', 1) + " " +
-                        QString::fromStdString(thresholdUnits_);
-   thresholdValueLabel_->setText(text);
+   const QString text = QLocale::system().toString(physicalValue, 'f', 1);
+   if (ShouldApplyThresholdLineEditText(*thresholdValueEdit_,
+                                        sliderValue,
+                                        thresholdRangeMin_,
+                                        thresholdRangeMax_,
+                                        force_line_edit))
+   {
+      thresholdValueEdit_->setText(text);
+   }
+   thresholdUnitsLabel_->setText(
+      QString::fromStdString(thresholdUnits_).trimmed());
 }
 
 float Level3SettingsWidgetImpl::SliderToPhysical(int sliderValue) const
 {
-   return thresholdRangeMin_ +
-          static_cast<float>(sliderValue) / kSliderStepsPerUnit_;
+   return ColorTableThresholdSliderToPhysical(sliderValue, thresholdRangeMin_);
 }
 
 int Level3SettingsWidgetImpl::PhysicalToSlider(float physicalValue) const
 {
-   return static_cast<int>(
-      std::round((physicalValue - thresholdRangeMin_) * kSliderStepsPerUnit_));
+   return ColorTableThresholdPhysicalToSlider(physicalValue,
+                                              thresholdRangeMin_);
 }
 
 bool Level3SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
@@ -166,17 +252,34 @@ bool Level3SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
 
    if (!validRange)
    {
+      p->suppressThresholdSignal_ = true;
+      if (std::isfinite(rangeMin) && std::isfinite(rangeMax))
+      {
+         p->thresholdRangeMin_ = rangeMin;
+         p->thresholdRangeMax_ = rangeMax;
+         p->thresholdUnits_    = units;
+      }
       if (threshold.has_value())
       {
-         p->suppressThresholdSignal_ = true;
          p->thresholdCheckBox_->setChecked(false);
          p->thresholdSlider_->setValue(0);
-         p->suppressThresholdSignal_ = false;
 
          activeMap->SetColorTableThreshold(std::nullopt);
       }
+      const bool force_line_edit =
+         threshold.has_value() ||
+         (std::isfinite(rangeMin) && std::isfinite(rangeMax));
+      p->UpdateThresholdValueDisplay(p->thresholdSlider_->value(),
+                                     force_line_edit);
+      p->suppressThresholdSignal_ = false;
       return false;
    }
+
+   const int         slider_before  = p->thresholdSlider_->value();
+   const bool        checked_before = p->thresholdCheckBox_->isChecked();
+   const float       rmin_before    = p->thresholdRangeMin_;
+   const float       rmax_before    = p->thresholdRangeMax_;
+   const std::string units_before   = p->thresholdUnits_;
 
    p->suppressThresholdSignal_ = true;
 
@@ -188,11 +291,13 @@ bool Level3SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
       p->thresholdUnits_    = units;
 
       const int sliderMin = 0;
-      const int sliderMax =
-         static_cast<int>((rangeMax - rangeMin) * kSliderStepsPerUnit_);
+      const int sliderMax = static_cast<int>(
+         (rangeMax - rangeMin) *
+         static_cast<float>(kColorTableThresholdSliderStepsPerUnit));
       p->thresholdSlider_->setRange(sliderMin, sliderMax);
 
-      const int tickInterval = std::max(1, 10 * kSliderStepsPerUnit_);
+      const int tickInterval =
+         std::max(1, 10 * kColorTableThresholdSliderStepsPerUnit);
       p->thresholdSlider_->setTickInterval(tickInterval);
    }
 
@@ -214,7 +319,16 @@ bool Level3SettingsWidget::UpdateThreshold(map::MapWidget* activeMap)
       p->thresholdSlider_->setValue(0);
    }
 
-   p->UpdateThresholdLabel(p->thresholdSlider_->value());
+   const bool range_or_units_changed =
+      (rmin_before != rangeMin || rmax_before != rangeMax ||
+       units_before != units);
+   const bool slider_changed = slider_before != p->thresholdSlider_->value();
+   const bool checkbox_changed =
+      checked_before != p->thresholdCheckBox_->isChecked();
+   const bool force_line_edit =
+      range_or_units_changed || slider_changed || checkbox_changed;
+   p->UpdateThresholdValueDisplay(p->thresholdSlider_->value(),
+                                  force_line_edit);
    p->suppressThresholdSignal_ = false;
    return true;
 }

--- a/scwx-qt/source/scwx/qt/ui/threshold_line_edit_sync.hpp
+++ b/scwx-qt/source/scwx/qt/ui/threshold_line_edit_sync.hpp
@@ -42,10 +42,9 @@ ThresholdLineEditTextMatchesSlider(const QString& trimmed_text,
 }
 
 /**
- * When `force_line_edit` is false, avoid overwriting focused text that is an
- * incomplete number, but do overwrite when the committed parse disagrees with
- * `slider_value` (map/slider moved). When true, always apply the canonical
- * string.
+ * When `force_line_edit` is false, avoid overwriting focused text the user is
+ * still editing (`isModified()`), or incomplete / non-matching input. When
+ * true, always apply the canonical string (slider, map, or explicit refresh).
  */
 [[nodiscard]] inline bool
 ShouldApplyThresholdLineEditText(const QLineEdit& edit,
@@ -61,6 +60,10 @@ ShouldApplyThresholdLineEditText(const QLineEdit& edit,
    if (!edit.hasFocus())
    {
       return true;
+   }
+   if (edit.isModified())
+   {
+      return false;
    }
    if (ThresholdLineEditMatchesSlider(edit, slider_value, range_min, range_max))
    {

--- a/scwx-qt/source/scwx/qt/ui/threshold_line_edit_sync.hpp
+++ b/scwx-qt/source/scwx/qt/ui/threshold_line_edit_sync.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <scwx/qt/ui/threshold_value_utility.hpp>
+
+#include <QLineEdit>
+#include <QLocale>
+#include <QString>
+
+#include <algorithm>
+#include <cmath>
+
+namespace scwx::qt::ui
+{
+
+/** `trimmed_text` parses and quantizes to same slider index as `slider_value`.
+ */
+[[nodiscard]] inline bool
+ThresholdLineEditTextMatchesSlider(const QString& trimmed_text,
+                                   int            slider_value,
+                                   float          range_min,
+                                   float          range_max)
+{
+   bool        ok     = false;
+   const float parsed = QLocale::system().toFloat(trimmed_text, &ok);
+   if (!ok || !std::isfinite(parsed))
+   {
+      return false;
+   }
+   const float clamped = std::clamp(parsed, range_min, range_max);
+   const int   from_text =
+      ColorTableThresholdPhysicalToSlider(clamped, range_min);
+   return from_text == slider_value;
+}
+
+[[nodiscard]] inline bool ThresholdLineEditMatchesSlider(const QLineEdit& edit,
+                                                         int   slider_value,
+                                                         float range_min,
+                                                         float range_max)
+{
+   return ThresholdLineEditTextMatchesSlider(
+      edit.text().trimmed(), slider_value, range_min, range_max);
+}
+
+/**
+ * When `force_line_edit` is false, avoid overwriting focused text that is an
+ * incomplete number, but do overwrite when the committed parse disagrees with
+ * `slider_value` (map/slider moved). When true, always apply the canonical
+ * string.
+ */
+[[nodiscard]] inline bool
+ShouldApplyThresholdLineEditText(const QLineEdit& edit,
+                                 int              slider_value,
+                                 float            range_min,
+                                 float            range_max,
+                                 bool             force_line_edit)
+{
+   if (force_line_edit)
+   {
+      return true;
+   }
+   if (!edit.hasFocus())
+   {
+      return true;
+   }
+   if (ThresholdLineEditMatchesSlider(edit, slider_value, range_min, range_max))
+   {
+      return false;
+   }
+   bool          ok      = false;
+   const QString trimmed = edit.text().trimmed();
+   const float   parsed  = QLocale::system().toFloat(trimmed, &ok);
+   if (!ok || !std::isfinite(parsed))
+   {
+      return false;
+   }
+   const int from_text = ColorTableThresholdPhysicalToSlider(
+      std::clamp(parsed, range_min, range_max), range_min);
+   return from_text != slider_value;
+}
+
+} // namespace scwx::qt::ui

--- a/scwx-qt/source/scwx/qt/ui/threshold_value_utility.hpp
+++ b/scwx-qt/source/scwx/qt/ui/threshold_value_utility.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cmath>
+
+namespace scwx::qt::ui
+{
+
+/** Steps per 1.0 physical unit on the color-table threshold slider. */
+inline constexpr int kColorTableThresholdSliderStepsPerUnit = 10;
+
+[[nodiscard]] inline float ColorTableThresholdSliderToPhysical(int slider_value,
+                                                               float range_min)
+{
+   return range_min +
+          static_cast<float>(slider_value) /
+             static_cast<float>(kColorTableThresholdSliderStepsPerUnit);
+}
+
+/** Map physical threshold to slider integer (callers clamp to colormap). */
+[[nodiscard]] inline int
+ColorTableThresholdPhysicalToSlider(float physical_value, float range_min)
+{
+   return static_cast<int>(
+      std::round((physical_value - range_min) *
+                 static_cast<float>(kColorTableThresholdSliderStepsPerUnit)));
+}
+
+} // namespace scwx::qt::ui

--- a/test/source/scwx/qt/ui/threshold_value_utility.test.cpp
+++ b/test/source/scwx/qt/ui/threshold_value_utility.test.cpp
@@ -1,0 +1,62 @@
+#include <scwx/qt/ui/threshold_line_edit_sync.hpp>
+#include <scwx/qt/ui/threshold_value_utility.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+namespace scwx::qt::ui
+{
+namespace
+{
+
+TEST(ThresholdValueUtility, SliderToPhysicalAtMin)
+{
+   EXPECT_FLOAT_EQ(ColorTableThresholdSliderToPhysical(0, -32.0f), -32.0f);
+}
+
+TEST(ThresholdValueUtility, SliderToPhysicalOneStep)
+{
+   EXPECT_FLOAT_EQ(ColorTableThresholdSliderToPhysical(1, -32.0f), -31.9f);
+}
+
+TEST(ThresholdValueUtility, PhysicalToSliderRoundTrip)
+{
+   constexpr float kMin {-10.0f};
+   constexpr float kMax {50.0f};
+   for (int slider = 0; slider <= 600; slider += 50)
+   {
+      const float physical = ColorTableThresholdSliderToPhysical(slider, kMin);
+      const float clamped  = std::clamp(physical, kMin, kMax);
+      const int   back     = ColorTableThresholdPhysicalToSlider(clamped, kMin);
+      EXPECT_EQ(back, slider);
+   }
+}
+
+TEST(ThresholdValueUtility, PhysicalToSliderMatchesTenStepsPerUnit)
+{
+   constexpr float kMin {0.0f};
+   EXPECT_EQ(ColorTableThresholdPhysicalToSlider(0.0f, kMin), 0);
+   EXPECT_EQ(ColorTableThresholdPhysicalToSlider(0.04f, kMin), 0);
+   EXPECT_EQ(ColorTableThresholdPhysicalToSlider(0.05f, kMin), 1);
+   EXPECT_EQ(ColorTableThresholdPhysicalToSlider(1.0f, kMin), 10);
+}
+
+TEST(ThresholdLineEditSync, TextMatchesSliderQuantized)
+{
+   constexpr float kMin {-32.0f};
+   constexpr float kMax {94.5f};
+   EXPECT_TRUE(ThresholdLineEditTextMatchesSlider(
+      QStringLiteral("14.2"), 462, kMin, kMax));
+   EXPECT_FALSE(ThresholdLineEditTextMatchesSlider(
+      QStringLiteral("14.3"), 462, kMin, kMax));
+}
+
+TEST(ThresholdLineEditSync, InvalidTextDoesNotMatch)
+{
+   EXPECT_FALSE(ThresholdLineEditTextMatchesSlider(
+      QStringLiteral(".."), 0, -32.0f, 94.5f));
+}
+
+} // namespace
+} // namespace scwx::qt::ui

--- a/test/source/scwx/qt/ui/threshold_value_utility.test.cpp
+++ b/test/source/scwx/qt/ui/threshold_value_utility.test.cpp
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <QLocale>
+
 #include <algorithm>
 
 namespace scwx::qt::ui
@@ -46,10 +48,10 @@ TEST(ThresholdLineEditSync, TextMatchesSliderQuantized)
 {
    constexpr float kMin {-32.0f};
    constexpr float kMax {94.5f};
-   EXPECT_TRUE(ThresholdLineEditTextMatchesSlider(
-      QStringLiteral("14.2"), 462, kMin, kMax));
-   EXPECT_FALSE(ThresholdLineEditTextMatchesSlider(
-      QStringLiteral("14.3"), 462, kMin, kMax));
+   const QString   text_14_2 = QLocale::system().toString(14.2, 'f', 1);
+   const QString   text_14_3 = QLocale::system().toString(14.3, 'f', 1);
+   EXPECT_TRUE(ThresholdLineEditTextMatchesSlider(text_14_2, 462, kMin, kMax));
+   EXPECT_FALSE(ThresholdLineEditTextMatchesSlider(text_14_3, 462, kMin, kMax));
 }
 
 TEST(ThresholdLineEditSync, InvalidTextDoesNotMatch)

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -33,6 +33,7 @@ set(SRC_QT_MANAGER_TESTS source/scwx/qt/manager/settings_manager.test.cpp
 set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_provider.test.cpp)
 set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp
                        source/scwx/qt/model/marker_model.test.cpp)
+set(SRC_QT_UI_TESTS source/scwx/qt/ui/threshold_value_utility.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp)
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
@@ -60,6 +61,7 @@ add_executable(wxtest ${SRC_MAIN}
                       ${SRC_QT_MANAGER_TESTS}
                       ${SRC_QT_MAP_TESTS}
                       ${SRC_QT_MODEL_TESTS}
+                      ${SRC_QT_UI_TESTS}
                       ${SRC_QT_SETTINGS_TESTS}
                       ${SRC_QT_UTIL_TESTS}
                       ${SRC_UTIL_TESTS}
@@ -77,6 +79,7 @@ source_group("Source Files\\qt\\main"     FILES ${SRC_QT_MAIN_TESTS})
 source_group("Source Files\\qt\\manager"  FILES ${SRC_QT_MANAGER_TESTS})
 source_group("Source Files\\qt\\map"      FILES ${SRC_QT_MAP_TESTS})
 source_group("Source Files\\qt\\model"    FILES ${SRC_QT_MODEL_TESTS})
+source_group("Source Files\\qt\\ui"       FILES ${SRC_QT_UI_TESTS})
 source_group("Source Files\\qt\\settings" FILES ${SRC_QT_SETTINGS_TESTS})
 source_group("Source Files\\qt\\util"     FILES ${SRC_QT_UTIL_TESTS})
 source_group("Source Files\\util"         FILES ${SRC_UTIL_TESTS})


### PR DESCRIPTION
tldr; Level 2 and Level 3 threshold rows use a QLineEdit for typed values, shared slider/physical conversion helpers, and line-edit sync rules so map-driven updates do not clobber in-progress input. Add wxtest coverage for the conversion and string/slider match helpers.

## Details
- Replace read-only numeric label with **`QLineEdit` + units label** on both L2 and L3 threshold rows.
- Extract **`threshold_value_utility.hpp`** for slider ↔ physical conversion (10 steps per unit).
- Add **`threshold_line_edit_sync.hpp`** for “should we overwrite the line edit?” rules.
- **`UpdateThreshold`** passes a **`force_line_edit`** flag when slider, checkbox, range, or units changed so external updates stay authoritative without constant churn on idle refresh.
- Register **`wxtest`** sources: **`threshold_value_utility.test.cpp`** (conversion + string/slider match cases).
- **`scwx-qt.cmake` / `test.cmake`**: list new headers / test file.

Screenshots
<img width="275" height="142" alt="image" src="https://github.com/user-attachments/assets/0d7525b2-73d7-4a98-85e2-8e18a776a0de" />
<img width="278" height="147" alt="image" src="https://github.com/user-attachments/assets/0ab33343-30fd-4a7f-bcef-832b16396a2a" />
