### PR TITLE
Level 2 Coordinate Fix

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -36,7 +36,9 @@ jobs:
 
     - name: Check Formatting
       shell: bash
+      env:
+        HEAD_REF: ${{ github.event.pull_request.head.sha || github.ref }}
       run: |
-        MERGE_BASE=$(git merge-base origin/develop ${{ github.event.pull_request.head.sha || github.ref }})
+        MERGE_BASE=$(git merge-base origin/develop "${HEAD_REF}")
         echo "Comparing against ${MERGE_BASE}"
         git clang-format-21 --diff --style=file -v ${MERGE_BASE}

--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -687,10 +687,6 @@ void Level2ProductView::ComputeSweep()
    vertexRadials =
       std::min<std::size_t>(vertexRadials, common::MAX_0_5_DEGREE_RADIALS);
 
-   p->ComputeCoordinates(radarData, smoothingEnabled);
-
-   const std::vector<float>& coordinates = p->coordinates_;
-
    auto& radarData0     = (*radarData)[0];
    auto  momentData0    = radarData0->moment_data_block(p->dataBlockType_);
    p->elevationScan_    = radarData;
@@ -703,6 +699,10 @@ void Level2ProductView::ComputeSweep()
       Q_EMIT SweepNotComputed(types::NoUpdateReason::InvalidData);
       return;
    }
+
+   p->ComputeCoordinates(radarData, smoothingEnabled);
+
+   const std::vector<float>& coordinates = p->coordinates_;
 
    const uint32_t gates = momentData0->number_of_data_moment_gates();
 
@@ -804,7 +804,9 @@ void Level2ProductView::ComputeSweep()
 
       // Compute gate range [startGate, endGate)
       std::int32_t startGate =
-         (dataMomentRange - dataMomentIntervalH) / gateSizeMeters;
+         (gateSizeMeters > 0) ?
+            (dataMomentRange - dataMomentIntervalH) / gateSizeMeters :
+            0;
       const std::int32_t numberOfDataMomentGates =
          std::min<std::int32_t>(momentData->number_of_data_moment_gates(),
                                 static_cast<std::int32_t>(gates));
@@ -1543,7 +1545,9 @@ Level2ProductView::GetBinLevel(const common::Coordinate& coordinate) const
 
    // Compute gate range [startGate, endGate)
    const std::int32_t startGate =
-      (dataMomentRange - dataMomentIntervalH) / gateSizeMeters;
+      (gateSizeMeters > 0) ?
+         (dataMomentRange - dataMomentIntervalH) / gateSizeMeters :
+         0;
    const std::int32_t numberOfDataMomentGates =
       momentData->number_of_data_moment_gates();
 


### PR DESCRIPTION
Fix level 2 compute sweep undefined behavior

- Coordinates should be computed after radar data is validated
- Prevent divide by zero in the event bad data is received

Cleanup Format Check action for previous peer review comment