### PR TITLE
refactor(manager): extract RadarCoordinateTable from RPM

### DIFF
--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -116,6 +116,7 @@ set(HDR_MANAGER source/scwx/qt/manager/alert_manager.hpp
                 source/scwx/qt/manager/media_manager.hpp
                 source/scwx/qt/manager/placefile_manager.hpp
                 source/scwx/qt/manager/position_manager.hpp
+                source/scwx/qt/manager/radar_coordinate_table.hpp
                 source/scwx/qt/manager/radar_product_manager.hpp
                 source/scwx/qt/manager/radar_product_manager_notifier.hpp
                 source/scwx/qt/manager/radar_site_status_manager.hpp
@@ -135,6 +136,7 @@ set(SRC_MANAGER source/scwx/qt/manager/alert_manager.cpp
                 source/scwx/qt/manager/media_manager.cpp
                 source/scwx/qt/manager/placefile_manager.cpp
                 source/scwx/qt/manager/position_manager.cpp
+                source/scwx/qt/manager/radar_coordinate_table.cpp
                 source/scwx/qt/manager/radar_product_manager.cpp
                 source/scwx/qt/manager/radar_product_manager_notifier.cpp
                 source/scwx/qt/manager/radar_site_status_manager.cpp

--- a/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
@@ -4,6 +4,8 @@
 
 #include <execution>
 #include <optional>
+#include <stdexcept>
+#include <string>
 
 #include <boost/range/irange.hpp>
 #include <boost/timer/timer.hpp>

--- a/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
@@ -1,0 +1,196 @@
+#include <scwx/qt/manager/radar_coordinate_table.hpp>
+#include <scwx/qt/util/geographic_lib.hpp>
+#include <scwx/util/logger.hpp>
+
+#include <execution>
+#include <optional>
+
+#include <boost/range/irange.hpp>
+#include <boost/timer/timer.hpp>
+#include <GeographicLib/Geodesic.hpp>
+#include <GeographicLib/GeodesicLine.hpp>
+
+namespace scwx::qt::manager
+{
+
+namespace
+{
+
+static const std::string logPrefix_ =
+   "scwx::qt::manager::radar_coordinate_table";
+static const auto logger_ = scwx::util::Logger::Create(logPrefix_);
+
+static constexpr uint32_t kNumRadialGates0_5Degree_ =
+   common::MAX_0_5_DEGREE_RADIALS * common::MAX_DATA_MOMENT_GATES;
+static constexpr uint32_t kNumRadialGates1Degree_ =
+   common::MAX_1_DEGREE_RADIALS * common::MAX_DATA_MOMENT_GATES;
+static constexpr uint32_t kNumCoordinates0_5Degree_ =
+   kNumRadialGates0_5Degree_ * 2;
+static constexpr uint32_t kNumCoordinates1Degree_ = kNumRadialGates1Degree_ * 2;
+static constexpr uint32_t kNumRadials0_5Degree_ =
+   common::MAX_0_5_DEGREE_RADIALS;
+static constexpr uint32_t kNumRadials1Degree_ = common::MAX_1_DEGREE_RADIALS;
+
+static constexpr float kRadialStepDegrees0_5_ {0.5F};
+static constexpr float kSmoothingRadialOffsetDegrees0_5_ {0.25F};
+static constexpr float kSmoothingRadialOffsetDegrees1_0_ {0.5F};
+static constexpr float kSmoothingGateRangeOffset_ {0.5F};
+static constexpr float kNoSmoothingGateRangeOffset_ {1.0F};
+
+static constexpr std::size_t kTimerPlaces_ {6u};
+
+} // namespace
+
+RadarCoordinateTable::RadarCoordinateTable(double latitude,
+                                           double longitude,
+                                           float  gateSize) :
+    latitude_ {latitude}, longitude_ {longitude}, gateSize_ {gateSize}
+{
+}
+
+const std::vector<float>&
+RadarCoordinateTable::coordinates(common::RadialSize radialSize,
+                                  bool               smoothingEnabled)
+{
+   EnsureCoordinatesInitialized(radialSize, smoothingEnabled);
+
+   switch (radialSize)
+   {
+   case common::RadialSize::_0_5Degree:
+      if (smoothingEnabled)
+      {
+         return coordinates0_5DegreeSmooth_;
+      }
+      return coordinates0_5Degree_;
+
+   case common::RadialSize::_1Degree:
+      if (smoothingEnabled)
+      {
+         return coordinates1DegreeSmooth_;
+      }
+      return coordinates1Degree_;
+
+   default:
+      throw std::invalid_argument("Invalid radial size");
+   }
+}
+
+void RadarCoordinateTable::CalculateCoordinates(
+   uint32_t                     radialCount,
+   units::angle::degrees<float> radialAngle,
+   units::angle::degrees<float> angleOffset,
+   float                        gateRangeOffset,
+   std::vector<float>&          outputCoordinates)
+{
+   const GeographicLib::Geodesic& geodesic(
+      util::GeographicLib::DefaultGeodesic());
+
+   const auto   radials = boost::irange<uint32_t>(0, radialCount);
+   const double radarLatitude {latitude_};
+   const double radarLongitude {longitude_};
+   const float  radialStep {radialAngle.value()};
+   const float  radialOffset {angleOffset.value()};
+
+   std::for_each(
+      std::execution::par_unseq,
+      radials.begin(),
+      radials.end(),
+      [&](uint32_t radial)
+      {
+         const float angle =
+            static_cast<float>(radial) * radialStep + radialOffset;
+         const auto geodesicLine =
+            geodesic.Line(radarLatitude, radarLongitude, angle);
+         const std::size_t baseOffset =
+            static_cast<std::size_t>(radial) *
+            static_cast<std::size_t>(common::MAX_DATA_MOMENT_GATES) * 2;
+
+         for (uint32_t gate = 0; gate < common::MAX_DATA_MOMENT_GATES; ++gate)
+         {
+            const float range =
+               (static_cast<float>(gate) + gateRangeOffset) * gateSize_;
+            const std::size_t offset =
+               baseOffset + static_cast<std::size_t>(gate) * 2;
+
+            double latitude  = 0.0;
+            double longitude = 0.0;
+
+            geodesicLine.Position(range, latitude, longitude);
+
+            outputCoordinates[offset]     = static_cast<float>(latitude);
+            outputCoordinates[offset + 1] = static_cast<float>(longitude);
+         }
+      });
+}
+
+void RadarCoordinateTable::EnsureCoordinatesInitialized(
+   common::RadialSize radialSize, bool smoothingEnabled)
+{
+   std::vector<float>*                         targetCoordinates = nullptr;
+   uint32_t                                    coordinateCount   = 0;
+   uint32_t                                    radialCount       = 0;
+   std::optional<units::angle::degrees<float>> radialAngle {};
+   std::optional<units::angle::degrees<float>> angleOffset {};
+   float                                       gateRangeOffset = 0.0f;
+   const char*                                 timerName       = nullptr;
+
+   switch (radialSize)
+   {
+   case common::RadialSize::_0_5Degree:
+      targetCoordinates = smoothingEnabled ? &coordinates0_5DegreeSmooth_ :
+                                             &coordinates0_5Degree_;
+      coordinateCount   = kNumCoordinates0_5Degree_;
+      radialCount       = kNumRadials0_5Degree_;
+      radialAngle       = units::angle::degrees<float> {kRadialStepDegrees0_5_};
+      angleOffset       = units::angle::degrees<float> {
+         smoothingEnabled ? kSmoothingRadialOffsetDegrees0_5_ : 0.0F};
+      gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
+                                           kNoSmoothingGateRangeOffset_;
+      timerName       = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
+                                           "Coordinates (0.5 degree)";
+      break;
+
+   case common::RadialSize::_1Degree:
+      targetCoordinates =
+         smoothingEnabled ? &coordinates1DegreeSmooth_ : &coordinates1Degree_;
+      coordinateCount = kNumCoordinates1Degree_;
+      radialCount     = kNumRadials1Degree_;
+      radialAngle     = units::angle::degrees<float> {1.0f};
+      angleOffset     = units::angle::degrees<float> {
+         smoothingEnabled ? kSmoothingRadialOffsetDegrees1_0_ : 0.0F};
+      gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
+                                           kNoSmoothingGateRangeOffset_;
+      timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
+                                           "Coordinates (1 degree)";
+      break;
+
+   default:
+      return;
+   }
+
+   std::unique_lock<std::mutex> const lock {coordinatesMutex_};
+   if (targetCoordinates == nullptr || !targetCoordinates->empty())
+   {
+      return;
+   }
+
+   if (!radialAngle.has_value() || !angleOffset.has_value())
+   {
+      return;
+   }
+
+   targetCoordinates->resize(coordinateCount);
+
+   boost::timer::cpu_timer timer {};
+   timer.start();
+   CalculateCoordinates(radialCount,
+                        radialAngle.value(),
+                        angleOffset.value(),
+                        gateRangeOffset,
+                        *targetCoordinates);
+   timer.stop();
+   logger_->debug(
+      "{} calculated in {}", timerName, timer.format(kTimerPlaces_, "%ws"));
+}
+
+} // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.cpp
@@ -1,8 +1,10 @@
 #include <scwx/qt/manager/radar_coordinate_table.hpp>
 #include <scwx/qt/util/geographic_lib.hpp>
+#include <scwx/common/constants.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <execution>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -11,6 +13,7 @@
 #include <boost/timer/timer.hpp>
 #include <GeographicLib/Geodesic.hpp>
 #include <GeographicLib/GeodesicLine.hpp>
+#include <units/angle.h>
 
 namespace scwx::qt::manager
 {
@@ -43,156 +46,185 @@ static constexpr std::size_t kTimerPlaces_ {6u};
 
 } // namespace
 
+class RadarCoordinateTable::Impl
+{
+public:
+   Impl(double latitude, double longitude, float gateSize) :
+       latitude_ {latitude}, longitude_ {longitude}, gateSize_ {gateSize}
+   {
+   }
+
+   const std::vector<float>& coordinates(common::RadialSize radialSize,
+                                         bool               smoothingEnabled)
+   {
+      EnsureCoordinatesInitialized(radialSize, smoothingEnabled);
+
+      switch (radialSize)
+      {
+      case common::RadialSize::_0_5Degree:
+         if (smoothingEnabled)
+         {
+            return coordinates0_5DegreeSmooth_;
+         }
+         return coordinates0_5Degree_;
+
+      case common::RadialSize::_1Degree:
+         if (smoothingEnabled)
+         {
+            return coordinates1DegreeSmooth_;
+         }
+         return coordinates1Degree_;
+
+      default:
+         throw std::invalid_argument("Invalid radial size");
+      }
+   }
+
+private:
+   void CalculateCoordinates(uint32_t                     radialCount,
+                             units::angle::degrees<float> radialAngle,
+                             units::angle::degrees<float> angleOffset,
+                             float                        gateRangeOffset,
+                             std::vector<float>&          outputCoordinates)
+   {
+      const GeographicLib::Geodesic& geodesic(
+         util::GeographicLib::DefaultGeodesic());
+
+      const auto   radials = boost::irange<uint32_t>(0, radialCount);
+      const double radarLatitude {latitude_};
+      const double radarLongitude {longitude_};
+      const float  radialStep {radialAngle.value()};
+      const float  radialOffset {angleOffset.value()};
+
+      std::for_each(
+         std::execution::par_unseq,
+         radials.begin(),
+         radials.end(),
+         [&](uint32_t radial)
+         {
+            const float angle =
+               static_cast<float>(radial) * radialStep + radialOffset;
+            const auto geodesicLine =
+               geodesic.Line(radarLatitude, radarLongitude, angle);
+            const std::size_t baseOffset =
+               static_cast<std::size_t>(radial) *
+               static_cast<std::size_t>(common::MAX_DATA_MOMENT_GATES) * 2;
+
+            for (uint32_t gate = 0; gate < common::MAX_DATA_MOMENT_GATES;
+                 ++gate)
+            {
+               const float range =
+                  (static_cast<float>(gate) + gateRangeOffset) * gateSize_;
+               const std::size_t offset =
+                  baseOffset + static_cast<std::size_t>(gate) * 2;
+
+               double latitude  = 0.0;
+               double longitude = 0.0;
+
+               geodesicLine.Position(range, latitude, longitude);
+
+               outputCoordinates[offset]     = static_cast<float>(latitude);
+               outputCoordinates[offset + 1] = static_cast<float>(longitude);
+            }
+         });
+   }
+
+   void EnsureCoordinatesInitialized(common::RadialSize radialSize,
+                                     bool               smoothingEnabled)
+   {
+      std::vector<float>*                         targetCoordinates = nullptr;
+      uint32_t                                    coordinateCount   = 0;
+      uint32_t                                    radialCount       = 0;
+      std::optional<units::angle::degrees<float>> radialAngle {};
+      std::optional<units::angle::degrees<float>> angleOffset {};
+      float                                       gateRangeOffset = 0.0f;
+      const char*                                 timerName       = nullptr;
+
+      switch (radialSize)
+      {
+      case common::RadialSize::_0_5Degree:
+         targetCoordinates = smoothingEnabled ? &coordinates0_5DegreeSmooth_ :
+                                                &coordinates0_5Degree_;
+         coordinateCount   = kNumCoordinates0_5Degree_;
+         radialCount       = kNumRadials0_5Degree_;
+         radialAngle = units::angle::degrees<float> {kRadialStepDegrees0_5_};
+         angleOffset = units::angle::degrees<float> {
+            smoothingEnabled ? kSmoothingRadialOffsetDegrees0_5_ : 0.0F};
+         gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
+                                              kNoSmoothingGateRangeOffset_;
+         timerName = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
+                                        "Coordinates (0.5 degree)";
+         break;
+
+      case common::RadialSize::_1Degree:
+         targetCoordinates = smoothingEnabled ? &coordinates1DegreeSmooth_ :
+                                                &coordinates1Degree_;
+         coordinateCount   = kNumCoordinates1Degree_;
+         radialCount       = kNumRadials1Degree_;
+         radialAngle       = units::angle::degrees<float> {1.0f};
+         angleOffset       = units::angle::degrees<float> {
+            smoothingEnabled ? kSmoothingRadialOffsetDegrees1_0_ : 0.0F};
+         gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
+                                              kNoSmoothingGateRangeOffset_;
+         timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
+                                              "Coordinates (1 degree)";
+         break;
+
+      default:
+         return;
+      }
+
+      std::unique_lock<std::mutex> const lock {coordinatesMutex_};
+      if (targetCoordinates == nullptr || !targetCoordinates->empty())
+      {
+         return;
+      }
+
+      if (!radialAngle.has_value() || !angleOffset.has_value())
+      {
+         return;
+      }
+
+      targetCoordinates->resize(coordinateCount);
+
+      boost::timer::cpu_timer timer {};
+      timer.start();
+      CalculateCoordinates(radialCount,
+                           radialAngle.value(),
+                           angleOffset.value(),
+                           gateRangeOffset,
+                           *targetCoordinates);
+      timer.stop();
+      logger_->debug(
+         "{} calculated in {}", timerName, timer.format(kTimerPlaces_, "%ws"));
+   }
+
+   double latitude_;
+   double longitude_;
+   float  gateSize_;
+
+   std::vector<float> coordinates0_5Degree_ {};
+   std::vector<float> coordinates0_5DegreeSmooth_ {};
+   std::vector<float> coordinates1Degree_ {};
+   std::vector<float> coordinates1DegreeSmooth_ {};
+
+   std::mutex coordinatesMutex_ {};
+};
+
 RadarCoordinateTable::RadarCoordinateTable(double latitude,
                                            double longitude,
                                            float  gateSize) :
-    latitude_ {latitude}, longitude_ {longitude}, gateSize_ {gateSize}
+    p(std::make_unique<Impl>(latitude, longitude, gateSize))
 {
 }
+
+RadarCoordinateTable::~RadarCoordinateTable() = default;
 
 const std::vector<float>&
 RadarCoordinateTable::coordinates(common::RadialSize radialSize,
                                   bool               smoothingEnabled)
 {
-   EnsureCoordinatesInitialized(radialSize, smoothingEnabled);
-
-   switch (radialSize)
-   {
-   case common::RadialSize::_0_5Degree:
-      if (smoothingEnabled)
-      {
-         return coordinates0_5DegreeSmooth_;
-      }
-      return coordinates0_5Degree_;
-
-   case common::RadialSize::_1Degree:
-      if (smoothingEnabled)
-      {
-         return coordinates1DegreeSmooth_;
-      }
-      return coordinates1Degree_;
-
-   default:
-      throw std::invalid_argument("Invalid radial size");
-   }
-}
-
-void RadarCoordinateTable::CalculateCoordinates(
-   uint32_t                     radialCount,
-   units::angle::degrees<float> radialAngle,
-   units::angle::degrees<float> angleOffset,
-   float                        gateRangeOffset,
-   std::vector<float>&          outputCoordinates)
-{
-   const GeographicLib::Geodesic& geodesic(
-      util::GeographicLib::DefaultGeodesic());
-
-   const auto   radials = boost::irange<uint32_t>(0, radialCount);
-   const double radarLatitude {latitude_};
-   const double radarLongitude {longitude_};
-   const float  radialStep {radialAngle.value()};
-   const float  radialOffset {angleOffset.value()};
-
-   std::for_each(
-      std::execution::par_unseq,
-      radials.begin(),
-      radials.end(),
-      [&](uint32_t radial)
-      {
-         const float angle =
-            static_cast<float>(radial) * radialStep + radialOffset;
-         const auto geodesicLine =
-            geodesic.Line(radarLatitude, radarLongitude, angle);
-         const std::size_t baseOffset =
-            static_cast<std::size_t>(radial) *
-            static_cast<std::size_t>(common::MAX_DATA_MOMENT_GATES) * 2;
-
-         for (uint32_t gate = 0; gate < common::MAX_DATA_MOMENT_GATES; ++gate)
-         {
-            const float range =
-               (static_cast<float>(gate) + gateRangeOffset) * gateSize_;
-            const std::size_t offset =
-               baseOffset + static_cast<std::size_t>(gate) * 2;
-
-            double latitude  = 0.0;
-            double longitude = 0.0;
-
-            geodesicLine.Position(range, latitude, longitude);
-
-            outputCoordinates[offset]     = static_cast<float>(latitude);
-            outputCoordinates[offset + 1] = static_cast<float>(longitude);
-         }
-      });
-}
-
-void RadarCoordinateTable::EnsureCoordinatesInitialized(
-   common::RadialSize radialSize, bool smoothingEnabled)
-{
-   std::vector<float>*                         targetCoordinates = nullptr;
-   uint32_t                                    coordinateCount   = 0;
-   uint32_t                                    radialCount       = 0;
-   std::optional<units::angle::degrees<float>> radialAngle {};
-   std::optional<units::angle::degrees<float>> angleOffset {};
-   float                                       gateRangeOffset = 0.0f;
-   const char*                                 timerName       = nullptr;
-
-   switch (radialSize)
-   {
-   case common::RadialSize::_0_5Degree:
-      targetCoordinates = smoothingEnabled ? &coordinates0_5DegreeSmooth_ :
-                                             &coordinates0_5Degree_;
-      coordinateCount   = kNumCoordinates0_5Degree_;
-      radialCount       = kNumRadials0_5Degree_;
-      radialAngle       = units::angle::degrees<float> {kRadialStepDegrees0_5_};
-      angleOffset       = units::angle::degrees<float> {
-         smoothingEnabled ? kSmoothingRadialOffsetDegrees0_5_ : 0.0F};
-      gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
-                                           kNoSmoothingGateRangeOffset_;
-      timerName       = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
-                                           "Coordinates (0.5 degree)";
-      break;
-
-   case common::RadialSize::_1Degree:
-      targetCoordinates =
-         smoothingEnabled ? &coordinates1DegreeSmooth_ : &coordinates1Degree_;
-      coordinateCount = kNumCoordinates1Degree_;
-      radialCount     = kNumRadials1Degree_;
-      radialAngle     = units::angle::degrees<float> {1.0f};
-      angleOffset     = units::angle::degrees<float> {
-         smoothingEnabled ? kSmoothingRadialOffsetDegrees1_0_ : 0.0F};
-      gateRangeOffset = smoothingEnabled ? kSmoothingGateRangeOffset_ :
-                                           kNoSmoothingGateRangeOffset_;
-      timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
-                                           "Coordinates (1 degree)";
-      break;
-
-   default:
-      return;
-   }
-
-   std::unique_lock<std::mutex> const lock {coordinatesMutex_};
-   if (targetCoordinates == nullptr || !targetCoordinates->empty())
-   {
-      return;
-   }
-
-   if (!radialAngle.has_value() || !angleOffset.has_value())
-   {
-      return;
-   }
-
-   targetCoordinates->resize(coordinateCount);
-
-   boost::timer::cpu_timer timer {};
-   timer.start();
-   CalculateCoordinates(radialCount,
-                        radialAngle.value(),
-                        angleOffset.value(),
-                        gateRangeOffset,
-                        *targetCoordinates);
-   timer.stop();
-   logger_->debug(
-      "{} calculated in {}", timerName, timer.format(kTimerPlaces_, "%ws"));
+   return p->coordinates(radialSize, smoothingEnabled);
 }
 
 } // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.hpp
@@ -1,14 +1,9 @@
 #pragma once
 
-#include <scwx/common/constants.hpp>
-#include <scwx/common/products.hpp>
 #include <scwx/common/types.hpp>
 
-#include <cstdint>
-#include <mutex>
+#include <memory>
 #include <vector>
-
-#include <units/angle.h>
 
 namespace scwx::qt::manager
 {
@@ -17,30 +12,19 @@ class RadarCoordinateTable
 {
 public:
    RadarCoordinateTable(double latitude, double longitude, float gateSize);
+   ~RadarCoordinateTable();
+
+   RadarCoordinateTable(const RadarCoordinateTable&)            = delete;
+   RadarCoordinateTable& operator=(const RadarCoordinateTable&) = delete;
+   RadarCoordinateTable(RadarCoordinateTable&&)                 = delete;
+   RadarCoordinateTable& operator=(RadarCoordinateTable&&)      = delete;
 
    [[nodiscard]] const std::vector<float>&
    coordinates(common::RadialSize radialSize, bool smoothingEnabled);
 
 private:
-   void CalculateCoordinates(uint32_t                     radialCount,
-                             units::angle::degrees<float> radialAngle,
-                             units::angle::degrees<float> angleOffset,
-                             float                        gateRangeOffset,
-                             std::vector<float>&          outputCoordinates);
-
-   void EnsureCoordinatesInitialized(common::RadialSize radialSize,
-                                     bool               smoothingEnabled);
-
-   double latitude_;
-   double longitude_;
-   float  gateSize_;
-
-   std::vector<float> coordinates0_5Degree_ {};
-   std::vector<float> coordinates0_5DegreeSmooth_ {};
-   std::vector<float> coordinates1Degree_ {};
-   std::vector<float> coordinates1DegreeSmooth_ {};
-
-   std::mutex coordinatesMutex_ {};
+   class Impl;
+   std::unique_ptr<Impl> p;
 };
 
 } // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_coordinate_table.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <scwx/common/constants.hpp>
+#include <scwx/common/products.hpp>
+#include <scwx/common/types.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include <units/angle.h>
+
+namespace scwx::qt::manager
+{
+
+class RadarCoordinateTable
+{
+public:
+   RadarCoordinateTable(double latitude, double longitude, float gateSize);
+
+   [[nodiscard]] const std::vector<float>&
+   coordinates(common::RadialSize radialSize, bool smoothingEnabled);
+
+private:
+   void CalculateCoordinates(uint32_t                     radialCount,
+                             units::angle::degrees<float> radialAngle,
+                             units::angle::degrees<float> angleOffset,
+                             float                        gateRangeOffset,
+                             std::vector<float>&          outputCoordinates);
+
+   void EnsureCoordinatesInitialized(common::RadialSize radialSize,
+                                     bool               smoothingEnabled);
+
+   double latitude_;
+   double longitude_;
+   float  gateSize_;
+
+   std::vector<float> coordinates0_5Degree_ {};
+   std::vector<float> coordinates0_5DegreeSmooth_ {};
+   std::vector<float> coordinates1Degree_ {};
+   std::vector<float> coordinates1DegreeSmooth_ {};
+
+   std::mutex coordinatesMutex_ {};
+};
+
+} // namespace scwx::qt::manager

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -164,6 +164,9 @@ public:
                level2ProviderManager_->provider_));
       }
 
