### PR TITLE
refactor(manager): extract ProviderManager from RadarProductManager

### DIFF
--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -116,6 +116,7 @@ set(HDR_MANAGER source/scwx/qt/manager/alert_manager.hpp
                 source/scwx/qt/manager/media_manager.hpp
                 source/scwx/qt/manager/placefile_manager.hpp
                 source/scwx/qt/manager/position_manager.hpp
+                source/scwx/qt/manager/provider_manager.hpp
                 source/scwx/qt/manager/radar_product_manager.hpp
                 source/scwx/qt/manager/radar_product_manager_notifier.hpp
                 source/scwx/qt/manager/radar_site_status_manager.hpp
@@ -135,6 +136,7 @@ set(SRC_MANAGER source/scwx/qt/manager/alert_manager.cpp
                 source/scwx/qt/manager/media_manager.cpp
                 source/scwx/qt/manager/placefile_manager.cpp
                 source/scwx/qt/manager/position_manager.cpp
+                source/scwx/qt/manager/provider_manager.cpp
                 source/scwx/qt/manager/radar_product_manager.cpp
                 source/scwx/qt/manager/radar_product_manager_notifier.cpp
                 source/scwx/qt/manager/radar_site_status_manager.cpp

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
@@ -1,0 +1,208 @@
+#include <scwx/qt/manager/provider_manager.hpp>
+#include <scwx/qt/manager/radar_product_manager.hpp>
+#include <scwx/util/logger.hpp>
+#include <scwx/util/time.hpp>
+
+#include <boost/asio/post.hpp>
+#include <fmt/chrono.h>
+
+namespace scwx::qt::manager
+{
+
+namespace
+{
+
+static const std::string logPrefix_ = "scwx::qt::manager::provider_manager";
+static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
+
+static constexpr std::chrono::seconds kFastRetryInterval_ {15};
+static constexpr std::chrono::seconds kFastRetryIntervalChunks_ {3};
+static constexpr std::chrono::seconds kSlowRetryInterval_ {120};
+static constexpr std::chrono::seconds kSlowRetryIntervalChunks_ {20};
+
+} // namespace
+
+ProviderManager::ProviderManager(RadarProductManager*      self,
+                                 std::string               radarId,
+                                 common::RadarProductGroup group,
+                                 std::string               product,
+                                 bool                      isChunks) :
+    radarId_ {std::move(radarId)},
+    group_ {group},
+    product_ {std::move(product)},
+    isChunks_ {isChunks}
+{
+   connect(this,
+           &ProviderManager::NewDataAvailable,
+           self,
+           [this, self](common::RadarProductGroup             group,
+                        const std::string&                    product,
+                        std::chrono::system_clock::time_point latestTime)
+           {
+              Q_EMIT self->NewDataAvailable(
+                 group, product, isChunks_, latestTime);
+           });
+}
+
+ProviderManager::~ProviderManager()
+{
+   if (provider_ != nullptr && !providerShutdown_)
+   {
+      provider_->Shutdown();
+   }
+
+   providerThreadPool_.stop();
+   providerThreadPool_.join();
+}
+
+std::string ProviderManager::name() const
+{
+   std::string name;
+
+   if (group_ == common::RadarProductGroup::Level3)
+   {
+      name = fmt::format("{}, {}, {}",
+                         radarId_,
+                         common::GetRadarProductGroupName(group_),
+                         product_);
+   }
+   else
+   {
+      name = fmt::format(
+         "{}, {}", radarId_, common::GetRadarProductGroupName(group_));
+   }
+
+   return name;
+}
+
+void ProviderManager::Disable(bool shutdown)
+{
+   logger_->debug("Disabling refresh: {}", name());
+
+   std::unique_lock lock(refreshTimerMutex_);
+   refreshEnabled_ = false;
+   refreshTimer_.cancel();
+
+   if (shutdown && provider_ != nullptr && !providerShutdown_)
+   {
+      provider_->Shutdown();
+      providerShutdown_ = true;
+   }
+}
+
+void ProviderManager::RefreshData()
+{
+   logger_->trace("RefreshData: {}", name());
+
+   {
+      const std::unique_lock lock(refreshTimerMutex_);
+      refreshTimer_.cancel();
+   }
+
+   boost::asio::post(providerThreadPool_,
+                     [this]()
+                     {
+                        try
+                        {
+                           RefreshDataSync();
+                        }
+                        catch (const std::exception& ex)
+                        {
+                           logger_->error(ex.what());
+                        }
+                     });
+}
+
+void ProviderManager::RefreshDataSync()
+{
+   using namespace std::chrono_literals;
+
+   if (provider_ == nullptr)
+   {
+      return;
+   }
+
+   auto [newObjects, totalObjects] = provider_->Refresh();
+
+   // Level2 chunked data is updated quickly and uses a faster interval
+   const std::chrono::milliseconds fastRetryInterval =
+      isChunks_ ? kFastRetryIntervalChunks_ : kFastRetryInterval_;
+   const std::chrono::milliseconds slowRetryInterval =
+      isChunks_ ? kSlowRetryIntervalChunks_ : kSlowRetryInterval_;
+   std::chrono::milliseconds interval = fastRetryInterval;
+
+   if (totalObjects > 0)
+   {
+      auto latestTime        = provider_->FindLatestTime();
+      auto updatePeriod      = provider_->update_period();
+      auto lastModified      = provider_->last_modified();
+      auto sinceLastModified = scwx::util::time::now() - lastModified;
+
+      // For the default interval, assume products are updated at a
+      // constant rate. Expect the next product at a time based on the
+      // previous two.
+      interval = std::chrono::duration_cast<std::chrono::milliseconds>(
+         updatePeriod - sinceLastModified);
+
+      // Allow 5 update periods before considering the data stale
+      constexpr std::size_t kUpdatePeriodStaleCount = 5;
+
+      if (updatePeriod > 0s &&
+          sinceLastModified > updatePeriod * kUpdatePeriodStaleCount)
+      {
+         // If it has been at least 5 update periods since the file has
+         // been last modified, slow the retry period
+         interval = slowRetryInterval;
+      }
+      else if (interval < std::chrono::milliseconds {fastRetryInterval})
+      {
+         // The interval should be no quicker than the fast retry interval
+         interval = fastRetryInterval;
+      }
+
+      if (newObjects > 0)
+      {
+         Q_EMIT NewDataAvailable(group_, product_, latestTime);
+      }
+   }
+   else if (refreshEnabled_)
+   {
+      logger_->info("[{}] No data found", name());
+
+      // If no data is found, retry at the slow retry interval
+      interval = slowRetryInterval;
+   }
+
+   std::unique_lock const lock(refreshTimerMutex_);
+
+   if (refreshEnabled_)
+   {
+      logger_->trace(
+         "[{}] Scheduled refresh in {:%M:%S}",
+         name(),
+         std::chrono::duration_cast<std::chrono::seconds>(interval));
+
+      {
+         refreshTimer_.expires_after(interval);
+         refreshTimer_.async_wait(
+            [this](const boost::system::error_code& e)
+            {
+               if (e == boost::system::errc::success)
+               {
+                  RefreshData();
+               }
+               else if (e == boost::asio::error::operation_aborted)
+               {
+                  logger_->debug("[{}] Data refresh timer cancelled", name());
+               }
+               else
+               {
+                  logger_->warn(
+                     "[{}] Data refresh timer error: {}", name(), e.message());
+               }
+            });
+      }
+   }
+}
+
+} // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
@@ -79,7 +79,7 @@ void ProviderManager::Disable(bool shutdown)
 {
    logger_->debug("Disabling refresh: {}", name());
 
-   std::unique_lock lock(refreshTimerMutex_);
+   std::unique_lock const lock(refreshTimerMutex_);
    refreshEnabled_ = false;
    refreshTimer_.cancel();
 

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
@@ -4,6 +4,8 @@
 #include <scwx/util/time.hpp>
 
 #include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/thread_pool.hpp>
 #include <fmt/chrono.h>
 
 namespace scwx::qt::manager
@@ -22,15 +24,41 @@ static constexpr std::chrono::seconds kSlowRetryIntervalChunks_ {20};
 
 } // namespace
 
+class ProviderManager::Impl
+{
+public:
+   Impl(std::string               radarId,
+        common::RadarProductGroup group,
+        std::string               product,
+        bool                      isChunks) :
+       radarId_ {std::move(radarId)},
+       group_ {group},
+       product_ {std::move(product)},
+       isChunks_ {isChunks}
+   {
+   }
+
+   boost::asio::thread_pool providerThreadPool_ {2u};
+
+   const std::string               radarId_;
+   const common::RadarProductGroup group_;
+   const std::string               product_;
+   const bool                      isChunks_;
+   bool                            refreshEnabled_ {false};
+   boost::asio::steady_timer       refreshTimer_ {providerThreadPool_};
+   std::mutex                      refreshTimerMutex_ {};
+   std::shared_ptr<provider::NexradDataProvider> provider_ {nullptr};
+   std::size_t                                   refreshCount_ {0};
+   bool                                          providerShutdown_ {false};
+};
+
 ProviderManager::ProviderManager(RadarProductManager*      self,
                                  std::string               radarId,
                                  common::RadarProductGroup group,
                                  std::string               product,
                                  bool                      isChunks) :
-    radarId_ {std::move(radarId)},
-    group_ {group},
-    product_ {std::move(product)},
-    isChunks_ {isChunks}
+    p(std::make_unique<Impl>(
+       std::move(radarId), group, std::move(product), isChunks))
 {
    connect(this,
            &ProviderManager::NewDataAvailable,
@@ -40,36 +68,36 @@ ProviderManager::ProviderManager(RadarProductManager*      self,
                         std::chrono::system_clock::time_point latestTime)
            {
               Q_EMIT self->NewDataAvailable(
-                 group, product, isChunks_, latestTime);
+                 group, product, p->isChunks_, latestTime);
            });
 }
 
 ProviderManager::~ProviderManager()
 {
-   if (provider_ != nullptr && !providerShutdown_)
+   if (p->provider_ != nullptr && !p->providerShutdown_)
    {
-      provider_->Shutdown();
+      p->provider_->Shutdown();
    }
 
-   providerThreadPool_.stop();
-   providerThreadPool_.join();
+   p->providerThreadPool_.stop();
+   p->providerThreadPool_.join();
 }
 
 std::string ProviderManager::name() const
 {
    std::string name;
 
-   if (group_ == common::RadarProductGroup::Level3)
+   if (p->group_ == common::RadarProductGroup::Level3)
    {
       name = fmt::format("{}, {}, {}",
-                         radarId_,
-                         common::GetRadarProductGroupName(group_),
-                         product_);
+                         p->radarId_,
+                         common::GetRadarProductGroupName(p->group_),
+                         p->product_);
    }
    else
    {
       name = fmt::format(
-         "{}, {}", radarId_, common::GetRadarProductGroupName(group_));
+         "{}, {}", p->radarId_, common::GetRadarProductGroupName(p->group_));
    }
 
    return name;
