### PR TITLE
Provider Fixes

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/provider_manager.cpp
@@ -4,6 +4,7 @@
 #include <scwx/util/time.hpp>
 
 #include <limits>
+#include <list>
 #include <map>
 #include <shared_mutex>
 
@@ -26,6 +27,11 @@ static constexpr std::chrono::seconds kFastRetryIntervalChunks_ {3};
 static constexpr std::chrono::seconds kSlowRetryInterval_ {120};
 static constexpr std::chrono::seconds kSlowRetryIntervalChunks_ {20};
 
+// Match AwsNexradDataProvider: keep today/yesterday plus several archived dates
+// before pruning least-recently used days once the ownership map is large.
+static constexpr std::size_t kMinDatesBeforePruning_ = 6u;
+static constexpr std::size_t kMaxVolumeTimeOwners_   = 2500u;
+
 } // namespace
 
 class ProviderManager::Impl
@@ -43,6 +49,10 @@ public:
    }
 
    [[nodiscard]] std::size_t ProviderIndex(const std::string& radarId) const;
+
+   // Assumes volumeTimeOwnersMutex_ is held exclusively.
+   void UpdateVolumeTimeOwnerDates(std::chrono::system_clock::time_point date);
+   void PruneVolumeTimeOwners();
 
    boost::asio::thread_pool providerThreadPool_ {2u};
 
@@ -66,6 +76,9 @@ public:
    mutable std::shared_mutex volumeTimeOwnersMutex_ {};
    std::map<std::chrono::system_clock::time_point, std::string>
       volumeTimeOwners_ {};
+   // Least-recently used dates at the front (same convention as provider
+   // caches).
+   std::list<std::chrono::system_clock::time_point> volumeTimeOwnerDates_ {};
 };
 
 std::size_t
@@ -80,6 +93,44 @@ ProviderManager::Impl::ProviderIndex(const std::string& radarId) const
    }
 
    return std::numeric_limits<std::size_t>::max();
+}
+
+void ProviderManager::Impl::UpdateVolumeTimeOwnerDates(
+   std::chrono::system_clock::time_point date)
+{
+   const auto day = std::chrono::floor<std::chrono::days>(date);
+
+   // Remove any existing occurrences of day, and add to the back of the list
+   volumeTimeOwnerDates_.remove(day);
+   volumeTimeOwnerDates_.emplace_back(day);
+}
+
+void ProviderManager::Impl::PruneVolumeTimeOwners()
+{
+   using namespace std::chrono;
+
+   const auto today     = floor<days>(util::time::now());
+   const auto yesterday = today - days {1};
+
+   for (auto it = volumeTimeOwnerDates_.cbegin();
+        it != volumeTimeOwnerDates_.cend() &&
+        volumeTimeOwners_.size() > kMaxVolumeTimeOwners_ &&
+        volumeTimeOwnerDates_.size() >= kMinDatesBeforePruning_;)
+   {
+      if (*it < yesterday)
+      {
+         // Erase ownership for the least-recently used archived day
+         const auto eraseBegin = volumeTimeOwners_.lower_bound(*it);
+         const auto eraseEnd   = volumeTimeOwners_.lower_bound(*it + days {1});
+         volumeTimeOwners_.erase(eraseBegin, eraseEnd);
+
+         it = volumeTimeOwnerDates_.erase(it);
+      }
+      else
+      {
+         ++it;
+      }
+   }
 }
 
 ProviderManager::ProviderManager(RadarProductManager*      self,
@@ -378,6 +429,23 @@ void ProviderManager::NoteVolumeTimes(
          it->second = radarId;
       }
    }
+
+   // Times from GetTimePointsByDate are chronologically ordered for one day;
+   // touch each distinct day once for LRU tracking.
+   std::chrono::system_clock::time_point lastDay {};
+   bool                                  haveLastDay = false;
+   for (const auto& time : times)
+   {
+      const auto day = std::chrono::floor<std::chrono::days>(time);
+      if (!haveLastDay || day != lastDay)
+      {
+         p->UpdateVolumeTimeOwnerDates(day);
+         lastDay     = day;
+         haveLastDay = true;
+      }
+   }
+
+   p->PruneVolumeTimeOwners();
 }
 
 std::shared_ptr<wsr88d::NexradFile>