+      // Match RadarProductManager::gate_size(); cannot call self_->gate_size()
+      // here because RadarProductManager::p is not constructed yet.
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       const float gateSize = (radarSite_->type() == "tdwr") ? 150.0f : 250.0f;
       coordinateTable_.emplace(
          radarSite_->latitude(), radarSite_->longitude(), gateSize);
@@ -416,7 +419,7 @@ const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
-   return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
+   return p->coordinateTable_.value().coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const
 {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -421,11 +421,6 @@ const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
-   if (p->coordinateTable_ == nullptr)
-   {
-      throw std::logic_error("Coordinate table not initialized");
-   }
-
    return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -425,7 +425,7 @@ RadarProductManager::coordinates(common::RadialSize radialSize,
       throw std::logic_error("Coordinate table not initialized");
    }
 
-   return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
+   return p->coordinateTable_.value().coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const
 {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -1,8 +1,8 @@
+#include <scwx/qt/manager/radar_coordinate_table.hpp>
 #include <scwx/qt/manager/radar_product_manager.hpp>
 #include <scwx/qt/manager/radar_product_manager_notifier.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/types/time_types.hpp>
-#include <scwx/qt/util/geographic_lib.hpp>
 #include <scwx/common/constants.hpp>
 #include <scwx/provider/aws_level2_chunks_data_provider.hpp>
 #include <scwx/provider/nexrad_data_provider_factory.hpp>
@@ -28,12 +28,7 @@
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/container_hash/hash.hpp>
-#include <boost/range/irange.hpp>
-#include <boost/timer/timer.hpp>
 #include <fmt/chrono.h>
-#include <GeographicLib/GeodesicLine.hpp>
-#include <qmaplibre.hpp>
-#include <units/angle.h>
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)
@@ -54,29 +49,7 @@ typedef std::map<std::chrono::system_clock::time_point,
 typedef std::list<std::shared_ptr<types::RadarProductRecord>>
    RadarProductRecordList;
 
-static constexpr uint32_t NUM_RADIAL_GATES_0_5_DEGREE =
-   common::MAX_0_5_DEGREE_RADIALS * common::MAX_DATA_MOMENT_GATES;
-static constexpr uint32_t NUM_RADIAL_GATES_1_DEGREE =
-   common::MAX_1_DEGREE_RADIALS * common::MAX_DATA_MOMENT_GATES;
-static constexpr uint32_t NUM_COORIDNATES_0_5_DEGREE =
-   NUM_RADIAL_GATES_0_5_DEGREE * 2;
-static constexpr uint32_t NUM_COORIDNATES_1_DEGREE =
-   NUM_RADIAL_GATES_1_DEGREE * 2;
-static constexpr uint32_t NUM_RADIALS_0_5_DEGREE =
-   common::MAX_0_5_DEGREE_RADIALS;
-static constexpr uint32_t NUM_RADIALS_1_DEGREE = common::MAX_1_DEGREE_RADIALS;
-
-// Coordinate grid tuning: radial step (deg), extra azimuth when smoothing is
-// on, and first-gate fractional offset into slant range (matches prior layout).
-static constexpr float kCoordinateRadialStepDegrees0_5_ {0.5F};
-static constexpr float kCoordinateSmoothingRadialOffsetDegrees0_5_ {0.25F};
-static constexpr float kCoordinateSmoothingRadialOffsetDegrees1_0_ {0.5F};
-static constexpr float kCoordinateSmoothingGateRangeOffset_ {0.5F};
-static constexpr float kCoordinateNoSmoothingGateRangeOffset_ {1.0F};
-
 static const std::string kDefaultLevel3Product_ {"N0B"};
-
-static constexpr std::size_t kTimerPlaces_ {6u};
 
 static constexpr std::chrono::seconds kFastRetryInterval_ {15};
 static constexpr std::chrono::seconds kFastRetryIntervalChunks_ {3};
@@ -190,6 +163,10 @@ public:
             std::dynamic_pointer_cast<provider::AwsLevel2DataProvider>(
                level2ProviderManager_->provider_));
       }
