### PR TITLE
Disable downed radars from automatically being selected when looking for nearest radar site

### DIFF
--- a/scwx-qt/source/scwx/qt/config/radar_site.cpp
+++ b/scwx-qt/source/scwx/qt/config/radar_site.cpp
@@ -218,8 +218,12 @@ std::vector<std::shared_ptr<RadarSite>> RadarSite::GetAll()
    return radarSites;
 }
 
-std::shared_ptr<RadarSite> RadarSite::FindNearest(
-   double latitude, double longitude, const std::optional<std::string>& type)
+std::shared_ptr<RadarSite>
+RadarSite::FindNearest(double                            latitude,
+                       double                            longitude,
+                       const std::optional<std::string>& type,
+                       bool                              includeDown,
+                       bool                              includeKlix)
 {
    std::shared_lock lock(siteMutex_);
 
@@ -234,6 +238,18 @@ std::shared_ptr<RadarSite> RadarSite::FindNearest(
 
       // If the type filter doesn't match, skip
       if (type.has_value() && radarSite->type() != type)
+      {
+         continue;
+      }
+
+      // Optionally exclude radars which are currently down.
+      if (!includeDown && radarSite->status() == types::RadarSiteStatus::Down)
+      {
+         continue;
+      }
+
+      // Optionally exclude KLIX from automatic selection.
+      if (!includeKlix && radarSite->id() == "KLIX")
       {
          continue;
       }

--- a/scwx-qt/source/scwx/qt/config/radar_site.cpp
+++ b/scwx-qt/source/scwx/qt/config/radar_site.cpp
@@ -223,7 +223,7 @@ RadarSite::FindNearest(double                            latitude,
                        double                            longitude,
                        const std::optional<std::string>& type,
                        bool                              includeDown,
-                       bool                              includeKlix)
+                       bool                              includeDecommissioned)
 {
    std::shared_lock lock(siteMutex_);
 
@@ -249,7 +249,7 @@ RadarSite::FindNearest(double                            latitude,
       }
 
       // Optionally exclude KLIX from automatic selection.
-      if (!includeKlix && radarSite->id() == "KLIX")
+      if (!includeDecommissioned && radarSite->id() == "KLIX")
       {
          continue;
       }

--- a/scwx-qt/source/scwx/qt/config/radar_site.hpp
+++ b/scwx-qt/source/scwx/qt/config/radar_site.hpp
@@ -63,7 +63,7 @@ public:
                double                            longitude,
                const std::optional<std::string>& type        = std::nullopt,
                bool                              includeDown = true,
-               bool                              includeKlix = true);
+               bool                              includeDecommissioned = true);
 
    static void   Initialize();
    static size_t ReadConfig(const std::string& path);

--- a/scwx-qt/source/scwx/qt/config/radar_site.hpp
+++ b/scwx-qt/source/scwx/qt/config/radar_site.hpp
@@ -61,7 +61,9 @@ public:
    static std::shared_ptr<RadarSite>
    FindNearest(double                            latitude,
                double                            longitude,
-               const std::optional<std::string>& type = std::nullopt);
+               const std::optional<std::string>& type        = std::nullopt,
+               bool                              includeDown = true,
+               bool                              includeKlix = true);
 
    static void   Initialize();
    static size_t ReadConfig(const std::string& path);

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.cpp
@@ -122,6 +122,11 @@ std::chrono::system_clock::time_point TimelineManager::GetSelectedTime() const
    return p->selectedTime_;
 }
 
