### PR TITLE
Fix Radar Product View Destruction Crash

### DIFF
--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -201,7 +201,7 @@ Level2ProductView::~Level2ProductView()
    // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
    // would deadlock.
    DisconnectProductSettings();
-   DisconnectRadarProductManager();
+   Level2ProductView::DisconnectRadarProductManager();
 
    p->threadPool_.stop();
    p->threadPool_.join();
@@ -1603,8 +1603,19 @@ Level2ProductView::GetBinLevel(const common::Coordinate& coordinate) const
       return std::nullopt;
    }
 
+   const auto radialData = radarData->find(*radial);
+   if (radialData == radarData->cend() || radialData->second == nullptr)
+   {
+      return std::nullopt;
+   }
+
+   const auto momentData = radialData->second->moment_data_block(dataBlockType);
+   if (momentData == nullptr)
+   {
+      return std::nullopt;
+   }
+
    // Compute gate interval
-   auto momentData = (*radarData)[*radial]->moment_data_block(dataBlockType);
    const std::int32_t dataMomentInterval =
       momentData->data_moment_range_sample_interval_raw();
    const std::int32_t dataMomentIntervalH = dataMomentInterval / 2;
@@ -1703,6 +1714,11 @@ Level2ProductView::GetDataLevelCode(std::uint16_t level) const
 
 std::optional<float> Level2ProductView::GetDataValue(std::uint16_t level) const
 {
+   if (p->momentDataBlock0_ == nullptr)
+   {
+      return std::nullopt;
+   }
+
    const float   offset    = p->momentDataBlock0_->offset();
    const float   scale     = p->momentDataBlock0_->scale();
    std::uint16_t threshold = std::numeric_limits<std::uint16_t>::max();

--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -108,8 +108,6 @@ public:
          otherUnitsCallbackUuid_);
       unitSettings.speed_units().UnregisterValueChangedCallback(
          speedUnitsCallbackUuid_);
-
-      threadPool_.join();
    };
 
    Impl(const Impl&)            = delete;