@@ -79,14 +107,14 @@ void ProviderManager::Disable(bool shutdown)
 {
    logger_->debug("Disabling refresh: {}", name());
 
-   std::unique_lock const lock(refreshTimerMutex_);
-   refreshEnabled_ = false;
-   refreshTimer_.cancel();
+   std::unique_lock const lock(p->refreshTimerMutex_);
+   p->refreshEnabled_ = false;
+   p->refreshTimer_.cancel();
 
-   if (shutdown && provider_ != nullptr && !providerShutdown_)
+   if (shutdown && p->provider_ != nullptr && !p->providerShutdown_)
    {
-      provider_->Shutdown();
-      providerShutdown_ = true;
+      p->provider_->Shutdown();
+      p->providerShutdown_ = true;
    }
 }
 
@@ -95,11 +123,11 @@ void ProviderManager::RefreshData()
    logger_->trace("RefreshData: {}", name());
 
    {
-      const std::unique_lock lock(refreshTimerMutex_);
-      refreshTimer_.cancel();
+      const std::unique_lock lock(p->refreshTimerMutex_);
+      p->refreshTimer_.cancel();
    }
 
-   boost::asio::post(providerThreadPool_,
+   boost::asio::post(p->providerThreadPool_,
                      [this]()
                      {
                         try
@@ -117,25 +145,25 @@ void ProviderManager::RefreshDataSync()
 {
    using namespace std::chrono_literals;
 
-   if (provider_ == nullptr)
+   if (p->provider_ == nullptr)
    {
       return;
    }
 
-   auto [newObjects, totalObjects] = provider_->Refresh();
+   auto [newObjects, totalObjects] = p->provider_->Refresh();
 
    // Level2 chunked data is updated quickly and uses a faster interval
    const std::chrono::milliseconds fastRetryInterval =
-      isChunks_ ? kFastRetryIntervalChunks_ : kFastRetryInterval_;
+      p->isChunks_ ? kFastRetryIntervalChunks_ : kFastRetryInterval_;
    const std::chrono::milliseconds slowRetryInterval =
-      isChunks_ ? kSlowRetryIntervalChunks_ : kSlowRetryInterval_;
+      p->isChunks_ ? kSlowRetryIntervalChunks_ : kSlowRetryInterval_;
    std::chrono::milliseconds interval = fastRetryInterval;
 
    if (totalObjects > 0)
    {
-      auto latestTime        = provider_->FindLatestTime();
-      auto updatePeriod      = provider_->update_period();
-      auto lastModified      = provider_->last_modified();
+      auto latestTime        = p->provider_->FindLatestTime();
+      auto updatePeriod      = p->provider_->update_period();
+      auto lastModified      = p->provider_->last_modified();
       auto sinceLastModified = scwx::util::time::now() - lastModified;
 
       // For the default interval, assume products are updated at a
@@ -162,10 +190,10 @@ void ProviderManager::RefreshDataSync()
 
       if (newObjects > 0)
       {
-         Q_EMIT NewDataAvailable(group_, product_, latestTime);
+         Q_EMIT NewDataAvailable(p->group_, p->product_, latestTime);
       }
    }
-   else if (refreshEnabled_)
+   else if (p->refreshEnabled_)
    {
       logger_->info("[{}] No data found", name());
 
@@ -173,9 +201,9 @@ void ProviderManager::RefreshDataSync()
       interval = slowRetryInterval;
    }
 
-   std::unique_lock const lock(refreshTimerMutex_);
+   std::unique_lock const lock(p->refreshTimerMutex_);
 
-   if (refreshEnabled_)
+   if (p->refreshEnabled_)
    {
       logger_->trace(
          "[{}] Scheduled refresh in {:%M:%S}",
@@ -183,8 +211,8 @@ void ProviderManager::RefreshDataSync()
          std::chrono::duration_cast<std::chrono::seconds>(interval));
 
       {
-         refreshTimer_.expires_after(interval);
-         refreshTimer_.async_wait(
+         p->refreshTimer_.expires_after(interval);
+         p->refreshTimer_.async_wait(
             [this](const boost::system::error_code& e)
             {
                if (e == boost::system::errc::success)
@@ -203,6 +231,52 @@ void ProviderManager::RefreshDataSync()
             });
       }
    }
+}
+
+std::shared_ptr<provider::NexradDataProvider> ProviderManager::provider() const
+{
+   return p->provider_;
+}
+
+void ProviderManager::set_provider(
+   std::shared_ptr<provider::NexradDataProvider> provider)
+{
+   p->provider_ = std::move(provider);
+}
+
+common::RadarProductGroup ProviderManager::group() const
+{
+   return p->group_;
+}
+
+const std::string& ProviderManager::product() const
+{
+   return p->product_;
+}
+
+void ProviderManager::increment_refresh_count()
+{
+   ++p->refreshCount_;
+}
+
+void ProviderManager::decrement_refresh_count()
+{
+   --p->refreshCount_;
+}
+
+std::size_t ProviderManager::refresh_count() const
+{
+   return p->refreshCount_;
+}
+
+bool ProviderManager::refresh_enabled() const
+{
+   return p->refreshEnabled_;
+}
+
+void ProviderManager::set_refresh_enabled(bool enabled)
+{
+   p->refreshEnabled_ = enabled;
 }
 
 } // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <scwx/common/products.hpp>
+#include <scwx/provider/nexrad_data_provider.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <QObject>
+
+namespace scwx::qt::manager
+{
+
+class RadarProductManager;
+
+class ProviderManager : public QObject
+{
+   Q_OBJECT
+
+public:
+   explicit ProviderManager(RadarProductManager*      self,
+                            std::string               radarId,
+                            common::RadarProductGroup group,
+                            std::string               product  = "???",
+                            bool                      isChunks = false);
+   ~ProviderManager() override;
+
+   ProviderManager(const ProviderManager&)            = delete;
+   ProviderManager& operator=(const ProviderManager&) = delete;
+
+   [[nodiscard]] std::string name() const;
+
+   void Disable(bool shutdown = false);
+   void RefreshData();
+   void RefreshDataSync();
+
+   boost::asio::thread_pool providerThreadPool_ {2u};
+
+   const std::string               radarId_;
+   const common::RadarProductGroup group_;
+   const std::string               product_;
+   const bool                      isChunks_;
+   bool                            refreshEnabled_ {false};
+   boost::asio::steady_timer       refreshTimer_ {providerThreadPool_};
+   std::mutex                      refreshTimerMutex_ {};
+   std::shared_ptr<provider::NexradDataProvider> provider_ {nullptr};
+   std::size_t                                   refreshCount_ {0};
+   bool                                          providerShutdown_ {false};
+
+signals:
+   void NewDataAvailable(common::RadarProductGroup             group,
+                         const std::string&                    product,
+                         std::chrono::system_clock::time_point latestTime);
+};
+
+} // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
@@ -6,11 +6,8 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
-#include <mutex>
 #include <string>
 
-#include <boost/asio/steady_timer.hpp>
-#include <boost/asio/thread_pool.hpp>
 #include <QObject>
 
 namespace scwx::qt::manager
@@ -41,23 +38,27 @@ public:
    void RefreshData();
    void RefreshDataSync();
 
-   boost::asio::thread_pool providerThreadPool_ {2u};
+   [[nodiscard]] std::shared_ptr<provider::NexradDataProvider> provider() const;
+   void set_provider(std::shared_ptr<provider::NexradDataProvider> provider);
 
-   const std::string               radarId_;
-   const common::RadarProductGroup group_;
-   const std::string               product_;
-   const bool                      isChunks_;
-   bool                            refreshEnabled_ {false};
-   boost::asio::steady_timer       refreshTimer_ {providerThreadPool_};
-   std::mutex                      refreshTimerMutex_ {};
-   std::shared_ptr<provider::NexradDataProvider> provider_ {nullptr};
-   std::size_t                                   refreshCount_ {0};
-   bool                                          providerShutdown_ {false};
+   [[nodiscard]] common::RadarProductGroup group() const;
+   [[nodiscard]] const std::string&        product() const;
+
+   void                      increment_refresh_count();
+   void                      decrement_refresh_count();
+   [[nodiscard]] std::size_t refresh_count() const;
+
+   [[nodiscard]] bool refresh_enabled() const;
+   void               set_refresh_enabled(bool enabled);
 
 signals:
    void NewDataAvailable(common::RadarProductGroup             group,
                          const std::string&                    product,
                          std::chrono::system_clock::time_point latestTime);
+
+private:
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.hpp
@@ -32,6 +32,8 @@ public:
 
    ProviderManager(const ProviderManager&)            = delete;
    ProviderManager& operator=(const ProviderManager&) = delete;
+   ProviderManager(ProviderManager&&)                 = delete;
+   ProviderManager& operator=(ProviderManager&&)      = delete;
 
    [[nodiscard]] std::string name() const;
 

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1,3 +1,4 @@
+#include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager_notifier.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
@@ -78,11 +79,6 @@ static const std::string kDefaultLevel3Product_ {"N0B"};
 
 static constexpr std::size_t kTimerPlaces_ {6u};
 
-static constexpr std::chrono::seconds kFastRetryInterval_ {15};
-static constexpr std::chrono::seconds kFastRetryIntervalChunks_ {3};
-static constexpr std::chrono::seconds kSlowRetryInterval_ {120};
-static constexpr std::chrono::seconds kSlowRetryIntervalChunks_ {20};
-
 static std::unordered_map<std::string, std::weak_ptr<RadarProductManager>>
                          instanceMap_;
 static std::shared_mutex instanceMutex_;
@@ -93,66 +89,6 @@ static std::unordered_map<std::string,
 static std::shared_mutex fileIndexMutex_;
 
 static std::mutex fileLoadMutex_;
-
-class ProviderManager : public QObject
-{
-   Q_OBJECT
-public:
-   explicit ProviderManager(RadarProductManager*      self,
-                            std::string               radarId,
-                            common::RadarProductGroup group,
-                            std::string               product  = "???",
-                            bool                      isChunks = false) :
-       radarId_ {std::move(radarId)},
-       group_ {group},
-       product_ {std::move(product)},
-       isChunks_ {isChunks}
-   {
-      connect(this,
-              &ProviderManager::NewDataAvailable,
-              self,
-              [this, self](common::RadarProductGroup             group,
-                           const std::string&                    product,
-                           std::chrono::system_clock::time_point latestTime)
-              {
-                 Q_EMIT self->NewDataAvailable(
-                    group, product, isChunks_, latestTime);
-              });
-   }
-   ~ProviderManager() override
-   {
-      if (provider_ != nullptr)
-      {
-         provider_->Shutdown();
-      }
-
-      providerThreadPool_.stop();
-      providerThreadPool_.join();
-   };
-
-   std::string name() const;
-
-   void Disable(bool shutdown = false);
-   void RefreshData();
-   void RefreshDataSync();
-
-   boost::asio::thread_pool providerThreadPool_ {2u};
-
-   const std::string               radarId_;
-   const common::RadarProductGroup group_;
-   const std::string               product_;
-   const bool                      isChunks_;
-   bool                            refreshEnabled_ {false};
-   boost::asio::steady_timer       refreshTimer_ {providerThreadPool_};
-   std::mutex                      refreshTimerMutex_ {};
-   std::shared_ptr<provider::NexradDataProvider> provider_ {nullptr};
-   size_t                                        refreshCount_ {0};
-
-signals:
-   void NewDataAvailable(common::RadarProductGroup             group,
-                         const std::string&                    product,
-                         std::chrono::system_clock::time_point latestTime);
-};
 
 class RadarProductManagerImpl
 {
@@ -345,40 +281,6 @@ RadarProductManager::RadarProductManager(const std::string& radarId) :
 {
 }
 RadarProductManager::~RadarProductManager() = default;
-
-std::string ProviderManager::name() const
-{
-   std::string name;
-
-   if (group_ == common::RadarProductGroup::Level3)
-   {
-      name = fmt::format("{}, {}, {}",
-                         radarId_,
-                         common::GetRadarProductGroupName(group_),
-                         product_);
-   }
-   else
-   {
-      name = fmt::format(
-         "{}, {}", radarId_, common::GetRadarProductGroupName(group_));
-   }
-
-   return name;
-}
-
-void ProviderManager::Disable(bool shutdown)
-{
-   logger_->debug("Disabling refresh: {}", name());
-
-   std::unique_lock lock(refreshTimerMutex_);
-   refreshEnabled_ = false;
-   refreshTimer_.cancel();
-
-   if (shutdown && provider_ != nullptr)
-   {
-      provider_->Shutdown();
-   }
-}
 
 void RadarProductManager::Cleanup()
 {
@@ -819,116 +721,6 @@ void RadarProductManagerImpl::EnableRefresh(
             providerManager->refreshEnabled_ = enabled;
             providerManager->RefreshData();
          }
-      }
-   }
-}
-
-void ProviderManager::RefreshData()
-{
-   logger_->trace("RefreshData: {}", name());
-
-   {
-      const std::unique_lock lock(refreshTimerMutex_);
-      refreshTimer_.cancel();
-   }
-
-   boost::asio::post(providerThreadPool_,
-                     [this]()
-                     {
-                        try
-                        {
-                           RefreshDataSync();
-                        }
-                        catch (const std::exception& ex)
-                        {
-                           logger_->error(ex.what());
-                        }
-                     });
-}
-
-void ProviderManager::RefreshDataSync()
-{
-   using namespace std::chrono_literals;
-
-   auto [newObjects, totalObjects] = provider_->Refresh();
-
-   // Level2 chunked data is updated quickly and uses a faster interval
-   const std::chrono::milliseconds fastRetryInterval =
-      isChunks_ ? kFastRetryIntervalChunks_ : kFastRetryInterval_;
-   const std::chrono::milliseconds slowRetryInterval =
-      isChunks_ ? kSlowRetryIntervalChunks_ : kSlowRetryInterval_;
-   std::chrono::milliseconds interval = fastRetryInterval;
-
-   if (totalObjects > 0)
-   {
-      auto latestTime        = provider_->FindLatestTime();
-      auto updatePeriod      = provider_->update_period();
-      auto lastModified      = provider_->last_modified();
-      auto sinceLastModified = scwx::util::time::now() - lastModified;
-
-      // For the default interval, assume products are updated at a
-      // constant rate. Expect the next product at a time based on the
-      // previous two.
-      interval = std::chrono::duration_cast<std::chrono::milliseconds>(
-         updatePeriod - sinceLastModified);
-
-      // Allow 5 update periods before considering the data stale
-      constexpr std::size_t kUpdatePeriodStaleCount = 5;
-
-      if (updatePeriod > 0s &&
-          sinceLastModified > updatePeriod * kUpdatePeriodStaleCount)
-      {
-         // If it has been at least 5 update periods since the file has
-         // been last modified, slow the retry period
-         interval = slowRetryInterval;
-      }
-      else if (interval < std::chrono::milliseconds {fastRetryInterval})
-      {
-         // The interval should be no quicker than the fast retry interval
-         interval = fastRetryInterval;
-      }
-
-      if (newObjects > 0)
-      {
-         Q_EMIT NewDataAvailable(group_, product_, latestTime);
-      }
-   }
-   else if (refreshEnabled_)
-   {
-      logger_->info("[{}] No data found", name());
-
-      // If no data is found, retry at the slow retry interval
-      interval = slowRetryInterval;
-   }
-
-   std::unique_lock const lock(refreshTimerMutex_);
-
-   if (refreshEnabled_)
-   {
-      logger_->trace(
-         "[{}] Scheduled refresh in {:%M:%S}",
-         name(),
-         std::chrono::duration_cast<std::chrono::seconds>(interval));
-
-      {
-         refreshTimer_.expires_after(interval);
-         refreshTimer_.async_wait(
-            [this](const boost::system::error_code& e)
-            {
-               if (e == boost::system::errc::success)
-               {
-                  RefreshData();
-               }
-               else if (e == boost::asio::error::operation_aborted)
-               {
-                  logger_->debug("[{}] Data refresh timer cancelled", name());
-               }
-               else
-               {
-                  logger_->warn(
-                     "[{}] Data refresh timer error: {}", name(), e.message());
-               }
-            });
       }
    }
 }
@@ -2066,7 +1858,5 @@ RadarProductManager::Instance(const std::string& radarSite)
 
    return instance;
 }
-
-#include "radar_product_manager.moc"
 
 } // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -111,20 +111,21 @@ public:
          radarSite_ = std::make_shared<config::RadarSite>();
       }
 