--- a/test/source/scwx/provider/nws_level3_behavior.test.cpp
+++ b/test/source/scwx/provider/nws_level3_behavior.test.cpp
@@ -21,7 +21,8 @@ TEST(NwsLevel3BehaviorTest, InvalidProductListObjects)
 {
    NwsLevel3Behavior behavior(kNwsLevel3BaseUri, "KLSX", "???");
 
-   const auto objects = behavior.ListObjects(std::chrono::system_clock::now());
+   const auto objects =
+      behavior.ListObjects(std::chrono::system_clock::now()).second;
 
    EXPECT_TRUE(objects.empty());
 }
@@ -37,7 +38,8 @@ TEST(NwsLevel3BehaviorTest, ListObjects)
 {
    NwsLevel3Behavior behavior(kNwsLevel3BaseUri, "KLSX", "N0Q");
 
-   const auto objects = behavior.ListObjects(std::chrono::system_clock::now());
+   const auto objects =
+      behavior.ListObjects(std::chrono::system_clock::now()).second;
 
    if (objects.empty())
    {
@@ -57,7 +59,8 @@ TEST(NwsLevel3BehaviorTest, GetTimePointByKey)
 {
    NwsLevel3Behavior behavior(kNwsLevel3BaseUri, "KLSX", "N0Q");
 
-   const auto objects = behavior.ListObjects(std::chrono::system_clock::now());
+   const auto objects =
+      behavior.ListObjects(std::chrono::system_clock::now()).second;
 
    if (objects.empty())
    {

--- a/wxdata/include/scwx/provider/http_level3_server_behavior.hpp
+++ b/wxdata/include/scwx/provider/http_level3_server_behavior.hpp
@@ -22,7 +22,7 @@ public:
 
    virtual void Shutdown() noexcept = 0;
 
-   virtual std::vector<std::string>
+   virtual std::pair<bool, std::vector<std::string>>
    ListObjects(std::chrono::system_clock::time_point date) = 0;
 
    [[nodiscard]] virtual std::string

--- a/wxdata/include/scwx/provider/http_nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/http_nexrad_data_provider.hpp
@@ -60,6 +60,7 @@ protected:
                                  std::chrono::system_clock::time_point lastModified);
    void               ResetCacheStart();
    void               ResetCacheFinish();
+   void               SetDataRefreshed();
    [[nodiscard]] bool IsRunning() const;
 
 private:

--- a/wxdata/include/scwx/provider/http_nexrad_data_provider.hpp
+++ b/wxdata/include/scwx/provider/http_nexrad_data_provider.hpp
@@ -44,7 +44,6 @@ public:
 
 protected:
    // HTTP operations for derived classes
-   std::string       DownloadToString(const std::string& url);
    std::stringstream DownloadToStream(const std::string& url);
 
    // Derived classes must implement these

--- a/wxdata/include/scwx/provider/nws_level3_behavior.hpp
+++ b/wxdata/include/scwx/provider/nws_level3_behavior.hpp
@@ -23,7 +23,7 @@ public:
 
    void Shutdown() noexcept override;
 
-   std::vector<std::string>
+   std::pair<bool, std::vector<std::string>>
    ListObjects(std::chrono::system_clock::time_point date) override;
 
    [[nodiscard]] std::string GetFileUrl(const std::string& key) const override;

--- a/wxdata/include/scwx/provider/ondas_level3_behavior.hpp
+++ b/wxdata/include/scwx/provider/ondas_level3_behavior.hpp
@@ -26,7 +26,7 @@ public:
 
    void Shutdown() noexcept override;
 
-   std::vector<std::string>
+   std::pair<bool, std::vector<std::string>>
    ListObjects(std::chrono::system_clock::time_point date) override;
 
    [[nodiscard]] std::string GetFileUrl(const std::string& key) const override;

--- a/wxdata/source/scwx/config/ondas_config_loader.cpp
+++ b/wxdata/source/scwx/config/ondas_config_loader.cpp
@@ -45,7 +45,8 @@ static OndasConfigLoader::Result FetchConfig(const std::string& baseUri,
                  network::cpr::GetDefaultProgressCallback(
                     common::ApplicationState::IsRunning()));
 
-   if (response.status_code == ::cpr::status::HTTP_OK)
+   if (response.status_code >= ::cpr::status::SUCCESS_CODE_OFFSET &&
+       response.status_code < ::cpr::status::CLIENT_ERROR_CODE_OFFSET)
    {
       auto config = std::make_shared<OndasConfig>();
       auto is     = std::istringstream(response.text);
@@ -54,7 +55,8 @@ static OndasConfigLoader::Result FetchConfig(const std::string& baseUri,
       result.status = OndasConfigLoader::Status::Loaded;
       result.config = config;
    }
-   else if (response.status_code == ::cpr::status::HTTP_NOT_FOUND)
+   else if (response.status_code >= ::cpr::status::CLIENT_ERROR_CODE_OFFSET &&
+            response.status_code < ::cpr::status::SERVER_ERROR_CODE_OFFSET)
    {
       logger_->debug("Config file not found: {0}/{1}", baseUri, configFile);
       result.status = OndasConfigLoader::Status::NotFound;

--- a/wxdata/source/scwx/provider/http_level3_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_level3_data_provider.cpp
@@ -129,13 +129,15 @@ HttpLevel3DataProvider::ListObjects(std::chrono::system_clock::time_point date)
 
    if (!serverBehavior)
    {
-      return {false, 0, 0};
+      // If the server behavior is not found, return success and no objects.
+      // Returning false would cause repeated attempts to list objects.
+      return {true, 0, 0};
    }
 
-   const auto objects = serverBehavior->ListObjects(date);
-   if (objects.empty())
+   const auto [success, objects] = serverBehavior->ListObjects(date);
+   if (!success || objects.empty())
    {
-      return {false, 0, 0};
+      return {success, 0, 0};
    }
 
    std::size_t newObjects   = 0;

--- a/wxdata/source/scwx/provider/http_level3_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_level3_data_provider.cpp
@@ -131,12 +131,17 @@ HttpLevel3DataProvider::ListObjects(std::chrono::system_clock::time_point date)
    {
       // If the server behavior is not found, return success and no objects.
       // Returning false would cause repeated attempts to list objects.
+      SetDataRefreshed();
       return {true, 0, 0};
    }
 
    const auto [success, objects] = serverBehavior->ListObjects(date);
    if (!success || objects.empty())
    {
+      if (success)
+      {
+         SetDataRefreshed();
+      }
       return {success, 0, 0};
    }
 

--- a/wxdata/source/scwx/provider/http_level3_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_level3_data_provider.cpp
@@ -129,10 +129,8 @@ HttpLevel3DataProvider::ListObjects(std::chrono::system_clock::time_point date)
 
    if (!serverBehavior)
    {
-      // If the server behavior is not found, return success and no objects.
-      // Returning false would cause repeated attempts to list objects.
-      SetDataRefreshed();
-      return {true, 0, 0};
+      // If the server behavior is not found, return failure and no objects.
+      return {false, 0, 0};
    }
 
    const auto [success, objects] = serverBehavior->ListObjects(date);

--- a/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
@@ -50,8 +50,8 @@ public:
    std::string baseUri_;
    std::string radarSite_;
 
-   bool dateArchiveAvailable_ {false};
-   bool dataRefreshed_ {false};
+   bool              dateArchiveAvailable_ {false};
+   std::atomic<bool> dataRefreshed_ {false};
 
    std::map<std::chrono::system_clock::time_point, ObjectRecord> objects_ {};
    std::map<std::chrono::system_clock::time_point, ObjectRecord> newObjects_ {};
@@ -304,18 +304,16 @@ void HttpNexradDataProvider::Impl::CheckDataPresent(
    }
    else
    {
-      if (update)
+      if (update && !dataRefreshed_)
       {
-         std::shared_lock lock(objectsMutex_);
+         // Update requested and data not refreshed, so list objects
+         self_->ListObjects(date);
 
-         // Is data present?
-         if (objects_.empty())
-         {
-            lock.unlock();
-
-            // List objects, since no data is present
-            self_->ListObjects(date);
-         }
+         // Ensure IsDateCached becomes true after a listing attempt so
+         // RadarProductManager does not tight-loop on ProductTimesPopulated.
+         // Retryable failures (e.g. 5xx) are retried by Refresh(), not by
+         // re-entering the populate path.
+         self_->SetDataRefreshed();
       }
    }
 }
@@ -386,6 +384,11 @@ void HttpNexradDataProvider::ResetCacheFinish()
    }
 
    p->cacheResetting_ = false;
+}
+
+void HttpNexradDataProvider::SetDataRefreshed()
+{
+   p->dataRefreshed_ = true;
 }
 
 } // namespace scwx::provider

--- a/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
@@ -337,11 +337,6 @@ void HttpNexradDataProvider::Shutdown() noexcept
    p->running_ = false;
 }
 