+
+      const float gateSize = (radarSite_->type() == "tdwr") ? 150.0f : 250.0f;
+      coordinateTable_.emplace(
+         radarSite_->latitude(), radarSite_->longitude(), gateSize);
    }
    ~RadarProductManagerImpl()
    {
@@ -266,14 +243,6 @@ public:
 
    void UpdateAvailableProductsSync();
 
-   void CalculateCoordinates(uint32_t                           radialCount,
-                             const units::angle::degrees<float> radialAngle,
-                             const units::angle::degrees<float> angleOffset,
-                             float                              gateRangeOffset,
-                             std::vector<float>& outputCoordinates);
-   void EnsureCoordinatesInitialized(common::RadialSize radialSize,
-                                     bool               smoothingEnabled);
-
    static bool AreProductTimesPopulated(
       const std::shared_ptr<ProviderManager>& providerManager,
       std::chrono::system_clock::time_point   time);
@@ -299,13 +268,7 @@ public:
    std::shared_ptr<config::RadarSite> radarSite_;
    std::size_t                        cacheLimit_ {6u};
 
-   // Lat/lon per radial/gate. Filled on first coordinates() for each table, not
-   // in Initialize(). coordinatesMutex_ serializes checks and builds so callers
-   // never observe a partially filled table.
-   std::vector<float> coordinates0_5Degree_ {};
-   std::vector<float> coordinates0_5DegreeSmooth_ {};
-   std::vector<float> coordinates1Degree_ {};
-   std::vector<float> coordinates1DegreeSmooth_ {};
+   std::optional<RadarCoordinateTable> coordinateTable_ {};
 
    RadarProductRecordMap  level2ProductRecords_ {};
    RadarProductRecordList level2ProductRecentRecords_ {};
@@ -323,7 +286,6 @@ public:
    std::shared_mutex level3ProviderManagerMutex_ {};
 
    std::mutex initializeMutex_ {};
-   std::mutex coordinatesMutex_ {};
    std::mutex level3ProductsInitializeMutex_ {};
    std::mutex loadLevel2DataMutex_ {};
    std::mutex loadLevel3DataMutex_ {};
@@ -449,36 +411,12 @@ void RadarProductManager::DumpRecords()
 }
 
 // Cached lat/lon grid; first use for a (radialSize, smoothing) pair may block