-      level2ProviderManager_->provider_ =
-         provider::NexradDataProviderFactory::CreateLevel2DataProvider(radarId);
-      level2ChunksProviderManager_->provider_ =
+      level2ProviderManager_->set_provider(
+         provider::NexradDataProviderFactory::CreateLevel2DataProvider(
+            radarId));
+      level2ChunksProviderManager_->set_provider(
          provider::NexradDataProviderFactory::CreateLevel2ChunksDataProvider(
-            radarId);
+            radarId));
 
       auto level2ChunksProvider =
          std::dynamic_pointer_cast<provider::AwsLevel2ChunksDataProvider>(
-            level2ChunksProviderManager_->provider_);
+            level2ChunksProviderManager_->provider());
       if (level2ChunksProvider != nullptr)
       {
          level2ChunksProvider->SetLevel2DataProvider(
             std::dynamic_pointer_cast<provider::AwsLevel2DataProvider>(
-               level2ProviderManager_->provider_));
+               level2ProviderManager_->provider()));
       }
    }
    ~RadarProductManagerImpl()
@@ -603,9 +604,9 @@ RadarProductManagerImpl::GetLevel3ProviderManager(const std::string& product)
          std::forward_as_tuple(product),
          std::forward_as_tuple(std::make_shared<ProviderManager>(
             self_, radarId_, common::RadarProductGroup::Level3, product)));