@@ -199,7 +197,14 @@ Level2ProductView::Level2ProductView(
 
 Level2ProductView::~Level2ProductView()
 {
-   std::unique_lock sweepLock {sweep_mutex()};
+   // Stop callbacks that can post ComputeSweep, then join while Impl is still
+   // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
+   // would deadlock.
+   DisconnectProductSettings();
+   DisconnectRadarProductManager();
+
+   p->threadPool_.stop();
+   p->threadPool_.join();
 }
 
 void Level2ProductView::ConnectRadarProductManager()
@@ -238,6 +243,10 @@ void Level2ProductView::DisconnectRadarProductManager()
 {
    disconnect(radar_product_manager().get(),
               &manager::RadarProductManager::DataReloaded,
+              this,
+              nullptr);
+   disconnect(radar_product_manager().get(),
+              &manager::RadarProductManager::ProductTimesPopulated,
               this,
               nullptr);
 }

--- a/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level2_product_view.cpp
@@ -696,10 +696,19 @@ void Level2ProductView::ComputeSweep()
    vertexRadials =
       std::min<std::size_t>(vertexRadials, common::MAX_0_5_DEGREE_RADIALS);
 
-   auto& radarData0     = (*radarData)[0];
-   auto  momentData0    = radarData0->moment_data_block(p->dataBlockType_);
-   p->elevationScan_    = radarData;
-   p->momentDataBlock0_ = momentData0;
+   const auto radarData0It = radarData->find(0);
+   if (radarData0It == radarData->cend() || radarData0It->second == nullptr)
+   {
+      logger_->warn("Empty radial data for {}",
+                    common::GetLevel2Name(p->product_));
+      Q_EMIT SweepNotComputed(types::NoUpdateReason::InvalidData);
+      return;
+   }
+
+   const auto& radarData0  = radarData0It->second;
+   const auto  momentData0 = radarData0->moment_data_block(p->dataBlockType_);
+   p->elevationScan_       = radarData;
+   p->momentDataBlock0_    = momentData0;
 
    if (momentData0 == nullptr)
    {
@@ -787,8 +796,20 @@ void Level2ProductView::ComputeSweep()
       const auto&   radialPair = *it;
       std::uint16_t radial     = radialPair.first;
       const auto&   radialData = radialPair.second;
+      if (radialData == nullptr)
+      {
+         logger_->warn("Radial {} has no data", radial);
+         continue;
+      }
+
       const std::shared_ptr<wsr88d::rda::GenericRadarData::MomentDataBlock>
          momentData = radialData->moment_data_block(p->dataBlockType_);
+
+      if (momentData == nullptr)
+      {
+         logger_->warn("Radial {} has no moment data", radial);
+         continue;
+      }
 
       if (momentData0->data_word_size() != momentData->data_word_size())
       {
@@ -850,9 +871,13 @@ void Level2ProductView::ComputeSweep()
 
       if (cfpMoments.size() > 0)
       {
-         cfpMomentsArray = reinterpret_cast<const std::uint8_t*>(
-            radialData->moment_data_block(wsr88d::rda::DataBlockType::MomentCfp)
-               ->data_moments());
+         const auto cfpMomentData = radialData->moment_data_block(
+            wsr88d::rda::DataBlockType::MomentCfp);
+         if (cfpMomentData != nullptr)
+         {
+            cfpMomentsArray = reinterpret_cast<const std::uint8_t*>(
+               cfpMomentData->data_moments());
+         }
       }
 
       std::shared_ptr<wsr88d::rda::GenericRadarData::MomentDataBlock>
@@ -869,7 +894,18 @@ void Level2ProductView::ComputeSweep()
 
          const auto& nextRadialPair = *(nextIt);
          const auto& nextRadialData = nextRadialPair.second;
+         if (nextRadialData == nullptr)
+         {
+            logger_->warn("Next radial has no data");
+            continue;
+         }
+
          nextMomentData = nextRadialData->moment_data_block(p->dataBlockType_);
+         if (nextMomentData == nullptr)
+         {
+            logger_->warn("Next radial has no moment data");
+            continue;
+         }
 
          if (momentData->data_word_size() != nextMomentData->data_word_size())
          {
@@ -1200,8 +1236,20 @@ void Level2ProductView::Impl::ComputeCoordinates(
    // Calculate azimuth coordinates
    timer.start();
 
-   auto& radarData0  = (*radarData)[0];
-   auto  momentData0 = radarData0->moment_data_block(dataBlockType_);
+   const auto radarData0It = radarData->find(0);
+   if (radarData0It == radarData->cend() || radarData0It->second == nullptr)
+   {
+      logger_->warn("Empty radial data");
+      return;
+   }
+
+   const auto& radarData0  = radarData0It->second;
+   const auto  momentData0 = radarData0->moment_data_block(dataBlockType_);
+   if (momentData0 == nullptr)
+   {
+      logger_->warn("No moment data");
+      return;
+   }
 
    const auto gateSize = momentData0->data_moment_range_sample_interval();
 
@@ -1240,8 +1288,9 @@ void Level2ProductView::Impl::ComputeCoordinates(
       {
          units::degrees<float> angle {};
 
-         auto radialData = radarData->find(radial);
-         if (radialData != radarData->cend() && smoothingEnabled)
+         const auto radialData = radarData->find(radial);
+         if (radialData != radarData->cend() && radialData->second != nullptr &&
+             smoothingEnabled)
          {
             angle = radialData->second->azimuth_angle();
          }
@@ -1253,7 +1302,9 @@ void Level2ProductView::Impl::ComputeCoordinates(
                (radial >= 2) ? radial - 2 : numRadials - (2 - radial));
 
             if (radialData != radarData->cend() &&
-                prevRadial1 != radarData->cend() && !smoothingEnabled)
+                radialData->second != nullptr &&
+                prevRadial1 != radarData->cend() &&
+                prevRadial1->second != nullptr && !smoothingEnabled)
             {
                const units::degrees<float> currentAngle =
                   radialData->second->azimuth_angle();
@@ -1270,7 +1321,8 @@ void Level2ProductView::Impl::ComputeCoordinates(
 
                angle = currentAngle - deltaAngle * deltaScale;
             }
-            else if (radialData != radarData->cend() && !smoothingEnabled)
+            else if (radialData != radarData->cend() &&
+                     radialData->second != nullptr && !smoothingEnabled)
             {
                const units::degrees<float> currentAngle =
                   radialData->second->azimuth_angle();
@@ -1286,7 +1338,9 @@ void Level2ProductView::Impl::ComputeCoordinates(
                angle = currentAngle - deltaAngle * deltaScale;
             }
             else if (prevRadial1 != radarData->cend() &&
-                     prevRadial2 != radarData->cend())
+                     prevRadial1->second != nullptr &&
+                     prevRadial2 != radarData->cend() &&
+                     prevRadial2->second != nullptr)
             {
                const units::degrees<float> prevAngle1 =
                   prevRadial1->second->azimuth_angle();
@@ -1308,7 +1362,8 @@ void Level2ProductView::Impl::ComputeCoordinates(
 
                angle = prevAngle1 + deltaAngle * deltaScale;
             }
-            else if (prevRadial1 != radarData->cend())
+            else if (prevRadial1 != radarData->cend() &&
+                     prevRadial1->second != nullptr)
             {
                const units::degrees<float> prevAngle1 =
                   prevRadial1->second->azimuth_angle();
@@ -1372,6 +1427,13 @@ bool Level2ProductView::Impl::IsRadarDataIncomplete(
    // Assume the data is incomplete when the delta between the first and last
    // angles is greater than 2.5 degrees.
    constexpr units::degrees<float> kIncompleteDataAngleThreshold_ {2.5};
+
+   if (radarData == nullptr || radarData->empty() ||
+       radarData->cbegin()->second == nullptr ||
+       radarData->crbegin()->second == nullptr)
+   {
+      return false;
+   }
 
    const units::degrees<float> firstAngle =
       radarData->cbegin()->second->azimuth_angle();
@@ -1471,13 +1533,14 @@ Level2ProductView::GetBinLevel(const common::Coordinate& coordinate) const
          units::degrees<float> startAngle {};
          units::degrees<float> nextAngle {};
 
-         auto radialData = radarData->find(i);
-         if (radialData != radarData->cend())
+         const auto radialData = radarData->find(i);
+         if (radialData != radarData->cend() && radialData->second != nullptr)
          {
             startAngle = radialData->second->azimuth_angle();
 
-            auto nextRadial = radarData->find((i + 1) % numRadials);
-            if (nextRadial != radarData->cend())
+            const auto nextRadial = radarData->find((i + 1) % numRadials);
+            if (nextRadial != radarData->cend() &&
+                nextRadial->second != nullptr)
             {
                nextAngle = nextRadial->second->azimuth_angle();
 
@@ -1495,7 +1558,8 @@ Level2ProductView::GetBinLevel(const common::Coordinate& coordinate) const
                auto prevRadial =
                   radarData->find((i >= 1) ? i - 1 : numRadials - (1 - i));
 
-               if (prevRadial != radarData->cend())
+               if (prevRadial != radarData->cend() &&
+                   prevRadial->second != nullptr)
                {
                   const units::degrees<float> prevAngle =
                      prevRadial->second->azimuth_angle();

--- a/scwx-qt/source/scwx/qt/view/level3_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level3_product_view.cpp
@@ -171,6 +171,10 @@ void Level3ProductView::DisconnectRadarProductManager()
               &manager::RadarProductManager::DataReloaded,
               this,
               nullptr);
+   disconnect(radar_product_manager().get(),
+              &manager::RadarProductManager::ProductTimesPopulated,
+              this,
+              nullptr);
 }
 
 std::shared_ptr<common::ColorTable> Level3ProductView::color_table() const

--- a/scwx-qt/source/scwx/qt/view/level3_radial_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level3_radial_view.cpp
@@ -28,7 +28,12 @@ class Level3RadialView::Impl
 {
 public:
    explicit Impl(Level3RadialView* self) : self_ {self} {}
-   ~Impl() { threadPool_.join(); };
+   ~Impl() = default;
+
+   Impl(const Impl&)                = delete;
+   Impl& operator=(const Impl&)     = delete;
+   Impl(Impl&&) noexcept            = delete;
+   Impl& operator=(Impl&&) noexcept = delete;
 
    void ComputeCoordinates(
       const std::shared_ptr<wsr88d::rpg::GenericRadialDataPacket>& radialData,
@@ -72,7 +77,14 @@ Level3RadialView::Level3RadialView(
 
 Level3RadialView::~Level3RadialView()
 {
-   std::unique_lock sweepLock {sweep_mutex()};
+   // Stop callbacks that can post ComputeSweep, then join while Impl is still
+   // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
+   // would deadlock.
+   DisconnectProductSettings();
+   DisconnectRadarProductManager();
+
+   p->threadPool_.stop();
+   p->threadPool_.join();
 }
 
 boost::asio::thread_pool& Level3RadialView::thread_pool()

--- a/scwx-qt/source/scwx/qt/view/level3_radial_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level3_radial_view.cpp
@@ -81,7 +81,7 @@ Level3RadialView::~Level3RadialView()
    // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
    // would deadlock.
    DisconnectProductSettings();
-   DisconnectRadarProductManager();
+   Level3RadialView::DisconnectRadarProductManager();
 
    p->threadPool_.stop();
    p->threadPool_.join();

--- a/scwx-qt/source/scwx/qt/view/level3_raster_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level3_raster_view.cpp
@@ -27,7 +27,12 @@ public:
        latitude_ {}, longitude_ {}, range_ {}, vcp_ {}, sweepTime_ {}
    {
    }
-   ~Level3RasterViewImpl() { threadPool_.join(); };
+   ~Level3RasterViewImpl() = default;
+
+   Level3RasterViewImpl(const Level3RasterViewImpl&)                = delete;
+   Level3RasterViewImpl& operator=(const Level3RasterViewImpl&)     = delete;
+   Level3RasterViewImpl(Level3RasterViewImpl&&) noexcept            = delete;
+   Level3RasterViewImpl& operator=(Level3RasterViewImpl&&) noexcept = delete;
 
    [[nodiscard]] inline std::uint8_t
    RemapDataMoment(std::uint8_t dataMoment) const;
@@ -62,7 +67,14 @@ Level3RasterView::Level3RasterView(
 
 Level3RasterView::~Level3RasterView()
 {
-   std::unique_lock sweepLock {sweep_mutex()};
+   // Stop callbacks that can post ComputeSweep, then join while Impl is still
+   // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
+   // would deadlock.
+   DisconnectProductSettings();
+   DisconnectRadarProductManager();
+
+   p->threadPool_.stop();
+   p->threadPool_.join();
 }
 
 boost::asio::thread_pool& Level3RasterView::thread_pool()

--- a/scwx-qt/source/scwx/qt/view/level3_raster_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/level3_raster_view.cpp
@@ -71,7 +71,7 @@ Level3RasterView::~Level3RasterView()
    // alive. Do not hold sweep_mutex across join: a worker blocked on that lock
    // would deadlock.
    DisconnectProductSettings();
-   DisconnectRadarProductManager();
+   Level3RasterView::DisconnectRadarProductManager();
 
    p->threadPool_.stop();
    p->threadPool_.join();

--- a/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/overlay_product_view.cpp
@@ -20,7 +20,12 @@ class OverlayProductView::Impl
 {
 public:
    explicit Impl(OverlayProductView* self) : self_ {self} {}
-   ~Impl() { threadPool_.join(); }
+   ~Impl() = default;
+
+   Impl(const Impl&)                = delete;
+   Impl& operator=(const Impl&)     = delete;
+   Impl(Impl&&) noexcept            = delete;
+   Impl& operator=(Impl&&) noexcept = delete;
 
    void ConnectRadarProductManager();
    void DisconnectRadarProductManager();
@@ -49,7 +54,15 @@ public:
 };
 
 OverlayProductView::OverlayProductView() : p(std::make_unique<Impl>(this)) {};
-OverlayProductView::~OverlayProductView() = default;
+OverlayProductView::~OverlayProductView()
+{
+   // Stop callbacks that can post work before joining the pool, while Impl and
+   // the QObject are still alive.
+   p->DisconnectRadarProductManager();
+
+   p->threadPool_.stop();
+   p->threadPool_.join();
+}
 
 std::shared_ptr<manager::RadarProductManager>
 OverlayProductView::radar_product_manager() const
@@ -147,7 +160,15 @@ void OverlayProductView::Impl::DisconnectRadarProductManager()
    if (radarProductManager_ != nullptr)
    {
       disconnect(radarProductManager_.get(),
+                 &manager::RadarProductManager::DataReloaded,
+                 self_,
+                 nullptr);
+      disconnect(radarProductManager_.get(),
                  &manager::RadarProductManager::NewDataAvailable,
+                 self_,
+                 nullptr);
+      disconnect(radarProductManager_.get(),
+                 &manager::RadarProductManager::ProductTimesPopulated,
                  self_,
                  nullptr);
    }

--- a/scwx-qt/source/scwx/qt/view/radar_product_view.cpp
+++ b/scwx-qt/source/scwx/qt/view/radar_product_view.cpp
@@ -50,6 +50,8 @@ public:
    }
    ~RadarProductViewImpl() {}
 
+   void DisconnectProductSettings() { connection_.disconnect(); }
+
    RadarProductView* self_;
 
    bool       initialized_;
@@ -138,6 +140,11 @@ std::mutex& RadarProductView::sweep_mutex()
 void RadarProductView::set_load_status(types::RadarProductLoadStatus loadStatus)
 {
    p->loadStatus_ = loadStatus;
+}
+
+void RadarProductView::DisconnectProductSettings()
+{
+   p->DisconnectProductSettings();
 }
 
 void RadarProductView::set_radar_product_manager(

--- a/scwx-qt/source/scwx/qt/view/radar_product_view.hpp
+++ b/scwx-qt/source/scwx/qt/view/radar_product_view.hpp
@@ -103,6 +103,12 @@ protected:
    virtual void DisconnectRadarProductManager() = 0;
    virtual void UpdateColorTableLut()           = 0;
 
+   /**
+    * Disconnects callbacks that can post work to the view thread pool.
+    * Derived destructors must call this before joining their thread pool.
+    */
+   void DisconnectProductSettings();
+
    void set_load_status(types::RadarProductLoadStatus loadStatus);
 
 protected slots:


### PR DESCRIPTION
**Bug Fixes**
- Improved radar data processing when scans contain missing or empty radial and moment data.
- Prevented invalid data access during coordinate, sweep, bin-level, and smoothing calculations.
- Improved detection of incomplete radar scans.

**Reliability**
- Strengthened view shutdown and callback cleanup to prevent stale updates and shutdown-related deadlocks.
- Improved orderly stopping and joining of background processing tasks across radar and product views.