-// on EnsureCoordinatesInitialized.
+// on lazy initialization inside RadarCoordinateTable.
 const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
-   p->EnsureCoordinatesInitialized(radialSize, smoothingEnabled);
-
-   switch (radialSize)
-   {
-   case common::RadialSize::_0_5Degree:
-      if (smoothingEnabled)
-      {
-         return p->coordinates0_5DegreeSmooth_;
-      }
-      else
-      {
-         return p->coordinates0_5Degree_;
-      }
-   case common::RadialSize::_1Degree:
-      if (smoothingEnabled)
-      {
-         return p->coordinates1DegreeSmooth_;
-      }
-      else
-      {
-         return p->coordinates1Degree_;
-      }
-   default:
-      throw std::invalid_argument("Invalid radial size");
-   }
+   return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const
 {
@@ -557,136 +495,6 @@ void RadarProductManager::Initialize()
    }
 
    p->initialized_ = true;
-}
-
-// One GeodesicLine per radial (Position per gate). Parallelism is over radials.
-void RadarProductManagerImpl::CalculateCoordinates(
-   uint32_t                           radialCount,
-   const units::angle::degrees<float> radialAngle,
-   const units::angle::degrees<float> angleOffset,
-   float                              gateRangeOffset,
-   std::vector<float>&                outputCoordinates)
-{
-   const GeographicLib::Geodesic& geodesic(
-      util::GeographicLib::DefaultGeodesic());
-
-   const QMapLibre::Coordinate radar(radarSite_->latitude(),
-                                     radarSite_->longitude());
-
-   const float gateSize = self_->gate_size();
-
-   const auto   radials = boost::irange<uint32_t>(0, radialCount);
-   const double radarLatitude {radar.first};
-   const double radarLongitude {radar.second};
-   const float  radialStep {radialAngle.value()};
-   const float  radialOffset {angleOffset.value()};
-
-   std::for_each(
-      std::execution::par_unseq,
-      radials.begin(),
-      radials.end(),
-      [&](uint32_t radial)
-      {
-         const float angle =
-            static_cast<float>(radial) * radialStep + radialOffset;
-         const auto geodesicLine =
-            geodesic.Line(radarLatitude, radarLongitude, angle);
-         const std::size_t baseOffset =
-            static_cast<std::size_t>(radial) *
-            static_cast<std::size_t>(common::MAX_DATA_MOMENT_GATES) * 2;
-
-         for (uint32_t gate = 0; gate < common::MAX_DATA_MOMENT_GATES; ++gate)
-         {
-            const float range =
-               (static_cast<float>(gate) + gateRangeOffset) * gateSize;
-            const std::size_t offset =
-               baseOffset + static_cast<std::size_t>(gate) * 2;
-
-            double latitude  = 0.0;
-            double longitude = 0.0;
-
-            geodesicLine.Position(range, latitude, longitude);
-
-            outputCoordinates[offset]     = static_cast<float>(latitude);
-            outputCoordinates[offset + 1] = static_cast<float>(longitude);
-         }
-      });
-}
-
-// One-time table fill under coordinatesMutex_. All readiness checks and writes
-// stay under the same lock so no thread sees non-empty after resize() before
-// CalculateCoordinates() finishes (avoids data races on empty()/size()).
-void RadarProductManagerImpl::EnsureCoordinatesInitialized(
-   common::RadialSize radialSize, bool smoothingEnabled)
-{
-   std::vector<float>*                         targetCoordinates = nullptr;
-   uint32_t                                    coordinateCount   = 0;
-   uint32_t                                    radialCount       = 0;
-   std::optional<units::angle::degrees<float>> radialAngle {};
-   std::optional<units::angle::degrees<float>> angleOffset {};
-   float                                       gateRangeOffset = 0.0f;
-   const char*                                 timerName       = nullptr;
-
-   switch (radialSize)
-   {
-   case common::RadialSize::_0_5Degree:
-      targetCoordinates = smoothingEnabled ? &coordinates0_5DegreeSmooth_ :
-                                             &coordinates0_5Degree_;
-      coordinateCount   = NUM_COORIDNATES_0_5_DEGREE;
-      radialCount       = NUM_RADIALS_0_5_DEGREE;
-      radialAngle =
-         units::angle::degrees<float> {kCoordinateRadialStepDegrees0_5_};
-      angleOffset = units::angle::degrees<float> {
-         smoothingEnabled ? kCoordinateSmoothingRadialOffsetDegrees0_5_ : 0.0F};
-      gateRangeOffset = smoothingEnabled ?
-                           kCoordinateSmoothingGateRangeOffset_ :
-                           kCoordinateNoSmoothingGateRangeOffset_;
-      timerName       = smoothingEnabled ? "Coordinates (0.5 degree smooth)" :
-                                           "Coordinates (0.5 degree)";
-      break;
-   case common::RadialSize::_1Degree:
-      targetCoordinates =
-         smoothingEnabled ? &coordinates1DegreeSmooth_ : &coordinates1Degree_;
-      coordinateCount = NUM_COORIDNATES_1_DEGREE;
-      radialCount     = NUM_RADIALS_1_DEGREE;
-      radialAngle     = units::angle::degrees<float> {1.0f};
-      angleOffset     = units::angle::degrees<float> {
-         smoothingEnabled ? kCoordinateSmoothingRadialOffsetDegrees1_0_ : 0.0F};
-      gateRangeOffset = smoothingEnabled ?
-                           kCoordinateSmoothingGateRangeOffset_ :
-                           kCoordinateNoSmoothingGateRangeOffset_;
-      timerName       = smoothingEnabled ? "Coordinates (1 degree smooth)" :
-                                           "Coordinates (1 degree)";
-      break;
-   default:
-      return;
-   }
-
-   std::unique_lock<std::mutex> const lock {coordinatesMutex_};
-   if (targetCoordinates == nullptr || !targetCoordinates->empty())
-   {
-      return;
-   }
-
-   // Switch arms above always set these; keeps static analysis safe if enum
-   // grows.
-   if (!radialAngle.has_value() || !angleOffset.has_value())
-   {
-      return;
-   }
-
-   targetCoordinates->resize(coordinateCount);
-
-   boost::timer::cpu_timer timer {};
-   timer.start();
-   CalculateCoordinates(radialCount,
-                        radialAngle.value(),
-                        angleOffset.value(),
-                        gateRangeOffset,
-                        *targetCoordinates);
-   timer.stop();
-   logger_->debug(
-      "{} calculated in {}", timerName, timer.format(kTimerPlaces_, "%ws"));
 }
 
 std::shared_ptr<ProviderManager>

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -13,6 +13,7 @@
 #include <scwx/wsr88d/nexrad_file_factory.hpp>
 
 #include <execution>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -169,7 +170,7 @@ public:
       // here because RadarProductManager::p is not constructed yet.
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       const float gateSize = (radarSite_->type() == "tdwr") ? 150.0f : 250.0f;
-      coordinateTable_.emplace(
+      coordinateTable_     = std::make_unique<RadarCoordinateTable>(
          radarSite_->latitude(), radarSite_->longitude(), gateSize);
    }
    ~RadarProductManagerImpl()
