### PR TITLE
Fix select product crash

### DIFF
--- a/scwx-qt/source/scwx/qt/map/map_context.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_context.cpp
@@ -3,6 +3,8 @@
 #include <scwx/qt/view/overlay_product_view.hpp>
 #include <scwx/qt/view/radar_product_view.hpp>
 
+#include <mutex>
+
 namespace scwx::qt::map
 {
 
@@ -31,6 +33,8 @@ public:
 
    QMargins           colorTableMargins_ {};
    common::Coordinate mouseCoordinate_ {};
+
+   mutable std::mutex productViewMutex_ {};
 
    std::shared_ptr<view::OverlayProductView> overlayProductView_ {nullptr};
    std::shared_ptr<view::RadarProductView>   radarProductView_;
@@ -86,11 +90,13 @@ common::Coordinate MapContext::mouse_coordinate() const
 std::shared_ptr<view::OverlayProductView>
 MapContext::overlay_product_view() const
 {
+   const std::scoped_lock lock {p->productViewMutex_};
    return p->overlayProductView_;
 }
 
 std::shared_ptr<view::RadarProductView> MapContext::radar_product_view() const
 {
+   const std::scoped_lock lock {p->productViewMutex_};
    return p->radarProductView_;
 }
 
@@ -152,6 +158,7 @@ void MapContext::set_mouse_coordinate(const common::Coordinate& coordinate)
 void MapContext::set_overlay_product_view(
    const std::shared_ptr<view::OverlayProductView>& overlayProductView)
 {
+   const std::scoped_lock lock {p->productViewMutex_};
    p->overlayProductView_ = overlayProductView;
 }
 
@@ -163,6 +170,7 @@ void MapContext::set_pixel_ratio(float pixelRatio)
 void MapContext::set_radar_product_view(
    const std::shared_ptr<view::RadarProductView>& radarProductView)
 {
+   const std::scoped_lock lock {p->productViewMutex_};
    p->radarProductView_ = radarProductView;
 }
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -191,6 +191,9 @@ public:
    void SetRadarSite(const std::string& radarSite,
                      bool               checkProductAvailability = false);
    void UpdateColorTable(const std::string& colorPalette);
+   void UpdateColorTable(
+      const std::string&                             colorPalette,
+      const std::shared_ptr<view::RadarProductView>& radarProductView);
    void UpdateLoadedStyle();
    bool UpdateStoredMapParameters();
    void CheckLevel3Availability();
@@ -2253,19 +2256,24 @@ void MapWidgetImpl::RadarProductManagerDisconnect()
 void MapWidgetImpl::InitializeNewRadarProductView(
    const std::string& colorPalette)
 {
-   boost::asio::post(threadPool_,
-                     [colorPalette, this]()
-                     {
-                        try
+   auto radarProductView = context_->radar_product_view();
+
+   if (radarProductView != nullptr)
+   {
+      boost::asio::post(threadPool_,
+                        [colorPalette, radarProductView, this]()
                         {
-                           UpdateColorTable(colorPalette);
-                           context_->radar_product_view()->Initialize();
-                        }
-                        catch (const std::exception& ex)
-                        {
-                           logger_->error(ex.what());
-                        }
-                     });
+                           try
+                           {
+                              UpdateColorTable(colorPalette, radarProductView);
+                              radarProductView->Initialize();
+                           }
+                           catch (const std::exception& ex)
+                           {
+                              logger_->error(ex.what());
+                           }
+                        });
+   }
 
    if (map_ != nullptr)
    {
@@ -2504,6 +2512,18 @@ void MapWidgetImpl::Update()
 
 void MapWidgetImpl::UpdateColorTable(const std::string& colorPalette)
 {
+   UpdateColorTable(colorPalette, context_->radar_product_view());
+}
+
+void MapWidgetImpl::UpdateColorTable(
+   const std::string&                             colorPalette,
+   const std::shared_ptr<view::RadarProductView>& radarProductView)
+{
+   if (radarProductView == nullptr)
+   {
+      return;
+   }
+
    auto& paletteSetting =
       settings::PaletteSettings::Instance().palette(colorPalette);
 
@@ -2530,7 +2550,7 @@ void MapWidgetImpl::UpdateColorTable(const std::string& colorPalette)
       colorTable       = common::ColorTable::Load(*colorTableStream);
    }
 
-   context_->radar_product_view()->LoadColorTable(colorTable);
+   radarProductView->LoadColorTable(colorTable);
 }
 
 bool MapWidgetImpl::UpdateStoredMapParameters()

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2263,6 +2263,14 @@ void MapWidgetImpl::InitializeNewRadarProductView(
       boost::asio::post(threadPool_,
                         [colorPalette, radarProductView, this]()
                         {
+                           if (radarProductView !=
+                               context_->radar_product_view())
+                           {
+                              // If the radar product view has changed, don't
+                              // initialize
+                              return;
+                           }
+
                            try
                            {
                               UpdateColorTable(colorPalette, radarProductView);


### PR DESCRIPTION
From #631:

> Rapid product changes (e.g. Level 2 hotkeys) could abort with glibc heap corruption (malloc_printerr / free). Main thread often in MapWidget::SelectRadarProduct / shared_ptr teardown; worker in boost::asio::thread_pool completing a posted job.

Latch radarProductView prior to posting the initialize task to the thread pool. If the view has changed before the initializer can execute, don't do anything. Additionally, the radarProductView should be protected with mutexes inside the MapContext.