### PR TITLE
Use frameless window for popped-out Draw panel.

### DIFF
--- a/scwx-qt/source/scwx/qt/ui/map_annotation_dock_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/map_annotation_dock_widget.cpp
@@ -855,8 +855,7 @@ public:
          const QWidget* const previousParent = self_->parentWidget();
          self_->hide();
          self_->setParent(ownerWindow,
-                          Qt::Tool | Qt::CustomizeWindowHint |
-                             Qt::WindowTitleHint);
+                          Qt::Tool | Qt::FramelessWindowHint);
          floating_ = true;
          expanded_ = true;
          QPoint floatPos;

--- a/scwx-qt/source/scwx/qt/ui/map_annotation_dock_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/map_annotation_dock_widget.cpp
@@ -854,8 +854,7 @@ public:
             hostIsInStableWindow ? stableParent->window() : nullptr;
          const QWidget* const previousParent = self_->parentWidget();
          self_->hide();
-         self_->setParent(ownerWindow,
-                          Qt::Tool | Qt::FramelessWindowHint);
+         self_->setParent(ownerWindow, Qt::Tool | Qt::FramelessWindowHint);
          floating_ = true;
          expanded_ = true;
          QPoint floatPos;


### PR DESCRIPTION
Remove the native Supercell Wx title bar so floating drag position stays in sync with floatingPosition when users move the panel.