### PR TITLE
Allow deselecting radar site; keep placefiles without radar

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -784,6 +784,8 @@ void MainWindow::on_radarSiteHomeButton_clicked()
    }
 
    p->UpdateRadarSite();
+   p->UpdateAvailableLevel3Products();
+   p->UpdateRadarProductSettings();
 }
 
 void MainWindow::on_radarSiteSelectButton_clicked()
@@ -1169,6 +1171,8 @@ void MainWindowImpl::ConnectAnimationSignals()
                  }
 
                  UpdateRadarSite();
+                 UpdateAvailableLevel3Products();
+                 UpdateRadarProductSettings();
               });
    }
 }
@@ -1373,6 +1377,8 @@ void MainWindowImpl::ConnectOtherSignals()
               }
 
               UpdateRadarSite();
+              UpdateAvailableLevel3Products();
+              UpdateRadarProductSettings();
            });
    connect(radarSiteModel_.get(),
            &model::RadarSiteModel::PresetToggled,
@@ -1533,6 +1539,8 @@ void MainWindowImpl::AddRadarSitePreset(const std::string& siteId)
               }
 
               UpdateRadarSite();
+              UpdateAvailableLevel3Products();
+              UpdateRadarProductSettings();
            });
 }
 
@@ -1809,7 +1817,7 @@ void MainWindowImpl::UpdateRadarSite()
       mainWindow_->ui->radarLocationLabel->setVisible(false);
       mainWindow_->ui->saveRadarProductsButton->setVisible(false);
 