@@ -272,7 +273,7 @@ public:
    std::shared_ptr<config::RadarSite> radarSite_;
    std::size_t                        cacheLimit_ {6u};
 
-   std::optional<RadarCoordinateTable> coordinateTable_ {};
+   std::unique_ptr<RadarCoordinateTable> coordinateTable_ {};
 
    RadarProductRecordMap  level2ProductRecords_ {};
    RadarProductRecordList level2ProductRecentRecords_ {};
@@ -420,12 +421,12 @@ const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
-   if (!p->coordinateTable_.has_value())
+   if (p->coordinateTable_ == nullptr)
    {
       throw std::logic_error("Coordinate table not initialized");
    }
 
-   return p->coordinateTable_.value().coordinates(radialSize, smoothingEnabled);
+   return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const
 {

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -419,7 +420,12 @@ const std::vector<float>&
 RadarProductManager::coordinates(common::RadialSize radialSize,
                                  bool               smoothingEnabled) const
 {
-   return p->coordinateTable_.value().coordinates(radialSize, smoothingEnabled);
+   if (!p->coordinateTable_.has_value())
+   {
+      throw std::logic_error("Coordinate table not initialized");
+   }
+
+   return p->coordinateTable_->coordinates(radialSize, smoothingEnabled);
 }
 const scwx::util::time_zone* RadarProductManager::default_time_zone() const
 {


### PR DESCRIPTION
Move lazy lat/lon grid precompute into a dedicated class. No behavior change; existing coordinate geodesic test still passes.