-      level3ProviderManagerMap_.at(product)->provider_ =
-         provider::NexradDataProviderFactory::CreateLevel3DataProvider(radarId_,
-                                                                       product);
+      level3ProviderManagerMap_.at(product)->set_provider(
+         provider::NexradDataProviderFactory::CreateLevel3DataProvider(
+            radarId_, product));
    }
 
    std::shared_ptr<ProviderManager> providerManager =
@@ -640,9 +641,9 @@ void RadarProductManager::EnableRefresh(common::RadarProductGroup group,
             {
                try
                {
-                  providerManager->provider_->RequestAvailableProducts();
+                  providerManager->provider()->RequestAvailableProducts();
                   const auto availableProducts =
-                     providerManager->provider_->GetAvailableProducts();
+                     providerManager->provider()->GetAvailableProducts();
 
                   if (std::find(std::execution::par,
                                 availableProducts.cbegin(),
@@ -678,13 +679,13 @@ void RadarProductManagerImpl::EnableRefresh(
    {
       for (const auto& currentProviderManager : currentProviderManagers->second)
       {
-         currentProviderManager->refreshCount_ -= 1;
+         currentProviderManager->decrement_refresh_count();
          // If the enabling refresh for a different product, or disabling
          // refresh
          if (!providerManagers.contains(currentProviderManager) || !enabled)
          {
             // If this is the last reference to the provider in the refresh map
-            if (currentProviderManager->refreshCount_ == 0)
+            if (currentProviderManager->refresh_count() == 0)
             {
                // Disable current provider
                currentProviderManager->Disable();
@@ -703,7 +704,7 @@ void RadarProductManagerImpl::EnableRefresh(
       refreshMap_.emplace(uuid, providerManagers);
       for (const auto& providerManager : providerManagers)
       {
-         providerManager->refreshCount_ += 1;
+         providerManager->increment_refresh_count();
       }
    }
 
@@ -716,9 +717,9 @@ void RadarProductManagerImpl::EnableRefresh(
    {
       for (const auto& providerManager : providerManagers)
       {
-         if (providerManager->refreshEnabled_ != enabled)
+         if (providerManager->refresh_enabled() != enabled)
          {
-            providerManager->refreshEnabled_ = enabled;
+            providerManager->set_refresh_enabled(enabled);
             providerManager->RefreshData();
          }
       }
@@ -749,7 +750,7 @@ RadarProductManager::GetActiveVolumeTimes(
       for (const auto& refreshEntry : refreshSet.second)
       {
          // Add the provider for the current entry
-         providers.insert(refreshEntry->provider_);
+         providers.insert(refreshEntry->provider());
       }
    }
 
@@ -837,7 +838,7 @@ void RadarProductManagerImpl::LoadProviderData(
 
          if (existingRecord == nullptr)
          {
-            nexradFile = providerManager->provider_->LoadObjectByTime(time);
+            nexradFile = providerManager->provider()->LoadObjectByTime(time);
             if (nexradFile == nullptr)
             {
                logger_->warn("Attempting to load object without key: {}",
@@ -1078,7 +1079,7 @@ bool RadarProductManagerImpl::AreProductTimesPopulated(
          continue;
       }
 
-      if (!providerManager->provider_->IsDateCached(date))
+      if (!providerManager->provider()->IsDateCached(date))
       {
          productTimesPopulated = false;
       }
@@ -1132,15 +1133,15 @@ void RadarProductManagerImpl::PopulateProductTimes(
    if (update)
    {
       logger_->debug("Populating product times: {}, {}, {}",
-                     common::GetRadarProductGroupName(providerManager->group_),
-                     providerManager->product_,
+                     common::GetRadarProductGroupName(providerManager->group()),
+                     providerManager->product(),
                      scwx::util::time::TimeString(time));
    }
    else
    {
       logger_->trace("Populating cached product times: {}, {}, {}",
-                     common::GetRadarProductGroupName(providerManager->group_),
-                     providerManager->product_,
+                     common::GetRadarProductGroupName(providerManager->group()),
+                     providerManager->product(),
                      scwx::util::time::TimeString(time));
    }
 
@@ -1173,8 +1174,8 @@ void RadarProductManagerImpl::PopulateProductTimes(
 
                     // Query the provider for volume time points
                     auto timePoints =
-                       providerManager->provider_->GetTimePointsByDate(date,
-                                                                       update);
+                       providerManager->provider()->GetTimePointsByDate(date,
+                                                                        update);
 
                     // Lock the merged volume time list
                     std::unique_lock volumeTimesLock {volumeTimesMutex};
@@ -1598,7 +1599,7 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
 
    // See if we have this one in the chunk provider.
    auto chunkFile = std::dynamic_pointer_cast<wsr88d::Ar2vFile>(
-      p->level2ChunksProviderManager_->provider_->LoadObjectByTime(time));
+      p->level2ChunksProviderManager_->provider()->LoadObjectByTime(time));
    if (chunkFile != nullptr)
    {
       std::tie(radarData, elevationCut, elevationCuts) =
@@ -1613,7 +1614,7 @@ RadarProductManager::GetLevel2Data(wsr88d::rda::DataBlockType dataBlockType,
 
          const std::optional<float> incomingElevation =
             std::dynamic_pointer_cast<provider::AwsLevel2ChunksDataProvider>(
-               p->level2ChunksProviderManager_->provider_)
+               p->level2ChunksProviderManager_->provider())
                ->GetCurrentElevation();
          if (incomingElevation != p->incomingLevel2Elevation_)
          {
@@ -1724,7 +1725,7 @@ std::vector<std::string> RadarProductManager::GetLevel3Products()
 {
    auto level3ProviderManager =
       p->GetLevel3ProviderManager(kDefaultLevel3Product_);
-   return level3ProviderManager->provider_->GetAvailableProducts();
+   return level3ProviderManager->provider()->GetAvailableProducts();
 }
 
 void RadarProductManager::SetCacheLimit(size_t cacheLimit)
@@ -1771,9 +1772,9 @@ void RadarProductManagerImpl::UpdateAvailableProductsSync()
 {
    auto level3ProviderManager =
       GetLevel3ProviderManager(kDefaultLevel3Product_);
-   level3ProviderManager->provider_->RequestAvailableProducts();
+   level3ProviderManager->provider()->RequestAvailableProducts();
    auto updatedAwipsIdList =
-      level3ProviderManager->provider_->GetAvailableProducts();
+      level3ProviderManager->provider()->GetAvailableProducts();
 
    std::unique_lock lock {availableCategoryMutex_};
 

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1,5 +1,5 @@
-#include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager.hpp>
+#include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager_notifier.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/types/time_types.hpp>

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -116,12 +116,12 @@ TEST(ProviderManager, NameFormatting)
 {
    config::RadarSite::Initialize();
 
-   RadarProductManager radarProductManager {"KLSX"};
-   ProviderManager     level2ProviderManager {
+   RadarProductManager   radarProductManager {"KLSX"};
+   const ProviderManager level2ProviderManager {
       &radarProductManager, "KLSX", common::RadarProductGroup::Level2};
-   ProviderManager level3ProviderManager {
+   const ProviderManager level3ProviderManager {
       &radarProductManager, "KLSX", common::RadarProductGroup::Level3, "N0B"};
-   ProviderManager level2ChunksProviderManager {
+   const ProviderManager level2ChunksProviderManager {
       &radarProductManager,
       "KLSX",
       common::RadarProductGroup::Level2,

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -1,4 +1,7 @@
 #include <scwx/qt/manager/radar_product_manager.hpp>
+// Include after radar_product_manager.hpp: Qt's emit macro breaks TBB if
+// reversed.
+#include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/config/radar_site.hpp>
 #include <scwx/qt/util/geographic_lib.hpp>
 #include <scwx/common/constants.hpp>
@@ -107,6 +110,27 @@ TEST(RadarProductManager, CoordinateGenerationMatchesGeodesicReference)
                              units::angle::degrees<float> {1.0f},
                              units::angle::degrees<float> {0.5f},
                              0.5f);
+}
+
+TEST(ProviderManager, NameFormatting)
+{
+   config::RadarSite::Initialize();
+
+   RadarProductManager radarProductManager {"KLSX"};
+   ProviderManager     level2ProviderManager {
+      &radarProductManager, "KLSX", common::RadarProductGroup::Level2};
+   ProviderManager level3ProviderManager {
+      &radarProductManager, "KLSX", common::RadarProductGroup::Level3, "N0B"};
+   ProviderManager level2ChunksProviderManager {
+      &radarProductManager,
+      "KLSX",
+      common::RadarProductGroup::Level2,
+      "???",
+      true};
+
+   EXPECT_EQ(level2ProviderManager.name(), "KLSX, L2");
+   EXPECT_EQ(level3ProviderManager.name(), "KLSX, L3, N0B");
+   EXPECT_EQ(level2ChunksProviderManager.name(), "KLSX, L2");
 }
 
 } // namespace scwx::qt::manager

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -1,6 +1,4 @@
 #include <scwx/qt/manager/radar_product_manager.hpp>
-// Include after radar_product_manager.hpp: Qt's emit macro breaks TBB if
-// reversed.
 #include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/config/radar_site.hpp>
 #include <scwx/qt/util/geographic_lib.hpp>

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -102,6 +102,11 @@ endif()
 
 target_compile_definitions(wxtest PRIVATE SCWX_TEST_DATA_DIR="${SCWX_DIR}/test/data")
 
+if (LINUX)
+    # Qt emit keyword is incompatible with TBB
+    target_compile_definitions(wxtest PRIVATE QT_NO_EMIT)
+endif()
+
 if (MSVC)
     # Don't include Windows macros
     target_compile_options(wxtest PRIVATE -DNOMINMAX)


### PR DESCRIPTION
Move refresh scheduling and provider lifecycle into dedicated files as the first step toward the multi-provider design in discussion #506. No behavior change; adds a name-formatting unit test and small guards for null provider and duplicate Shutdown.