+types::MapTime TimelineManager::GetViewType() const
+{
+   return p->viewType_;
+}
+
 void TimelineManager::SetMapCount(std::size_t mapCount)
 {
    p->mapCount_ = mapCount;

--- a/scwx-qt/source/scwx/qt/manager/timeline_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/timeline_manager.hpp
@@ -25,6 +25,7 @@ public:
    static std::shared_ptr<TimelineManager> Instance();
 
    [[nodiscard]] std::chrono::system_clock::time_point GetSelectedTime() const;
+   [[nodiscard]] types::MapTime                        GetViewType() const;
 
    void SetMapCount(std::size_t mapCount);
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1602,23 +1602,24 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
       case types::InformationLayer::RadarSite:
          radarSiteLayer_ = std::make_shared<RadarSiteLayer>(glContext_);
          AddLayer(layerName, radarSiteLayer_, before);
-         connect(radarSiteLayer_.get(),
-                 &RadarSiteLayer::RadarSiteSelected,
-                 this,
-                 [this](const std::string& id)
-                 {
-                    auto& generalSettings =
-                       settings::GeneralSettings::Instance();
-                    auto selectedRadarSite = widget_->GetRadarSite();
-                    const std::string requestedRadarSite =
-                       (selectedRadarSite != nullptr &&
-                        selectedRadarSite->id() == id) ?
-                          std::string {} :
-                          id;
-                    widget_->RadarSiteRequested(
-                       requestedRadarSite,
-                       generalSettings.center_on_radar_selection().GetValue());
-                 });
+         connect(
+            radarSiteLayer_.get(),
+            &RadarSiteLayer::RadarSiteSelected,
+            this,
+            [this](const std::string& id)
+            {
+               auto& generalSettings   = settings::GeneralSettings::Instance();
+               auto  selectedRadarSite = widget_->GetRadarSite();
+               if (selectedRadarSite != nullptr &&
+                   selectedRadarSite->id() == id)
+               {
+                  // Clicking the currently selected radar should not clear
+                  // the site or reset timeline state.
+                  return;
+               }
+               widget_->RadarSiteRequested(
+                  id, generalSettings.center_on_radar_selection().GetValue());
+            });
          break;
 
       // Create the location marker layer

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -4,6 +4,7 @@
 #include <scwx/qt/manager/hotkey_manager.hpp>
 #include <scwx/qt/manager/placefile_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager.hpp>
+#include <scwx/qt/manager/timeline_manager.hpp>
 #include <scwx/qt/map/alert_layer.hpp>
 #include <scwx/qt/map/color_table_layer.hpp>
 #include <scwx/qt/map/layer_wrapper.hpp>
@@ -1275,8 +1276,14 @@ void MapWidget::SetMapLocation(double latitude,
          }
 
          // Find the nearest radar
+         const bool isArchiveMode =
+            manager::TimelineManager::Instance()->GetViewType() ==
+            types::MapTime::Archive;
+         const bool                               includeDown = isArchiveMode;
+         const bool                               includeKlix = isArchiveMode;
          const std::shared_ptr<config::RadarSite> nearestRadarSite =
-            config::RadarSite::FindNearest(latitude, longitude, type);
+            config::RadarSite::FindNearest(
+               latitude, longitude, type, includeDown, includeKlix);
 
          // If found, select it
          if (nearestRadarSite != nullptr)
@@ -2672,7 +2679,13 @@ void MapWidgetImpl::SelectNearestRadarSite(double                     latitude,
                                            double                     longitude,
                                            std::optional<std::string> type)
 {
-   auto radarSite = config::RadarSite::FindNearest(latitude, longitude, type);
+   const bool isArchiveMode =
+      manager::TimelineManager::Instance()->GetViewType() ==
+      types::MapTime::Archive;
+   const bool includeDown = isArchiveMode;
+   const bool includeKlix = isArchiveMode;
+   auto       radarSite   = config::RadarSite::FindNearest(
+      latitude, longitude, type, includeDown, includeKlix);
 
    if (radarSite != nullptr)
    {

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1279,11 +1279,11 @@ void MapWidget::SetMapLocation(double latitude,
          const bool isArchiveMode =
             manager::TimelineManager::Instance()->GetViewType() ==
             types::MapTime::Archive;
-         const bool                               includeDown = isArchiveMode;
-         const bool                               includeKlix = isArchiveMode;
+         const bool includeDown           = isArchiveMode;
+         const bool includeDecommissioned = isArchiveMode;
          const std::shared_ptr<config::RadarSite> nearestRadarSite =
             config::RadarSite::FindNearest(
-               latitude, longitude, type, includeDown, includeKlix);
+               latitude, longitude, type, includeDown, includeDecommissioned);
 
          // If found, select it
          if (nearestRadarSite != nullptr)
@@ -2682,10 +2682,10 @@ void MapWidgetImpl::SelectNearestRadarSite(double                     latitude,
    const bool isArchiveMode =
       manager::TimelineManager::Instance()->GetViewType() ==
       types::MapTime::Archive;
-   const bool includeDown = isArchiveMode;
-   const bool includeKlix = isArchiveMode;
-   auto       radarSite   = config::RadarSite::FindNearest(
-      latitude, longitude, type, includeDown, includeKlix);
+   const bool includeDown           = isArchiveMode;
+   const bool includeDecommissioned = isArchiveMode;
+   auto       radarSite             = config::RadarSite::FindNearest(
+      latitude, longitude, type, includeDown, includeDecommissioned);
 
    if (radarSite != nullptr)
    {

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -1602,24 +1602,23 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
       case types::InformationLayer::RadarSite:
          radarSiteLayer_ = std::make_shared<RadarSiteLayer>(glContext_);
          AddLayer(layerName, radarSiteLayer_, before);
-         connect(
-            radarSiteLayer_.get(),
-            &RadarSiteLayer::RadarSiteSelected,
-            this,
-            [this](const std::string& id)
-            {
-               auto& generalSettings   = settings::GeneralSettings::Instance();
-               auto  selectedRadarSite = widget_->GetRadarSite();
-               if (selectedRadarSite != nullptr &&
-                   selectedRadarSite->id() == id)
-               {
-                  // Clicking the currently selected radar should not clear
-                  // the site or reset timeline state.
-                  return;
-               }
-               widget_->RadarSiteRequested(
-                  id, generalSettings.center_on_radar_selection().GetValue());
-            });
+         connect(radarSiteLayer_.get(),
+                 &RadarSiteLayer::RadarSiteSelected,
+                 this,
+                 [this](const std::string& id)
+                 {
+                    auto& generalSettings =
+                       settings::GeneralSettings::Instance();
+                    auto selectedRadarSite = widget_->GetRadarSite();
+                    const std::string requestedRadarSite =
+                       (selectedRadarSite != nullptr &&
+                        selectedRadarSite->id() == id) ?
+                          std::string {} :
+                          id;
+                    widget_->RadarSiteRequested(
+                       requestedRadarSite,
+                       generalSettings.center_on_radar_selection().GetValue());
+                 });
          break;
 
       // Create the location marker layer


### PR DESCRIPTION
This pull request should allow for downed radars to be blocked from being automatically selected when searching from the nearest radar, unless the app is in Archive Mode. KLIX is also included, as it was moved and is now KHDC. 

I haven't been able to test every scenario, such as a warning popping up and hitting the go to button.
Below is a video of me testing the feature:

https://github.com/user-attachments/assets/87cf5dcb-d0c9-4d47-a732-bfbdceba6433

