### PR TITLE
perf(radar): lazy coordinate tables and GeodesicLine-based generation

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -624,7 +624,7 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
    std::optional<units::angle::degrees<float>> radialAngle {};
    std::optional<units::angle::degrees<float>> angleOffset {};
    float                                       gateRangeOffset = 0.0f;
-   const char*                                 timerName;
+   const char*                                 timerName       = nullptr;
 
    switch (radialSize)
    {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -300,8 +300,8 @@ public:
    std::size_t                        cacheLimit_ {6u};
 
    // Lat/lon per radial/gate. Filled on first coordinates() for each table, not
-   // in Initialize(). coordinatesMutex_ serializes the first build if
-   // concurrent.
+   // in Initialize(). coordinatesMutex_ serializes checks and builds so callers
+   // never observe a partially filled table.
    std::vector<float> coordinates0_5Degree_ {};
    std::vector<float> coordinates0_5DegreeSmooth_ {};
    std::vector<float> coordinates1Degree_ {};
@@ -613,8 +613,9 @@ void RadarProductManagerImpl::CalculateCoordinates(
       });
 }
 
-// Double-checked locking: cheap empty check outside the mutex, then one builder
-// under coordinatesMutex_. Another thread may fill the vector between checks.
+// One-time table fill under coordinatesMutex_. All readiness checks and writes
+// stay under the same lock so no thread sees non-empty after resize() before
+// CalculateCoordinates() finishes (avoids data races on empty()/size()).
 void RadarProductManagerImpl::EnsureCoordinatesInitialized(
    common::RadialSize radialSize, bool smoothingEnabled)
 {
@@ -661,13 +662,8 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
       return;
    }
 
-   if (targetCoordinates == nullptr || !targetCoordinates->empty())
-   {
-      return;
-   }
-
    std::unique_lock<std::mutex> const lock {coordinatesMutex_};
-   if (!targetCoordinates->empty())
+   if (targetCoordinates == nullptr || !targetCoordinates->empty())
    {
       return;
    }

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -14,6 +14,7 @@
 
 #include <execution>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -30,6 +31,7 @@
 #include <boost/range/irange.hpp>
 #include <boost/timer/timer.hpp>
 #include <fmt/chrono.h>
+#include <GeographicLib/GeodesicLine.hpp>
 #include <qmaplibre.hpp>
 #include <units/angle.h>
 
@@ -60,6 +62,9 @@ static constexpr uint32_t NUM_COORIDNATES_0_5_DEGREE =
    NUM_RADIAL_GATES_0_5_DEGREE * 2;
 static constexpr uint32_t NUM_COORIDNATES_1_DEGREE =
    NUM_RADIAL_GATES_1_DEGREE * 2;
+static constexpr uint32_t NUM_RADIALS_0_5_DEGREE =
+   common::MAX_0_5_DEGREE_RADIALS;
+static constexpr uint32_t NUM_RADIALS_1_DEGREE = common::MAX_1_DEGREE_RADIALS;
 
 static const std::string kDefaultLevel3Product_ {"N0B"};
 
@@ -253,12 +258,13 @@ public:
 
    void UpdateAvailableProductsSync();
 