-std::string HttpNexradDataProvider::DownloadToString(const std::string& url)
-{
-   return network::cpr::DownloadToString(url, p->running_).first;
-}
-
 std::stringstream
 HttpNexradDataProvider::DownloadToStream(const std::string& url)
 {

--- a/wxdata/source/scwx/provider/nws_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/nws_level3_behavior.cpp
@@ -209,7 +209,8 @@ NwsLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
 
    // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
    // error.
-   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+   const bool success = statusCode >= cpr::status::SUCCESS_CODE_OFFSET &&
+                        statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
 
    if (content.empty())
    {

--- a/wxdata/source/scwx/provider/nws_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/nws_level3_behavior.cpp
@@ -188,7 +188,7 @@ void NwsLevel3Behavior::Shutdown() noexcept
    p->running_ = false;
 }
 
-std::vector<std::string>
+std::pair<bool, std::vector<std::string>>
 NwsLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
 {
    (void) date; // Not needed since NWS directory structure contains all dates
@@ -202,11 +202,18 @@ NwsLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
    logger_->debug("ListObjects: {}", p->listingUrl_);
 
    // Download directory listing
-   const std::string content =
-      network::cpr::DownloadToString(p->listingUrl_, p->running_).first;
+   const auto response =
+      network::cpr::DownloadToString(p->listingUrl_, p->running_);
+   const std::string& content    = response.first;
+   const long         statusCode = response.second;
+
+   // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
+   // error.
+   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+
    if (content.empty())
    {
-      return {};
+      return {success, {}};
    }
 
    std::unordered_map<std::string, std::chrono::system_clock::time_point>
@@ -234,7 +241,8 @@ NwsLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
    const std::unique_lock lock {p->objectsMutex_};
    p->objectList_.swap(newObjectList);
 
-   return p->objectList_ | ranges::views::keys | ranges::to<std::vector>();
+   return {true,
+           p->objectList_ | ranges::views::keys | ranges::to<std::vector>()};
 }
 
 std::string NwsLevel3Behavior::GetFileUrl(const std::string& key) const

--- a/wxdata/source/scwx/provider/nws_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/nws_level3_behavior.cpp
@@ -290,7 +290,7 @@ void NwsLevel3SiteData::ListProducts()
    std::deque<std::pair<std::string, cpr::AsyncResponse>> asyncResponses {};
    std::atomic<bool>                                      error {false};
 
-   static constexpr std::size_t kMaxConcurrentRequests = 8u;
+   static constexpr std::size_t kMaxConcurrentRequests = 4u;
 
    for (const auto& product : kProductDirectoryMap_)
    {

--- a/wxdata/source/scwx/provider/nws_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/nws_level3_behavior.cpp
@@ -196,7 +196,7 @@ NwsLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
    if (!p->productValid_)
    {
       // Skip product listing for invalid products
-      return {};
+      return {true, {}};
    }
 
    logger_->debug("ListObjects: {}", p->listingUrl_);

--- a/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
+++ b/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
@@ -1,10 +1,13 @@
 #include <scwx/provider/ondas_level2_data_provider.hpp>
 #include <scwx/config/ondas_config_loader.hpp>
+#include <scwx/network/cpr.hpp>
 #include <scwx/types/ondas_types.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <chrono>
 #include <mutex>
+
+#include <cpr/status_codes.h>
 
 namespace scwx::provider
 {
@@ -70,10 +73,17 @@ OndasLevel2DataProvider::ListObjects(std::chrono::system_clock::time_point date)
    logger_->debug("ListObjects: {}", listingUrl);
 
    // Download dir.list
-   const std::string content = DownloadToString(listingUrl);
+   const auto         response   = network::cpr::DownloadToString(listingUrl);
+   const std::string& content    = response.first;
+   const long         statusCode = response.second;
+
+   // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
+   // error.
+   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+
    if (content.empty())
    {
-      return {false, 0, 0};
+      return {success, 0, 0};
    }
 
    // Parse ONDAS format

--- a/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
+++ b/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
@@ -79,7 +79,8 @@ OndasLevel2DataProvider::ListObjects(std::chrono::system_clock::time_point date)
 
    // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
    // error.
-   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+   const bool success = statusCode >= cpr::status::SUCCESS_CODE_OFFSET &&
+                        statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
 
    if (!success || content.empty())
    {

--- a/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
+++ b/wxdata/source/scwx/provider/ondas_level2_data_provider.cpp
@@ -81,8 +81,12 @@ OndasLevel2DataProvider::ListObjects(std::chrono::system_clock::time_point date)
    // error.
    const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
 
-   if (content.empty())
+   if (!success || content.empty())
    {
+      if (success)
+      {
+         SetDataRefreshed();
+      }
       return {success, 0, 0};
    }
 

--- a/wxdata/source/scwx/provider/ondas_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/ondas_level3_behavior.cpp
@@ -125,7 +125,8 @@ OndasLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
 
    // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
    // error.
-   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+   const bool success = statusCode >= cpr::status::SUCCESS_CODE_OFFSET &&
+                        statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
 
    if (content.empty())
    {

--- a/wxdata/source/scwx/provider/ondas_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/ondas_level3_behavior.cpp
@@ -110,7 +110,7 @@ void OndasLevel3Behavior::Shutdown() noexcept
    p->running_ = false;
 }
 
-std::vector<std::string>
+std::pair<bool, std::vector<std::string>>
 OndasLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
 {
    (void) date; // Not needed since ONDAS dir.list contains all dates
@@ -118,11 +118,18 @@ OndasLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
    logger_->debug("ListObjects: {}", p->listingUrl_);
 
    // Download dir.list
-   const std::string content =
-      network::cpr::DownloadToString(p->listingUrl_, p->running_).first;
+   const auto response =
+      network::cpr::DownloadToString(p->listingUrl_, p->running_);
+   const std::string& content    = response.first;
+   const long         statusCode = response.second;
+
+   // Treat 2xx and 4xx status codes as success, and 5xx (server errors) as
+   // error.
+   const bool success = statusCode < cpr::status::SERVER_ERROR_CODE_OFFSET;
+
    if (content.empty())
    {
-      return {};
+      return {success, {}};
    }
 
    // Parse ONDAS format
@@ -133,7 +140,7 @@ OndasLevel3Behavior::ListObjects(std::chrono::system_clock::time_point date)
                           std::back_inserter(keys),
                           [](const auto& record) { return record.filename_; });
 
-   return keys;
+   return {true, std::move(keys)};
 }
 
 std::string OndasLevel3Behavior::GetFileUrl(const std::string& key) const


### PR DESCRIPTION
- Mark HTTP Level 2/3 listings as refreshed on empty or non-retryable results (SetDataRefreshed), so missing server behavior or empty directories no longer leave IsDateCached false and spin ProductTimesPopulated.
- Cap NWS Level 3 product discovery at 4 concurrent requests to reduce throttling.
- Fix refresh / populate tight loops: non-archive CheckDataPresent sets refreshed after a list attempt; ProviderManager sticks to the first-hit site after cutover and only slow-retries when totalObjects == 0; AreProductTimesPopulated ignores providers outside radar-ID candidate windows.
- Prune ProviderManager volumeTimeOwners_ by LRU day (keep today/yesterday, cap size) so ownership maps do not grow without bound.