### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,3 +196,15 @@ See [.github/workflows/ci.yml](.github/workflows/ci.yml) for complete build matr
 ## Resources
 - **Documentation:** https://supercell-wx.readthedocs.io/
 - **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Cursor Cloud specific instructions
+
+The Linux dev environment (Ubuntu 24.04) is pre-provisioned in the VM snapshot and refreshed on startup by the update script (`git submodule update --init --recursive` + `./tools/setup-linux-ninja-release.sh`). The setup script (re)creates the `.venv`, installs Python deps, runs Conan, and configures CMake into `build-release/`. Notes that are not obvious:
+
+- **Compiler gotcha:** The base image's default `cc`/`c++` alternatives point at Clang, and Clang fails the project's compiler check with `cannot find -lstdc++`. The project builds with GCC 13, so the default alternatives are set to `gcc-13`/`g++-13` (persisted in the snapshot via `update-alternatives`). Don't switch them back to Clang.
+- **Qt:** Qt 6.11.1 lives at `/opt/Qt/6.11.1/gcc_64` (installed via `aqt`, persisted in snapshot). The setup script already points CMake at it.
+- **Build:** `source .venv/bin/activate`, then `cmake --build build-release --target supercell-wx wxtest` (or `cd build-release && ninja supercell-wx wxtest`). Binaries land in `build-release/Release/bin/`. The first full build is long (~1300 targets, includes vendored MapLibre).
+- **Test:** `cd build-release && ctest --output-on-failure --exclude-regex "test_mln.*|NtpClient.*|UpdateManager.*"` (same exclusions as CI; those tests need network and/or a map API key). Running tests writes into the `test/data` submodule (e.g. `json/settings/*.json`) — `git checkout` those before committing.
+- **Running the GUI:** Display `:1` is a TigerVNC desktop (also used by computer-use) with software OpenGL 4.5 (llvmpipe), which is sufficient. Launch with `DISPLAY=:1 build-release/Release/bin/supercell-wx`. Headless test/launch also works via `xvfb-run -a -s "-screen 0 1920x1080x24" ...`.
+- **Map API key:** Without `MAPTILER_API_KEY`/`MAPBOX_API_KEY` the base map renders **black**, but radar data (reflectivity/velocity from AWS NEXRAD) still downloads and renders normally. Set those as secrets only if the base map background is needed (also required for the `test_mln*` map tests). The first-run setup wizard requires a value in the map-key field — any non-empty string lets you proceed.
+- **Network:** Outbound access to AWS S3 (NEXRAD data), NWS, and IEM APIs works from the VM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Supercell Wx development environment for Cursor Cloud agents and documents non-obvious caveats. The only code change is an appended `## Cursor Cloud specific instructions` section in `AGENTS.md`; all other setup (system packages, Qt, Conan cache, Python venv, default compiler) is captured in the VM snapshot and refreshed via the update script.

## What was set up

- **System deps:** `ninja-build`, Wayland/X11 dev libs (incl. `xcb-cursor` and the full `xorg/system` Conan list), `libglu1-mesa-dev`, Mesa/`xvfb` for headless OpenGL, `doxygen`, `libfuse2`, `python3-venv`, `fontconfig`.
- **Compiler:** default `cc`/`c++` alternatives switched from Clang to `gcc-13`/`g++-13` (the project's Conan profile builds with GCC; Clang failed the compiler check with `cannot find -lstdc++`).
- **Qt 6.11.1** installed via `aqt` to `/opt/Qt/6.11.1/gcc_64`.
- **Conan 2** + Python venv (`.venv`) from `requirements.txt`; all C++ deps installed and CMake configured into `build-release/` via `tools/setup-linux-ninja-release.sh`.

## Verification

- Built `supercell-wx` and `wxtest` (GCC 13, Ninja, Release).
- `ctest` (CI exclusions) — **247/247 passed**.
- With `MAPTILER_API_KEY`/`MAPBOX_API_KEY` secrets set, the `MapProviderTest` map tests pass (fetch live styles from MapTiler + Mapbox).
- Launched the GUI on the VNC desktop (software OpenGL/llvmpipe): completed first-run wizard, selected radar sites (KLSX/KTLX/KFWS), confirmed live NEXRAD reflectivity downloads from AWS and renders, and verified the MapTiler base map (satellite/streets) renders with the radar overlay.

[scwx_basemap_with_api_key_demo.mp4](https://cursor.com/agents/bc-25c08fd4-c737-4159-864d-08dcfec51d44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscwx_basemap_with_api_key_demo.mp4)

Base map (MapTiler satellite/streets) with live NEXRAD radar overlay, panning/zooming and map-style switching.

[Satellite base map with radar overlay](https://cursor.com/agents/bc-25c08fd4-c737-4159-864d-08dcfec51d44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscwx_basemap_satellite_radar.webp)
[Streets base map with radar overlay](https://cursor.com/agents/bc-25c08fd4-c737-4159-864d-08dcfec51d44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscwx_basemap_streets.webp)

## Update script

```
git submodule update --init --recursive
./tools/setup-linux-ninja-release.sh
```

Validated as idempotent (~12s on a warm snapshot).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25c08fd4-c737-4159-864d-08dcfec51d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25c08fd4-c737-4159-864d-08dcfec51d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