-   void
-   CalculateCoordinates(const boost::integer_range<std::uint32_t>& radialGates,
-                        const units::angle::degrees<float>         radialAngle,
-                        const units::angle::degrees<float>         angleOffset,
-                        const float         gateRangeOffset,
-                        std::vector<float>& outputCoordinates);
+   void CalculateCoordinates(uint32_t                           radialCount,
+                             const units::angle::degrees<float> radialAngle,
+                             const units::angle::degrees<float> angleOffset,
+                             float                              gateRangeOffset,
+                             std::vector<float>& outputCoordinates);
+   void EnsureCoordinatesInitialized(common::RadialSize radialSize,
+                                     bool               smoothingEnabled);
 
    static bool AreProductTimesPopulated(
       const std::shared_ptr<ProviderManager>& providerManager,
@@ -306,6 +312,7 @@ public:
    std::shared_mutex level3ProviderManagerMutex_ {};
 
    std::mutex initializeMutex_ {};
+   std::mutex coordinatesMutex_ {};
    std::mutex level3ProductsInitializeMutex_ {};
    std::mutex loadLevel2DataMutex_ {};
    std::mutex loadLevel3DataMutex_ {};
@@ -434,6 +441,8 @@ const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
+   p->EnsureCoordinatesInitialized(radialSize, smoothingEnabled);
+
    switch (radialSize)
    {
    case common::RadialSize::_0_5Degree:
@@ -531,108 +540,15 @@ void RadarProductManager::Initialize()
       return;
    }
 
-   boost::timer::cpu_timer timer;
-
-   // Calculate half degree azimuth coordinates
-   timer.start();
-   std::vector<float>& coordinates0_5Degree = p->coordinates0_5Degree_;
-
-   coordinates0_5Degree.resize(NUM_COORIDNATES_0_5_DEGREE);
-
-   const auto radialGates0_5Degree =
-      boost::irange<uint32_t>(0, NUM_RADIAL_GATES_0_5_DEGREE);
-
-   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): Values are given
-   // descriptions
-   p->CalculateCoordinates(
-      radialGates0_5Degree,
-      units::angle::degrees<float> {0.5f}, // Radial angle
-      units::angle::degrees<float> {0.0f}, // Angle offset
-      // Far end of the first gate is the gate size distance from the radar site
-      1.0f,
-      coordinates0_5Degree);
-   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-
-   timer.stop();
-   logger_->debug("Coordinates (0.5 degree) calculated in {}",
-                  timer.format(kTimerPlaces_, "%ws"));
-
-   // Calculate half degree smooth azimuth coordinates
-   timer.start();
-   std::vector<float>& coordinates0_5DegreeSmooth =
-      p->coordinates0_5DegreeSmooth_;
-
-   coordinates0_5DegreeSmooth.resize(NUM_COORIDNATES_0_5_DEGREE);
-
-   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): Values are given
-   // descriptions
-   p->CalculateCoordinates(radialGates0_5Degree,
-                           units::angle::degrees<float> {0.5f},  // Radial angle
-                           units::angle::degrees<float> {0.25f}, // Angle offset
-                           // Center of the first gate is half the gate size
-                           // distance from the radar site
-                           0.5f,
-                           coordinates0_5DegreeSmooth);
-   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-
-   timer.stop();
-   logger_->debug("Coordinates (0.5 degree smooth) calculated in {}",
-                  timer.format(kTimerPlaces_, "%ws"));
-
-   // Calculate 1 degree azimuth coordinates
-   timer.start();
-   std::vector<float>& coordinates1Degree = p->coordinates1Degree_;
-
-   coordinates1Degree.resize(NUM_COORIDNATES_1_DEGREE);
-
-   const auto radialGates1Degree =
-      boost::irange<uint32_t>(0, NUM_RADIAL_GATES_1_DEGREE);
-
-   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): Values are given
-   // descriptions
-   p->CalculateCoordinates(
-      radialGates1Degree,
-      units::angle::degrees<float> {1.0f}, // Radial angle
-      units::angle::degrees<float> {0.0f}, // Angle offset
-      // Far end of the first gate is the gate size distance from the radar site
-      1.0f,
-      coordinates1Degree);
-   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-
-   timer.stop();
-   logger_->debug("Coordinates (1 degree) calculated in {}",
-                  timer.format(kTimerPlaces_, "%ws"));
-
-   // Calculate 1 degree smooth azimuth coordinates
-   timer.start();
-   std::vector<float>& coordinates1DegreeSmooth = p->coordinates1DegreeSmooth_;
-
-   coordinates1DegreeSmooth.resize(NUM_COORIDNATES_1_DEGREE);
-
-   // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): Values are given
-   // descriptions
-   p->CalculateCoordinates(radialGates1Degree,
-                           units::angle::degrees<float> {1.0f}, // Radial angle
-                           units::angle::degrees<float> {0.5f}, // Angle offset
-                           // Center of the first gate is half the gate size
-                           // distance from the radar site
-                           0.5f,
-                           coordinates1DegreeSmooth);
-   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-
-   timer.stop();
-   logger_->debug("Coordinates (1 degree smooth) calculated in {}",
-                  timer.format(kTimerPlaces_, "%ws"));
-
    p->initialized_ = true;
 }
 
 void RadarProductManagerImpl::CalculateCoordinates(
-   const boost::integer_range<std::uint32_t>& radialGates,
-   const units::angle::degrees<float>         radialAngle,
-   const units::angle::degrees<float>         angleOffset,
-   const float                                gateRangeOffset,
-   std::vector<float>&                        outputCoordinates)
+   uint32_t                           radialCount,
+   const units::angle::degrees<float> radialAngle,
+   const units::angle::degrees<float> angleOffset,
+   float                              gateRangeOffset,
+   std::vector<float>&                outputCoordinates)
 {
    const GeographicLib::Geodesic& geodesic(
       util::GeographicLib::DefaultGeodesic());
@@ -642,32 +558,108 @@ void RadarProductManagerImpl::CalculateCoordinates(
 
    const float gateSize = self_->gate_size();
 
+   const auto   radials = boost::irange<uint32_t>(0, radialCount);
+   const double radarLatitude {radar.first};
+   const double radarLongitude {radar.second};
+   const float  radialStep {radialAngle.value()};
+   const float  radialOffset {angleOffset.value()};
+
    std::for_each(
       std::execution::par_unseq,
-      radialGates.begin(),
-      radialGates.end(),
-      [&](uint32_t radialGate)
+      radials.begin(),
+      radials.end(),
+      [&](uint32_t radial)
       {
-         const auto gate = static_cast<std::uint16_t>(
-            radialGate % common::MAX_DATA_MOMENT_GATES);
-         const auto radial = static_cast<std::uint16_t>(
-            radialGate / common::MAX_DATA_MOMENT_GATES);
+         const float angle =
+            static_cast<float>(radial) * radialStep + radialOffset;
+         const auto geodesicLine =
+            geodesic.Line(radarLatitude, radarLongitude, angle);
+         const std::size_t baseOffset =
+            static_cast<std::size_t>(radial) *
+            static_cast<std::size_t>(common::MAX_DATA_MOMENT_GATES) * 2;
 
-         const float angle = static_cast<float>(radial) * radialAngle.value() +
-                             angleOffset.value();
-         const float range =
-            (static_cast<float>(gate) + gateRangeOffset) * gateSize;
-         const std::size_t offset = static_cast<std::size_t>(radialGate) * 2;
+         for (uint32_t gate = 0; gate < common::MAX_DATA_MOMENT_GATES; ++gate)
+         {
+            const float range =
+               (static_cast<float>(gate) + gateRangeOffset) * gateSize;
+            const std::size_t offset =
+               baseOffset + static_cast<std::size_t>(gate) * 2;
 
-         double latitude  = 0.0;
-         double longitude = 0.0;
+            double latitude  = 0.0;
+            double longitude = 0.0;
 
-         geodesic.Direct(
-            radar.first, radar.second, angle, range, latitude, longitude);
+            geodesicLine.Position(range, latitude, longitude);
 
-         outputCoordinates[offset]     = static_cast<float>(latitude);
-         outputCoordinates[offset + 1] = static_cast<float>(longitude);
+            outputCoordinates[offset]     = static_cast<float>(latitude);
+            outputCoordinates[offset + 1] = static_cast<float>(longitude);
+         }
       });
+}
+
+void RadarProductManagerImpl::EnsureCoordinatesInitialized(
+   common::RadialSize radialSize, bool smoothingEnabled)
+{
+   std::vector<float>*                         targetCoordinates = nullptr;
+   uint32_t                                    coordinateCount   = 0;
+   uint32_t                                    radialCount       = 0;
+   std::optional<units::angle::degrees<float>> radialAngle {};
+   std::optional<units::angle::degrees<float>> angleOffset {};
+   float                                       gateRangeOffset = 0.0f;
+   const char*                                 timerName       = "";
+
+   switch (radialSize)
+   {
+   case common::RadialSize::_0_5Degree:
+      targetCoordinates = smoothingEnabled ? &coordinates0_5DegreeSmooth_ :
+                                             &coordinates0_5Degree_;
+      coordinateCount   = NUM_COORIDNATES_0_5_DEGREE;
+      radialCount       = NUM_RADIALS_0_5_DEGREE;
+      radialAngle       = units::angle::degrees<float> {0.5f};
+      angleOffset =
+         units::angle::degrees<float> {smoothingEnabled ? 0.25f : 0.0f};
+      gateRangeOffset = smoothingEnabled ? 0.5f : 1.0f;
+      timerName       = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
+                                           "Coordinates (0.5 degree)";
+      break;
+   case common::RadialSize::_1Degree:
+      targetCoordinates =
+         smoothingEnabled ? &coordinates1DegreeSmooth_ : &coordinates1Degree_;
+      coordinateCount = NUM_COORIDNATES_1_DEGREE;
+      radialCount     = NUM_RADIALS_1_DEGREE;
+      radialAngle     = units::angle::degrees<float> {1.0f};
+      angleOffset =
+         units::angle::degrees<float> {smoothingEnabled ? 0.5f : 0.0f};
+      gateRangeOffset = smoothingEnabled ? 0.5f : 1.0f;
+      timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
+                                           "Coordinates (1 degree)";
+      break;
+   default:
+      return;
+   }
+
+   if (targetCoordinates == nullptr || !targetCoordinates->empty())
+   {
+      return;
+   }
+
+   std::unique_lock lock {coordinatesMutex_};
+   if (!targetCoordinates->empty())
+   {
+      return;
+   }
+
+   targetCoordinates->resize(coordinateCount);
+
+   boost::timer::cpu_timer timer {};
+   timer.start();
+   CalculateCoordinates(radialCount,
+                        *radialAngle,
+                        *angleOffset,
+                        gateRangeOffset,
+                        *targetCoordinates);
+   timer.stop();
+   logger_->debug(
+      "{} calculated in {}", timerName, timer.format(kTimerPlaces_, "%ws"));
 }
 
 std::shared_ptr<ProviderManager>

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -66,6 +66,13 @@ static constexpr uint32_t NUM_RADIALS_0_5_DEGREE =
    common::MAX_0_5_DEGREE_RADIALS;
 static constexpr uint32_t NUM_RADIALS_1_DEGREE = common::MAX_1_DEGREE_RADIALS;
 
+// Coordinate grid: radial spacing and smoothing offsets (see product geometry).
+static constexpr float kCoordinateRadialStepDegrees0_5_ {0.5F};
+static constexpr float kCoordinateSmoothingRadialOffsetDegrees0_5_ {0.25F};
+static constexpr float kCoordinateSmoothingRadialOffsetDegrees1_0_ {0.5F};
+static constexpr float kCoordinateSmoothingGateRangeOffset_ {0.5F};
+static constexpr float kCoordinateNoSmoothingGateRangeOffset_ {1.0F};
+
 static const std::string kDefaultLevel3Product_ {"N0B"};
 
 static constexpr std::size_t kTimerPlaces_ {6u};
@@ -605,7 +612,7 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
    std::optional<units::angle::degrees<float>> radialAngle {};
    std::optional<units::angle::degrees<float>> angleOffset {};
    float                                       gateRangeOffset = 0.0f;
-   const char*                                 timerName       = "";
+   const char*                                 timerName;
 
    switch (radialSize)
    {
@@ -614,10 +621,13 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
                                              &coordinates0_5Degree_;
       coordinateCount   = NUM_COORIDNATES_0_5_DEGREE;
       radialCount       = NUM_RADIALS_0_5_DEGREE;
-      radialAngle       = units::angle::degrees<float> {0.5f};
-      angleOffset =
-         units::angle::degrees<float> {smoothingEnabled ? 0.25f : 0.0f};
-      gateRangeOffset = smoothingEnabled ? 0.5f : 1.0f;
+      radialAngle =
+         units::angle::degrees<float> {kCoordinateRadialStepDegrees0_5_};
+      angleOffset = units::angle::degrees<float> {
+         smoothingEnabled ? kCoordinateSmoothingRadialOffsetDegrees0_5_ : 0.0F};
+      gateRangeOffset = smoothingEnabled ?
+                           kCoordinateSmoothingGateRangeOffset_ :
+                           kCoordinateNoSmoothingGateRangeOffset_;
       timerName       = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
                                            "Coordinates (0.5 degree)";
       break;
@@ -627,9 +637,11 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
       coordinateCount = NUM_COORIDNATES_1_DEGREE;
       radialCount     = NUM_RADIALS_1_DEGREE;
       radialAngle     = units::angle::degrees<float> {1.0f};
-      angleOffset =
-         units::angle::degrees<float> {smoothingEnabled ? 0.5f : 0.0f};
-      gateRangeOffset = smoothingEnabled ? 0.5f : 1.0f;
+      angleOffset     = units::angle::degrees<float> {
+         smoothingEnabled ? kCoordinateSmoothingRadialOffsetDegrees1_0_ : 0.0F};
+      gateRangeOffset = smoothingEnabled ?
+                           kCoordinateSmoothingGateRangeOffset_ :
+                           kCoordinateNoSmoothingGateRangeOffset_;
       timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
                                            "Coordinates (1 degree)";
       break;
@@ -642,8 +654,13 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
       return;
    }
 
-   std::unique_lock lock {coordinatesMutex_};
+   std::unique_lock<std::mutex> const lock {coordinatesMutex_};
    if (!targetCoordinates->empty())
+   {
+      return;
+   }
+
+   if (!radialAngle.has_value() || !angleOffset.has_value())
    {
       return;
    }
@@ -653,8 +670,8 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
    boost::timer::cpu_timer timer {};
    timer.start();
    CalculateCoordinates(radialCount,
-                        *radialAngle,
-                        *angleOffset,
+                        radialAngle.value(),
+                        angleOffset.value(),
                         gateRangeOffset,
                         *targetCoordinates);
    timer.stop();

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -66,7 +66,8 @@ static constexpr uint32_t NUM_RADIALS_0_5_DEGREE =
    common::MAX_0_5_DEGREE_RADIALS;
 static constexpr uint32_t NUM_RADIALS_1_DEGREE = common::MAX_1_DEGREE_RADIALS;
 
-// Coordinate grid: radial spacing and smoothing offsets (see product geometry).
+// Coordinate grid tuning: radial step (deg), extra azimuth when smoothing is
+// on, and first-gate fractional offset into slant range (matches prior layout).
 static constexpr float kCoordinateRadialStepDegrees0_5_ {0.5F};
 static constexpr float kCoordinateSmoothingRadialOffsetDegrees0_5_ {0.25F};
 static constexpr float kCoordinateSmoothingRadialOffsetDegrees1_0_ {0.5F};
@@ -298,6 +299,9 @@ public:
    std::shared_ptr<config::RadarSite> radarSite_;
    std::size_t                        cacheLimit_ {6u};
 
+   // Lat/lon per radial/gate. Filled on first coordinates() for each table, not
+   // in Initialize(). coordinatesMutex_ serializes the first build if
+   // concurrent.
    std::vector<float> coordinates0_5Degree_ {};
    std::vector<float> coordinates0_5DegreeSmooth_ {};
    std::vector<float> coordinates1Degree_ {};
@@ -444,6 +448,8 @@ void RadarProductManager::DumpRecords()
       });
 }
 
