### PR TITLE
Fix select radar product hotkey crash

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -190,8 +190,8 @@ public:
    void SetRadarSite(const std::string& radarSite,
                      bool               checkProductAvailability = false);
    void UpdateColorTable(
-      const std::string&                      colorPalette,
-      std::shared_ptr<view::RadarProductView> radarProductView = nullptr);
+      const std::string&                             colorPalette,
+      const std::shared_ptr<view::RadarProductView>& radarProductView = {});
    void UpdateLoadedStyle();
    bool UpdateStoredMapParameters();
    void CheckLevel3Availability();
@@ -2425,8 +2425,8 @@ void MapWidgetImpl::Update()
 }
 
 void MapWidgetImpl::UpdateColorTable(
-   const std::string&                      colorPalette,
-   std::shared_ptr<view::RadarProductView> radarProductView)
+   const std::string&                             colorPalette,
+   const std::shared_ptr<view::RadarProductView>& radarProductView)
 {
    const std::shared_ptr<view::RadarProductView> view =
       radarProductView != nullptr ? radarProductView :

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2181,9 +2181,10 @@ void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
    // Must run on the GUI thread: UpdateColorTable / Initialize touch
-   // RadarProductView (mutex, LUT, Q_EMIT). Posting to threadPool_ raced product
-   // switches (e.g. hotkeys) with destruction and queued Qt connections, causing
-   // heap corruption. AddLayers() must run after init, not concurrently.
+   // RadarProductView (mutex, LUT, Q_EMIT). Posting to threadPool_ raced
+   // product switches (e.g. hotkeys) with destruction and queued Qt
+   // connections, causing heap corruption. AddLayers() must run after init, not
+   // concurrently.
    try
    {
       auto radarProductView = context_->radar_product_view();

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2180,11 +2180,8 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
 void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
-   // Must run on the GUI thread: UpdateColorTable / Initialize touch
-   // RadarProductView (mutex, LUT, Q_EMIT). Posting to threadPool_ raced
-   // product switches (e.g. hotkeys) with destruction and queued Qt
-   // connections, causing heap corruption. AddLayers() must run after init, not
-   // concurrently.
+   // GUI thread only: view state + Qt signals; async post raced rapid product
+   // switch (heap corruption) and let AddLayers() run before init finished.
    try
    {
       auto radarProductView = context_->radar_product_view();

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2180,19 +2180,25 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
 void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
-   boost::asio::post(threadPool_,
-                     [colorPalette, this]()
-                     {
-                        try
-                        {
-                           UpdateColorTable(colorPalette);
-                           context_->radar_product_view()->Initialize();
-                        }
-                        catch (const std::exception& ex)
-                        {
-                           logger_->error(ex.what());
-                        }
-                     });
+   // Must run on the GUI thread: UpdateColorTable / Initialize touch
+   // RadarProductView (mutex, LUT, Q_EMIT). Posting to threadPool_ raced product
+   // switches (e.g. hotkeys) with destruction and queued Qt connections, causing
+   // heap corruption. AddLayers() must run after init, not concurrently.
+   try
+   {
+      auto radarProductView = context_->radar_product_view();
+      if (radarProductView == nullptr)
+      {
+         return;
+      }
+
+      UpdateColorTable(colorPalette);
+      radarProductView->Initialize();
+   }
+   catch (const std::exception& ex)
+   {
+      logger_->error(ex.what());
+   }
 
    if (map_ != nullptr)
    {

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -189,7 +189,9 @@ public:
                                std::optional<std::string> type);
    void SetRadarSite(const std::string& radarSite,
                      bool               checkProductAvailability = false);
-   void UpdateColorTable(const std::string& colorPalette);
+   void UpdateColorTable(
+      const std::string&                      colorPalette,
+      std::shared_ptr<view::RadarProductView> radarProductView = nullptr);
    void UpdateLoadedStyle();
    bool UpdateStoredMapParameters();
    void CheckLevel3Availability();
@@ -2182,6 +2184,9 @@ void MapWidgetImpl::InitializeNewRadarProductView(
 {
    // GUI thread only: view state + Qt signals; async post raced rapid product
    // switch (heap corruption) and let AddLayers() run before init finished.
+   // ComputeSweep() can cost a frame; async here reintroduced cross-thread
+   // bugs.
+   bool initOk = false;
    try
    {
       auto radarProductView = context_->radar_product_view();
@@ -2190,15 +2195,16 @@ void MapWidgetImpl::InitializeNewRadarProductView(
          return;
       }
 
-      UpdateColorTable(colorPalette);
+      UpdateColorTable(colorPalette, radarProductView);
       radarProductView->Initialize();
+      initOk = true;
    }
    catch (const std::exception& ex)
    {
       logger_->error(ex.what());
    }
 
-   if (map_ != nullptr)
+   if (initOk && map_ != nullptr)
    {
       AddLayers();
    }
@@ -2418,8 +2424,18 @@ void MapWidgetImpl::Update()
    }
 }
 
-void MapWidgetImpl::UpdateColorTable(const std::string& colorPalette)
+void MapWidgetImpl::UpdateColorTable(
+   const std::string&                      colorPalette,
+   std::shared_ptr<view::RadarProductView> radarProductView)
 {
+   const std::shared_ptr<view::RadarProductView> view =
+      radarProductView != nullptr ? radarProductView :
+                                    context_->radar_product_view();
+   if (view == nullptr)
+   {
+      return;
+   }
+
    auto& paletteSetting =
       settings::PaletteSettings::Instance().palette(colorPalette);
 
@@ -2446,7 +2462,7 @@ void MapWidgetImpl::UpdateColorTable(const std::string& colorPalette)
       colorTable       = common::ColorTable::Load(*colorTableStream);
    }
 
-   context_->radar_product_view()->LoadColorTable(colorTable);
+   view->LoadColorTable(colorTable);
 }
 
 bool MapWidgetImpl::UpdateStoredMapParameters()

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2182,32 +2182,50 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
 void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
-   // GUI thread only: view state + Qt signals; async post raced rapid product
-   // switch (heap corruption) and let AddLayers() run before init finished.
-   // ComputeSweep() can cost a frame; async here reintroduced cross-thread
-   // bugs.
-   bool initOk = false;
-   try
+   auto radarProductView = context_->radar_product_view();
+   if (radarProductView == nullptr)
    {
-      auto radarProductView = context_->radar_product_view();
-      if (radarProductView == nullptr)
+      return;
+   }
+
+   // Keep expensive work off GUI thread. Only apply AddLayers() on GUI thread,
+   // and only if this latched view is still active.
+   std::weak_ptr<view::RadarProductView> weakRadarProductView {
+      radarProductView};
+
+   boost::asio::post(
+      threadPool_,
+      [colorPalette, radarProductView, weakRadarProductView, this]()
       {
-         return;
-      }
+         try
+         {
+            UpdateColorTable(colorPalette, radarProductView);
+            radarProductView->Initialize();
+         }
+         catch (const std::exception& ex)
+         {
+            logger_->error(ex.what());
+            return;
+         }
 
-      UpdateColorTable(colorPalette, radarProductView);
-      radarProductView->Initialize();
-      initOk = true;
-   }
-   catch (const std::exception& ex)
-   {
-      logger_->error(ex.what());
-   }
+         QMetaObject::invokeMethod(
+            this,
+            [this, weakRadarProductView]()
+            {
+               auto activeRadarProductView = weakRadarProductView.lock();
+               if (activeRadarProductView == nullptr ||
+                   context_->radar_product_view() != activeRadarProductView)
+               {
+                  return;
+               }
 
-   if (initOk && map_ != nullptr)
-   {
-      AddLayers();
-   }
+               if (map_ != nullptr)
+               {
+                  AddLayers();
+               }
+            },
+            Qt::QueuedConnection);
+      });
 }
 
 void MapWidgetImpl::RadarProductViewConnect()


### PR DESCRIPTION
## Problem
Rapid product changes (e.g. Level 2 hotkeys) could abort with glibc heap corruption (`malloc_printerr` / `free`). Main thread often in `MapWidget::SelectRadarProduct` / shared_ptr teardown; worker in `boost::asio::thread_pool` completing a posted job.

## Cause
`MapWidgetImpl::InitializeNewRadarProductView` posted `UpdateColorTable` and `RadarProductView::Initialize()` to `MapWidgetImpl::thread_pool_` instead of running them on the Qt GUI thread. That path touches product view state (`UpdateColorTableLut`, parallel fill, `Q_EMIT`) while the UI could replace or destroy the same view. `AddLayers()` also ran immediately on the GUI thread, so layers could be added before async init finished.

## Fix
Run `UpdateColorTable` → `Initialize()` → `AddLayers()` synchronously on the GUI thread, with null check on `radar_product_view()`.

## Notes
Repro: spam L2 product hotkeys on map with live/archive data. After fix, no cross-thread view access from this path.