-      timelineManager_->SetRadarSite("?");
+      timelineManager_->SetRadarSite("");
    }
 
    alertManager_->SetRadarSite(radarSite);

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -558,7 +558,7 @@ std::pair<bool, bool> TimelineManager::Impl::SelectTime(
    }
    else if (selectedTime == std::chrono::system_clock::time_point {})
    {
-      std::unique_lock lock {selectTimeMutex_};
+      std::unique_lock const lock {selectTimeMutex_};
 
       // If a default time point is given, reset to a live view
       selectedTime_      = selectedTime;
@@ -579,7 +579,7 @@ std::pair<bool, bool> TimelineManager::Impl::SelectTime(
 
    if (radarSite_.empty())
    {
-      std::unique_lock lock {selectTimeMutex_};
+      std::unique_lock const lock {selectTimeMutex_};
 
       adjustedTime_      = selectedTime;
       selectedTime_      = selectedTime;

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -558,6 +558,8 @@ std::pair<bool, bool> TimelineManager::Impl::SelectTime(
    }
    else if (selectedTime == std::chrono::system_clock::time_point {})
    {
+      std::unique_lock lock {selectTimeMutex_};
+
       // If a default time point is given, reset to a live view
       selectedTime_      = selectedTime;
       adjustedTime_      = selectedTime;
@@ -577,6 +579,8 @@ std::pair<bool, bool> TimelineManager::Impl::SelectTime(
 
    if (radarSite_.empty())
    {
+      std::unique_lock lock {selectTimeMutex_};
+
       adjustedTime_      = selectedTime;
       selectedTime_      = selectedTime;
       previousRadarSite_ = radarSite_;

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -575,6 +575,23 @@ std::pair<bool, bool> TimelineManager::Impl::SelectTime(
       return {volumeTimeUpdated, selectedTimeUpdated};
    }
 
+   if (radarSite_.empty())
+   {
+      adjustedTime_      = selectedTime;
+      selectedTime_      = selectedTime;
+      previousRadarSite_ = radarSite_;
+
+      Q_EMIT self_->LiveStateUpdated(selectedTime ==
+                                     std::chrono::system_clock::time_point {});
+      Q_EMIT self_->VolumeTimeUpdated(selectedTime);
+      Q_EMIT self_->SelectedTimeUpdated(selectedTime);
+
+      volumeTimeUpdated   = true;
+      selectedTimeUpdated = true;
+
+      return {volumeTimeUpdated, selectedTimeUpdated};
+   }
+
    // Take a lock for time selection
    std::unique_lock lock {selectTimeMutex_};
 

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -180,7 +180,16 @@ void TimelineManager::SetViewType(types::MapTime viewType)
    }
    else
    {
-      // If the selected view type is archive, select using the pinned time
+      // If the selected view type is archive, select using the pinned time.
+      // A default time of {} is treated as "live" by SelectTime; when first
+      // switching to archive the dock may not have emitted a date yet, so
+      // pin to the current wall-clock time (minute resolution) so the UI
+      // shows archive time instead of "Live".
+      if (p->pinnedTime_ == std::chrono::system_clock::time_point {})
+      {
+         p->pinnedTime_ =
+            std::chrono::floor<std::chrono::minutes>(scwx::util::time::now());
+      }
       p->SelectTimeAsync(p->pinnedTime_);
    }
 
@@ -474,20 +483,29 @@ void TimelineManager::Impl::PlaySync()
    // Unlock prior to selecting time
    lock.unlock();
 
-   // Lock radar sweep monitor
-   std::unique_lock radarSweepMonitorLock {radarSweepMonitorMutex_};
-
-   // Reset radar sweep monitor in preparation for update
-   RadarSweepMonitorReset();
-
-   // Select the time
    auto selectTimeStart = std::chrono::steady_clock::now();
-   SelectTime(newTime);
+   if (radarSite_.empty())
+   {
+      // No radar product: sweeps will not complete the monitor; skip the wait
+      // so play advances at the configured loop rate instead of timing out.
+      SelectTime(newTime);
+   }
+   else
+   {
+      // Lock radar sweep monitor
+      std::unique_lock radarSweepMonitorLock {radarSweepMonitorMutex_};
+
+      // Reset radar sweep monitor in preparation for update
+      RadarSweepMonitorReset();
+
+      // Select the time
+      SelectTime(newTime);
+
+      // Wait for radar sweeps to update
+      RadarSweepMonitorWait(radarSweepMonitorLock);
+   }
    auto selectTimeEnd = std::chrono::steady_clock::now();
    auto elapsedTime   = selectTimeEnd - selectTimeStart;
-
-   // Wait for radar sweeps to update
-   RadarSweepMonitorWait(radarSweepMonitorLock);
 
    // Calculate the interval until the next update, prior to selecting
    std::chrono::milliseconds interval;
@@ -694,6 +712,27 @@ void TimelineManager::Impl::Step(Direction direction)
 
    // Unlock prior to selecting time
    lock.unlock();
+
+   if (radarSite_.empty())
+   {
+      // No radar: apply a single one-minute step without waiting for sweeps
+      // that will never be recorded as complete.
+      using namespace std::chrono_literals;
+      if (direction == Direction::Back)
+      {
+         newTime -= 1min;
+      }
+      else
+      {
+         newTime += 1min;
+         if (newTime > scwx::util::time::now() + 2min)
+         {
+            return;
+         }
+      }
+      SelectTime(newTime);
+      return;
+   }
 
    // Lock radar sweep monitor
    std::unique_lock radarSweepMonitorLock {radarSweepMonitorMutex_};

--- a/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/color_table_layer.cpp
@@ -124,7 +124,9 @@ void ColorTableLayer::Render(
 
    if (radarProductView == nullptr || !radarProductView->IsInitialized())
    {
-      // Defer rendering until view is initialized
+      // No color bar: clear reserved bottom margin (overlay uses this for
+      // attribution / logo). Avoid stale margin when the table is hidden.
+      mapContext->set_color_table_margins({});
       return;
    }
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -948,12 +948,6 @@ void MapWidget::SelectRadarProduct(common::RadarProductGroup group,
                                    std::chrono::system_clock::time_point time,
                                    bool                                  update)
 {
-   if (p->radarProductManager_ == nullptr)
-   {
-      logger_->warn("Cannot select radar product without selected radar site");
-      return;
-   }
-
    bool radarProductViewCreated = false;
 
    auto radarProductView = p->context_->radar_product_view();
@@ -983,6 +977,16 @@ void MapWidget::SelectRadarProduct(common::RadarProductGroup group,
    else
    {
       p->currentTiltIndex_ = 0;
+   }
+
+   if (p->radarProductManager_ == nullptr)
+   {
+      p->context_->set_radar_product_group(group);
+      p->context_->set_radar_product(productName);
+      p->context_->set_radar_product_code(productCode);
+      p->RadarProductViewDisconnect();
+      p->context_->set_radar_product_view(nullptr);
+      return;
    }
 
    if (radarProductView == nullptr ||

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -18,6 +18,7 @@
 #include <scwx/qt/map/radar_site_layer.hpp>
 #include <scwx/qt/model/imgui_context_model.hpp>
 #include <scwx/qt/model/layer_model.hpp>
+#include <scwx/qt/types/layer_types.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/settings/map_settings.hpp>
 #include <scwx/qt/settings/palette_settings.hpp>
@@ -1398,6 +1399,15 @@ void MapWidgetImpl::AddLayers()
          // If the layer is displayed for the current map, add it
          AddLayer(customLayer.type_, customLayer.description_, before);
       }
+   }
+
+   // Color table layer is omitted when there is no radar product view, but
+   // map context can still hold bottom margin from a previous site; clear it.
+   static const std::string kColorTableLayerId = types::GetLayerName(
+      types::LayerType::Information, types::InformationLayer::ColorTable);
+   if (std::ranges::find(layerList_, kColorTableLayerId) == layerList_.cend())
+   {
+      context_->set_color_table_margins({});
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -719,7 +719,9 @@ std::vector<float> MapWidget::GetElevationCuts() const
 
 std::optional<float> MapWidget::GetIncomingLevel2Elevation() const
 {
-   return p->radarProductManager_->incoming_level_2_elevation();
+   return p->radarProductManager_ != nullptr ?
+             p->radarProductManager_->incoming_level_2_elevation() :
+             std::optional<float> {};
 }
 
 common::Level2Product
@@ -917,7 +919,9 @@ void MapWidget::SetColorTableThreshold(std::optional<float> threshold)
 
 const scwx::util::time_zone* MapWidget::GetDefaultTimeZone() const
 {
-   return p->radarProductManager_->default_time_zone();
+   return p->radarProductManager_ != nullptr ?
+             p->radarProductManager_->default_time_zone() :
+             scwx::util::time::current_time_zone();
 }
 
 void MapWidget::ScreenCapture(types::CaptureType captureType)
@@ -944,6 +948,12 @@ void MapWidget::SelectRadarProduct(common::RadarProductGroup group,
                                    std::chrono::system_clock::time_point time,
                                    bool                                  update)
 {
+   if (p->radarProductManager_ == nullptr)
+   {
+      logger_->warn("Cannot select radar product without selected radar site");
+      return;
+   }
+
    bool radarProductViewCreated = false;
 
    auto radarProductView = p->context_->radar_product_view();
@@ -1067,13 +1077,39 @@ void MapWidget::SelectRadarSite(const std::string& id, bool updateCoordinates)
 void MapWidget::SelectRadarSite(std::shared_ptr<config::RadarSite> radarSite,
                                 bool updateCoordinates)
 {
-   // Verify radar site is valid and has changed
-   if (radarSite != nullptr &&
-       (p->radarProductManager_ == nullptr ||
-        radarSite->id() != p->radarProductManager_->radar_site()->id()))
-   {
-      auto radarProductView = p->context_->radar_product_view();
+   const std::shared_ptr<config::RadarSite> currentRadarSite = GetRadarSite();
+   auto radarProductView = p->context_->radar_product_view();
 
+   if (radarSite == nullptr)
+   {
+      if (currentRadarSite == nullptr)
+      {
+         return;
+      }
+
+      if (p->autoRefreshEnabled_ && p->radarProductManager_ != nullptr &&
+          radarProductView != nullptr)
+      {
+         p->radarProductManager_->EnableRefresh(
+            radarProductView->GetRadarProductGroup(),
+            radarProductView->GetRadarProductName(),
+            false,
+            p->uuid_);
+      }
+
+      p->RadarProductViewDisconnect();
+      p->context_->set_radar_product_view(nullptr);
+      p->SetRadarSite("");
+      p->AddLayers();
+      p->Update();
+
+      Q_EMIT RadarSiteUpdated(nullptr);
+      return;
+   }
+
+   // Verify radar site has changed
+   if (currentRadarSite == nullptr || radarSite->id() != currentRadarSite->id())
+   {
       if (updateCoordinates)
       {
          p->map_->setCoordinate(
@@ -1086,6 +1122,13 @@ void MapWidget::SelectRadarSite(std::shared_ptr<config::RadarSite> radarSite,
       if (radarProductView != nullptr)
       {
          radarProductView->set_radar_product_manager(p->radarProductManager_);
+      }
+      else if (p->context_->radar_product_group() !=
+               common::RadarProductGroup::Unknown)
+      {
+         SelectRadarProduct(p->context_->radar_product_group(),
+                            p->context_->radar_product(),
+                            p->context_->radar_product_code());
       }
 
       p->AddLayers();
@@ -1417,16 +1460,23 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
       case types::InformationLayer::RadarSite:
          radarSiteLayer_ = std::make_shared<RadarSiteLayer>(glContext_);
          AddLayer(layerName, radarSiteLayer_, before);
-         connect(
-            radarSiteLayer_.get(),
-            &RadarSiteLayer::RadarSiteSelected,
-            this,
-            [this](const std::string& id)
-            {
-               auto& generalSettings = settings::GeneralSettings::Instance();
-               widget_->RadarSiteRequested(
-                  id, generalSettings.center_on_radar_selection().GetValue());
-            });
+         connect(radarSiteLayer_.get(),
+                 &RadarSiteLayer::RadarSiteSelected,
+                 this,
+                 [this](const std::string& id)
+                 {
+                    auto& generalSettings =
+                       settings::GeneralSettings::Instance();
+                    auto selectedRadarSite = widget_->GetRadarSite();
+                    const std::string requestedRadarSite =
+                       (selectedRadarSite != nullptr &&
+                        selectedRadarSite->id() == id) ?
+                          std::string {} :
+                          id;
+                    widget_->RadarSiteRequested(
+                       requestedRadarSite,
+                       generalSettings.center_on_radar_selection().GetValue());
+                 });
          break;
 
       // Create the location marker layer
@@ -1455,7 +1505,8 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
 
       // If there is a radar product view, create the radar range layer
       case types::DataLayer::RadarRange:
-         if (radarProductView != nullptr)
+         if (radarProductView != nullptr && radarProductManager_ != nullptr &&
+             radarProductManager_->radar_site() != nullptr)
          {
             std::shared_ptr<config::RadarSite> radarSite =
                radarProductManager_->radar_site();
@@ -1727,9 +1778,17 @@ void MapWidgetImpl::ResetMap(const std::string& styleName)
    else
    {
       const std::shared_ptr<config::RadarSite> radarSite =
-         radarProductManager_->radar_site();
-      map_->setCoordinateZoom({radarSite->latitude(), radarSite->longitude()},
-                              prevZoom_);
+         radarProductManager_ != nullptr ? radarProductManager_->radar_site() :
+                                           nullptr;
+      if (radarSite != nullptr)
+      {
+         map_->setCoordinateZoom(
+            {radarSite->latitude(), radarSite->longitude()}, prevZoom_);
+      }
+      else
+      {
+         map_->setCoordinateZoom({prevLatitude_, prevLongitude_}, prevZoom_);
+      }
    }
 
    // Update style
@@ -2218,9 +2277,11 @@ void MapWidgetImpl::RadarProductViewConnect()
          [=, this]()
          {
             std::shared_ptr<config::RadarSite> radarSite =
-               radarProductManager_->radar_site();
+               radarProductManager_ != nullptr ?
+                  radarProductManager_->radar_site() :
+                  nullptr;
 
-            if (map_ != nullptr)
+            if (map_ != nullptr && radarSite != nullptr)
             {
                RadarRangeLayer::Update(
                   map_,
@@ -2375,17 +2436,30 @@ void MapWidgetImpl::SetRadarSite(const std::string& radarSite,
    // Set the radar site in the context
    context_->set_radar_site(config::RadarSite::Get(radarSite));
 
+   const std::shared_ptr<config::RadarSite> currentRadarSite =
+      radarProductManager_ != nullptr ? radarProductManager_->radar_site() :
+                                        nullptr;
+
    // Check if radar site has changed
-   if (radarProductManager_ == nullptr ||
-       radarSite != radarProductManager_->radar_site()->id())
+   if ((currentRadarSite == nullptr && !radarSite.empty()) ||
+       (currentRadarSite != nullptr && radarSite != currentRadarSite->id()))
    {
       // Disconnect signals from old RadarProductManager
       RadarProductManagerDisconnect();
 
+      // Update views
+      if (radarSite.empty())
+      {
+         radarProductManager_.reset();
+         context_->overlay_product_view()->set_radar_product_manager(nullptr);
+         productAvailabilityCheckNeeded_     = false;
+         productAvailabilityUpdated_         = false;
+         productAvailabilityProductSelected_ = false;
+         return;
+      }
+
       // Set new RadarProductManager
       radarProductManager_ = manager::RadarProductManager::Instance(radarSite);
-
-      // Update views
       context_->overlay_product_view()->set_radar_product_manager(
          radarProductManager_);
 

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -356,7 +356,7 @@ void OverlayLayer::Render(const std::shared_ptr<MapContext>& mapContext,
 
    if (radarProductView != nullptr)
    {
-      scwx::util::ClockFormat clockFormat = scwx::util::GetClockFormat(
+      scwx::util::ClockFormat const clockFormat = scwx::util::GetClockFormat(
          settings::GeneralSettings::Instance().clock_format().GetValue());
 
       auto radarProductManager = radarProductView->radar_product_manager();
@@ -377,7 +377,7 @@ void OverlayLayer::Render(const std::shared_ptr<MapContext>& mapContext,
       auto overlayView = mapContext->overlay_product_view();
       if (overlayView != nullptr)
       {
-         scwx::util::ClockFormat clockFormat = scwx::util::GetClockFormat(
+         scwx::util::ClockFormat const clockFormat = scwx::util::GetClockFormat(
             settings::GeneralSettings::Instance().clock_format().GetValue());
 
          const std::chrono::system_clock::time_point selectedTime =

--- a/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/overlay_layer.cpp
@@ -9,6 +9,7 @@
 #include <scwx/qt/map/overlay_layer.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/types/texture_types.hpp>
+#include <scwx/qt/view/overlay_product_view.hpp>
 #include <scwx/qt/view/radar_product_view.hpp>
 #include <scwx/util/logger.hpp>
 #include <scwx/util/time.hpp>
@@ -368,6 +369,36 @@ void OverlayLayer::Render(const std::shared_ptr<MapContext>& mapContext,
       p->sweepTimeString_ = scwx::util::TimeString(
          radarProductView->sweep_time(), clockFormat, currentZone, false);
       p->sweepTimeNeedsUpdate_ = false;
+   }
+   else
+   {
+      // No radar data: show timeline / overlay time so placefiles, alerts, and
+      // animation stay correlated with the selected time.
+      auto overlayView = mapContext->overlay_product_view();
+      if (overlayView != nullptr)
+      {
+         scwx::util::ClockFormat clockFormat = scwx::util::GetClockFormat(
+            settings::GeneralSettings::Instance().clock_format().GetValue());
+
+         const std::chrono::system_clock::time_point selectedTime =
+            overlayView->selected_time();
+         if (selectedTime == std::chrono::system_clock::time_point {})
+         {
+            p->sweepTimeString_ = "Live";
+         }
+         else
+         {
+            p->sweepTimeString_ =
+               scwx::util::TimeString(selectedTime,
+                                      clockFormat,
+                                      scwx::util::time::current_time_zone(),
+                                      false);
+         }
+      }
+      else
+      {
+         p->sweepTimeString_.clear();
+      }
    }
 
    // Active Box

--- a/scwx-qt/source/scwx/qt/ui/radar_site_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/radar_site_dialog.cpp
@@ -65,11 +65,22 @@ RadarSiteDialog::RadarSiteDialog(QWidget* parent) :
 
    // Button Box
    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+   QPushButton* noneButton =
+      ui->buttonBox->addButton(tr("None"), QDialogButtonBox::ResetRole);
 
    connect(ui->radarSiteFilter,
            &QLineEdit::textChanged,
            p->proxyModel_,
            &QSortFilterProxyModel::setFilterWildcard);
+   connect(noneButton,
+           &QPushButton::clicked,
+           this,
+           [this]()
+           {
+              ui->radarSiteView->clearSelection();
+              p->selectedRadarSite_.clear();
+              Q_EMIT accept();
+           });
    connect(ui->radarSiteView,
            &QAbstractItemView::doubleClicked,
            this,

--- a/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
@@ -279,7 +279,10 @@ void OverlayProductView::SelectTime(std::chrono::system_clock::time_point time)
    if (time != p->selectedTime_)
    {
       p->selectedTime_ = time;
-      p->Update(kNst_);
+      if (p->radarProductManager_ != nullptr)
+      {
+         p->Update(kNst_);
+      }
    }
 }
 
@@ -294,6 +297,11 @@ void OverlayProductView::SetAutoRefresh(bool enabled)
 
 void OverlayProductView::Impl::Update(const std::string& product)
 {
+   if (radarProductManager_ == nullptr)
+   {
+      return;
+   }
+
    // Retrieve message from Radar Product Manager
    std::shared_ptr<wsr88d::rpg::Level3Message> message;
    std::chrono::system_clock::time_point       requestedTime {selectedTime_};


### PR DESCRIPTION
- Map: click selected site to clear; None in radar dialog; hide ring when no site
- TimelineManager: empty site skips RadarProductManager; no bogus "?" ID
- MainWindow/overlay: null-safe updates when no radar selected

Screenshots:
<img width="618" height="541" alt="image" src="https://github.com/user-attachments/assets/2fdad2cc-489e-4d6c-b9f3-1499eb130fe7" />

Selected:
<img width="1467" height="750" alt="image" src="https://github.com/user-attachments/assets/9f598a8a-ce70-4943-a53d-37f196e6f65a" />
Deselected (Via None/Clicking Radar site again)
<img width="1467" height="750" alt="image" src="https://github.com/user-attachments/assets/ac7e9447-d7f9-4527-9fe0-1f328517fd97" />


This would close #83 