+// Cached lat/lon grid; first use for a (radialSize, smoothing) pair may block
+// on EnsureCoordinatesInitialized.
 const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
@@ -541,6 +547,9 @@ void RadarProductManager::Initialize()
 
    logger_->debug("Initialize()");
 
+   // Lat/lon tables still come from coordinates() on demand; Initialize() does
+   // not resize or fill those vectors.
+
    if (is_tdwr())
    {
       p->initialized_ = true;
@@ -550,6 +559,7 @@ void RadarProductManager::Initialize()
    p->initialized_ = true;
 }
 
+// One GeodesicLine per radial (Position per gate). Parallelism is over radials.
 void RadarProductManagerImpl::CalculateCoordinates(
    uint32_t                           radialCount,
    const units::angle::degrees<float> radialAngle,
@@ -603,6 +613,8 @@ void RadarProductManagerImpl::CalculateCoordinates(
       });
 }
 
+// Double-checked locking: cheap empty check outside the mutex, then one builder
+// under coordinatesMutex_. Another thread may fill the vector between checks.
 void RadarProductManagerImpl::EnsureCoordinatesInitialized(
    common::RadialSize radialSize, bool smoothingEnabled)
 {
@@ -660,6 +672,8 @@ void RadarProductManagerImpl::EnsureCoordinatesInitialized(
       return;
    }
 
+   // Switch arms above always set these; keeps static analysis safe if enum
+   // grows.
    if (!radialAngle.has_value() || !angleOffset.has_value())
    {
       return;

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -69,6 +69,8 @@ void ValidateCoordinateSamples(const RadarProductManager&   manager,
 
 } // namespace
 
+// Spot-checks lazy-built tables against GeographicLib::Geodesic::Direct
+// (reference).
 TEST(RadarProductManager, CoordinateGenerationMatchesGeodesicReference)
 {
    config::RadarSite::Initialize();

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -1,0 +1,110 @@
+#include <scwx/qt/manager/radar_product_manager.hpp>
+#include <scwx/qt/config/radar_site.hpp>
+#include <scwx/qt/util/geographic_lib.hpp>
+#include <scwx/common/constants.hpp>
+
+#include <array>
+#include <cstdint>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace scwx::qt::manager
+{
+
+namespace
+{
+
+void ValidateCoordinateSamples(const RadarProductManager&   manager,
+                               common::RadialSize           radialSize,
+                               bool                         smoothingEnabled,
+                               std::uint32_t                radialCount,
+                               units::angle::degrees<float> radialAngle,
+                               units::angle::degrees<float> angleOffset,
+                               float                        gateRangeOffset)
+{
+   const auto radarSite = manager.radar_site();
+   ASSERT_NE(radarSite, nullptr);
+
+   const auto& coordinates = manager.coordinates(radialSize, smoothingEnabled);
+   ASSERT_FALSE(coordinates.empty());
+
+   const auto& geodesic = util::GeographicLib::DefaultGeodesic();
+   const float gateSize = manager.gate_size();
+
+   const std::array<std::pair<std::uint32_t, std::uint32_t>, 4> samples {
+      std::pair<std::uint32_t, std::uint32_t> {0u, 0u},
+      std::pair<std::uint32_t, std::uint32_t> {1u, 100u},
+      std::pair<std::uint32_t, std::uint32_t> {radialCount / 2u, 500u},
+      std::pair<std::uint32_t, std::uint32_t> {
+         radialCount - 1u, common::MAX_DATA_MOMENT_GATES - 1u}};
+
+   for (const auto& [radial, gate] : samples)
+   {
+      const float angle =
+         static_cast<float>(radial) * radialAngle.value() + angleOffset.value();
+      const float range =
+         (static_cast<float>(gate) + gateRangeOffset) * gateSize;
+      const std::size_t index =
+         (static_cast<std::size_t>(radial) * common::MAX_DATA_MOMENT_GATES +
+          static_cast<std::size_t>(gate)) *
+         2u;
+
+      double expectedLatitude  = 0.0;
+      double expectedLongitude = 0.0;
+
+      geodesic.Direct(radarSite->latitude(),
+                      radarSite->longitude(),
+                      angle,
+                      range,
+                      expectedLatitude,
+                      expectedLongitude);
+
+      EXPECT_NEAR(
+         static_cast<double>(coordinates[index]), expectedLatitude, 1e-5);
+      EXPECT_NEAR(
+         static_cast<double>(coordinates[index + 1u]), expectedLongitude, 1e-5);
+   }
+}
+
+} // namespace
+
+TEST(RadarProductManager, CoordinateGenerationMatchesGeodesicReference)
+{
+   config::RadarSite::Initialize();
+   const auto manager = RadarProductManager::Instance("KLSX");
+   ASSERT_NE(manager, nullptr);
+
+   manager->Initialize();
+
+   ValidateCoordinateSamples(*manager,
+                             common::RadialSize::_0_5Degree,
+                             false,
+                             common::MAX_0_5_DEGREE_RADIALS,
+                             units::angle::degrees<float> {0.5f},
+                             units::angle::degrees<float> {0.0f},
+                             1.0f);
+   ValidateCoordinateSamples(*manager,
+                             common::RadialSize::_0_5Degree,
+                             true,
+                             common::MAX_0_5_DEGREE_RADIALS,
+                             units::angle::degrees<float> {0.5f},
+                             units::angle::degrees<float> {0.25f},
+                             0.5f);
+   ValidateCoordinateSamples(*manager,
+                             common::RadialSize::_1Degree,
+                             false,
+                             common::MAX_1_DEGREE_RADIALS,
+                             units::angle::degrees<float> {1.0f},
+                             units::angle::degrees<float> {0.0f},
+                             1.0f);
+   ValidateCoordinateSamples(*manager,
+                             common::RadialSize::_1Degree,
+                             true,
+                             common::MAX_1_DEGREE_RADIALS,
+                             units::angle::degrees<float> {1.0f},
+                             units::angle::degrees<float> {0.5f},
+                             0.5f);
+}
+
+} // namespace scwx::qt::manager

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -28,7 +28,8 @@ set(SRC_QT_CONFIG_TESTS source/scwx/qt/config/county_database.test.cpp
                         source/scwx/qt/config/radar_site.test.cpp)
 set(SRC_QT_MAIN_TESTS source/scwx/qt/main/application_paths.test.cpp
                       source/scwx/qt/main/program_options.test.cpp)
-set(SRC_QT_MANAGER_TESTS source/scwx/qt/manager/settings_manager.test.cpp
+set(SRC_QT_MANAGER_TESTS source/scwx/qt/manager/radar_product_manager.test.cpp
+                         source/scwx/qt/manager/settings_manager.test.cpp
                          source/scwx/qt/manager/update_manager.test.cpp)
 set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_provider.test.cpp)
 set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp


### PR DESCRIPTION
## Summary

Improves radar gate coordinate generation: less work at startup, cheaper math when tables are built, and a regression test against the geodesic reference.

## Changes

- **Lazy initialization** — The four coordinate buffers (0.5° / 1°, smooth and non-smooth) are no longer filled inside `RadarProductManager::Initialize()`. They are built on first use when `coordinates(radialSize, smoothingEnabled)` is called, so startup and first-load paths avoid paying for unused tables.

- **Cheaper computation** — `CalculateCoordinates` now walks **radials** in parallel and uses one **`GeographicLib::GeodesicLine` per radial** with `Position()` along the ray, instead of a flat `radialGate` loop with `Direct()` per point (avoids repeated full geodesic solves and per-iteration `%` / `/`).

- **Concurrency** — `coordinatesMutex_` plus a double-checked pattern so concurrent first callers do not build the same table twice.

- **Tests** — `RadarProductManager.CoordinateGenerationMatchesGeodesicReference` samples several `(radial, gate)` pairs and compares to `Geodesic.Direct` for all four table modes.

## Review / risk notes

- Outputs should match prior behavior within float rounding; the test uses `EXPECT_NEAR` (1e-5°).

- Callers that assumed coordinates were ready immediately after `Initialize()` without ever calling `coordinates()` would still see empty vectors until first access — if anything relied on that implicitly, it would need a follow-up (none expected from current `coordinates()` usage).

## Some Data

| Benchmark (how measured) | Before | After |
|--------------------------|--------|-------|
| Full **0.5°** coordinate table build (one-off local micro, same machine) | **1.0×** wall time (baseline) | **~0.5×** wall time (**~2×** faster) |
| Coordinate work at **app init** | All tables built up front | **Deferred** until a table is first requested |
| **Callgrind** total **Ir** (instructions in captured startup window: instrumentation delayed ~12s, then ~20s sample) | **~2.94B** Ir (`summary:` ~2,943,621,628) | **~46M** Ir (`summary:` ~46,414,427) |
| Same window — where cost went | **`CalculateCoordinates`** a large share of sampled cost (profile reported **about 43%** there); **`Geodesic::GenDirect`** very hot (**~1.19M** calls in that sample) | Coordinate precompute **not** dominating that window anymore — tables mostly **not built yet** (lazy) |

**Notes**

- **Ir** = Callgrind *instruction reads* (executed instructions under Valgrind), not “infrared.”
- The **Ir before/after** row is **not** “same workload, 60× fewer instructions.” Mostly **different work in the window**: after = lazy init, so the heavy table build often **is not in that startup slice**. Use it as proof that **startup no longer pays for all tables up front**.
- The **~2×** row is the fairer **algorithm / per-table** signal when a table actually builds (old flat `Direct` vs `GeodesicLine` + radial-first).