### PR TITLE
Add Flatpak Repository to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,10 @@ jobs:
       env:
         INSTALL_DIR: ${{ github.workspace }}/supercell-wx/
         FLATPAK_DIR: ${{ github.workspace }}/supercell-wx-flatpak/
+        # CI always builds the nightly branch. Stable is assigned later by the
+        # Flatpak repo publish job when a GitHub Release is published (tags
+        # are often created after this workflow has already finished).
+        FLATPAK_DEFAULT_BRANCH: nightly
       shell: bash
       run: |
         cp -r ${{ env.INSTALL_DIR }} ${{ env.FLATPAK_DIR }}
@@ -430,10 +434,12 @@ jobs:
         flatpak-builder --force-clean \
             --user \
             --install-deps-from=flathub \
+            --default-branch="${FLATPAK_DEFAULT_BRANCH}" \
             --repo=flatpak-repo \
             --install flatpak-build \
             ${{ github.workspace }}/source/tools/net.supercellwx.app.yml
-        flatpak build-bundle flatpak-repo supercell-wx.flatpak net.supercellwx.app
+        flatpak build-bundle flatpak-repo supercell-wx.flatpak \
+            net.supercellwx.app "${FLATPAK_DEFAULT_BRANCH}"
 
     - name: Upload FlatPak (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,10 @@ jobs:
         path: ${{ github.workspace }}/*-${{ matrix.appimage_arch }}.AppImage*
 
     - name: Build FlatPak (Linux)
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      # Ubuntu 22.04 ships flatpak-builder < 1.4, which still runs appstream-compose
+      # inside the SDK. Freedesktop 25.08 removed that tool; 24.04+ builder uses
+      # host appstreamcli compose instead. Publish only consumes gcc-13 artifacts.
+      if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-22.04' }}
       env:
         INSTALL_DIR: ${{ github.workspace }}/supercell-wx/
         FLATPAK_DIR: ${{ github.workspace }}/supercell-wx-flatpak/
@@ -442,7 +445,7 @@ jobs:
             net.supercellwx.app "${FLATPAK_DEFAULT_BRANCH}"
 
     - name: Upload FlatPak (Linux)
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-22.04' }}
       uses: actions/upload-artifact@v7
       with:
         name: supercell-wx-flatpak-${{ matrix.artifact_suffix }}

--- a/.github/workflows/publish-flatpak-repo.yml
+++ b/.github/workflows/publish-flatpak-repo.yml
@@ -1,0 +1,380 @@
+name: Publish Flatpak Repo
+
+# Publishes the dual-arch Flatpak OSTree repository to GitHub Pages.
+#
+# Nightly: workflow_run after CI completes on develop (push / workflow_dispatch only).
+#   workflow_run always loads THIS file from the default branch, so a PR cannot
+#   weaken the branch/event checks below by editing the workflow in the PR.
+# Stable: release published, or workflow_dispatch.
+#
+# Repo settings required once: Settings → Pages → Source = GitHub Actions.
+# Secrets required: FLATPAK_GPG_PRIVATE_KEY, optional FLATPAK_GPG_PASSPHRASE.
+#
+# id-token: write is required by actions/deploy-pages (OIDC to GitHub Pages).
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Flatpak branch to publish
+        type: choice
+        options: [nightly, stable]
+        default: nightly
+      bundle_source:
+        description: Where to get .flatpak bundles
+        type: choice
+        options: [artifacts, release]
+        default: artifacts
+      release_tag:
+        description: Release tag when bundle_source=release (empty = latest)
+        type: string
+        required: false
+        default: ''
+      ci_run_id:
+        description: CI run ID when bundle_source=artifacts (required for manual artifact publish)
+        type: string
+        required: false
+        default: ''
+
+concurrency:
+  group: flatpak-repo
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+env:
+  PAGES_URL: https://dpaulat.github.io/supercell-wx
+  HOMEPAGE_URL: https://supercellwx.net
+
+jobs:
+  build-repo:
+    name: Build Flatpak OSTree repo
+    runs-on: ubuntu-24.04
+    # Refuse PR-triggered CI and non-develop heads. These checks live only on the
+    # default-branch copy of this workflow (workflow_run property).
+    # Allow CI conclusion=failure so a non-Flatpak matrix cell (e.g. clang) can
+    # fail without blocking nightly; missing gcc-13 artifacts still fail later.
+    if: |
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        github.event.workflow_run.conclusion != 'skipped' &&
+        github.event.workflow_run.head_branch == 'develop' &&
+        (github.event.workflow_run.event == 'push' ||
+         github.event.workflow_run.event == 'workflow_dispatch')
+      )
+    steps:
+      - name: Resolve publish metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            workflow_run)
+              channel="nightly"
+              bundle_source="artifacts"
+              release_tag=""
+              ci_run_id="${{ github.event.workflow_run.id }}"
+              ;;
+            release)
+              channel="stable"
+              bundle_source="release"
+              release_tag="${{ github.event.release.tag_name }}"
+              ci_run_id=""
+              ;;
+            workflow_dispatch)
+              channel="${{ inputs.channel }}"
+              bundle_source="${{ inputs.bundle_source }}"
+              release_tag="${{ inputs.release_tag }}"
+              ci_run_id="${{ inputs.ci_run_id }}"
+              ;;
+            *)
+              echo "Unsupported event: ${{ github.event_name }}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "${channel}" != "nightly" && "${channel}" != "stable" ]]; then
+            echo "Invalid channel: ${channel}" >&2
+            exit 1
+          fi
+          if [[ "${bundle_source}" != "artifacts" && "${bundle_source}" != "release" ]]; then
+            echo "Invalid bundle_source: ${bundle_source}" >&2
+            exit 1
+          fi
+          if [[ "${bundle_source}" == "artifacts" && -z "${ci_run_id}" ]]; then
+            echo "ci_run_id is required when bundle_source=artifacts" >&2
+            exit 1
+          fi
+
+          echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
+          echo "bundle_source=${bundle_source}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "ci_run_id=${ci_run_id}" >> "${GITHUB_OUTPUT}"
+          echo "Publishing channel=${channel} bundle_source=${bundle_source} release_tag=${release_tag:-<none>} ci_run_id=${ci_run_id:-<none>}"
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Flatpak tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y flatpak ostree curl gnupg
+
+      - name: Import GPG signing key
+        id: import-gpg
+        shell: bash
+        env:
+          FLATPAK_GPG_PRIVATE_KEY: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
+          FLATPAK_GPG_PASSPHRASE: ${{ secrets.FLATPAK_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+
+          # Validate the key secret and passphrase are set
+          if [[ -z "${FLATPAK_GPG_PRIVATE_KEY}" ]]; then
+            echo "FLATPAK_GPG_PRIVATE_KEY secret is not set" >&2
+            exit 1
+          fi
+          if [[ -z "${FLATPAK_GPG_PASSPHRASE}" ]]; then
+            echo "FLATPAK_GPG_PASSPHRASE secret is not set" >&2
+            exit 1
+          fi
+
+          # Set up a temporary GNUPG home directory
+          GNUPGHOME="$(mktemp -d)"
+          chmod 700 "${GNUPGHOME}"
+          export GNUPGHOME
+
+          # Make this home available to later workflow steps
+          echo "GNUPGHOME=${GNUPGHOME}" >> "${GITHUB_ENV}"
+
+          # Cleanup on failure
+          cleanup_on_failure() {
+            status=$?
+            if (( status != 0 )); then
+              gpgconf --homedir "${GNUPGHOME}" --kill gpg-agent \
+                2>/dev/null || true
+              rm -rf "${GNUPGHOME}"
+            fi
+            exit "${status}"
+          }
+          trap cleanup_on_failure EXIT
+
+          # Non-interactive signing for flatpak/ostree (they invoke gpg without a TTY).
+          cat > "${GNUPGHOME}/gpg-agent.conf" <<'EOF'
+          allow-preset-passphrase
+          EOF
+          gpgconf --kill gpg-agent 2>/dev/null || true
+
+          # Import the private key
+          printf '%s\n' "${FLATPAK_GPG_PRIVATE_KEY}" |
+            gpg --batch --no-tty --import
+
+          # Get the fingerprint of the imported key
+          mapfile -t fingerprints < <(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '
+                $1 == "sec" { want_fingerprint = 1; next }
+                want_fingerprint && $1 == "fpr" {
+                  print $10
+                  want_fingerprint = 0
+                }
+              '
+          )
+
+          if (( ${#fingerprints[@]} != 1 )); then
+            echo "Expected exactly one imported GPG identity" >&2
+            exit 1
+          fi
+
+          fingerprint="${fingerprints[0]}"
+          echo "fingerprint=${fingerprint}" >> "${GITHUB_OUTPUT}"
+          echo "Imported GPG key ${fingerprint}"
+
+          # Unlock the key with the passphrase
+          preset_bin=""
+          for candidate in \
+            /usr/lib/gnupg/gpg-preset-passphrase \
+            /usr/lib/gnupg2/gpg-preset-passphrase \
+            /usr/libexec/gpg-preset-passphrase; do
+            if [[ -x "${candidate}" ]]; then
+              preset_bin="${candidate}"
+              break
+            fi
+          done
+
+          if [[ -z "${preset_bin}" ]]; then
+            echo "gpg-preset-passphrase not found; cannot unlock keyed passphrase" >&2
+            exit 1
+          fi
+
+          gpgconf --launch gpg-agent
+
+          mapfile -t keygrips < <(
+            gpg \
+              --batch \
+              --with-colons \
+              --with-keygrip \
+              --list-secret-keys |
+              awk -F: '$1 == "grp" && $10 != "" { print $10 }'
+          )
+
+          if (( ${#keygrips[@]} == 0 )); then
+            echo "No secret-key keygrips found" >&2
+            exit 1
+          fi
+
+          for keygrip in "${keygrips[@]}"; do
+            printf '%s' "$FLATPAK_GPG_PASSPHRASE" |
+              "$preset_bin" --preset "$keygrip"
+          done
+
+          # Prove that unattended signing works from the agent cache
+          printf 'Flatpak signing test' |
+            gpg \
+              --batch \
+              --no-tty \
+              --local-user "${fingerprint}" \
+              --detach-sign \
+              --output /dev/null
+
+          # Remove the trap now that we've proven the key is unlocked
+          trap - EXIT
+
+      - name: Download CI Flatpak artifacts
+        if: steps.meta.outputs.bundle_source == 'artifacts'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: supercell-wx-flatpak-linux-gcc-13-*
+          path: bundles
+          merge-multiple: false
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.meta.outputs.ci_run_id }}
+
+      - name: Locate CI bundles
+        if: steps.meta.outputs.bundle_source == 'artifacts'
+        id: bundles-artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          x64="bundles/supercell-wx-flatpak-linux-gcc-13-x64/supercell-wx.flatpak"
+          arm="bundles/supercell-wx-flatpak-linux-gcc-13-arm64/supercell-wx.flatpak"
+          if [[ ! -f "${x64}" || ! -f "${arm}" ]]; then
+            echo "Expected gcc-13 x64 and arm64 Flatpak artifacts were not found in run ${{ steps.meta.outputs.ci_run_id }}." >&2
+            find bundles -type f -print >&2 || true
+            exit 1
+          fi
+          echo "bundle_x64=${x64}" >> "${GITHUB_OUTPUT}"
+          echo "bundle_aarch64=${arm}" >> "${GITHUB_OUTPUT}"
+          ls -lh "${x64}" "${arm}"
+
+      - name: Resolve release tag
+        if: steps.meta.outputs.bundle_source == 'release'
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.meta.outputs.release_tag }}"
+          if [[ -z "${tag}" ]]; then
+            tag="$(gh release view -R "${{ github.repository }}" --json tagName -q .tagName)"
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "Using release tag: ${tag}"
+
+      - name: Download release Flatpak assets
+        if: steps.meta.outputs.bundle_source == 'release'
+        id: bundles-release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p bundles
+          gh release download "${{ steps.release.outputs.tag }}" \
+            -R "${{ github.repository }}" \
+            -D bundles \
+            -p '*-linux-x64.flatpak' \
+            -p '*-linux-arm64.flatpak'
+          x64="$(find bundles -type f -name '*-linux-x64.flatpak' | head -n1)"
+          arm="$(find bundles -type f -name '*-linux-arm64.flatpak' | head -n1)"
+          if [[ -z "${x64}" || -z "${arm}" ]]; then
+            echo "Release ${{ steps.release.outputs.tag }} is missing linux-x64/arm64 Flatpak assets." >&2
+            ls -la bundles >&2 || true
+            exit 1
+          fi
+          echo "bundle_x64=${x64}" >> "${GITHUB_OUTPUT}"
+          echo "bundle_aarch64=${arm}" >> "${GITHUB_OUTPUT}"
+          ls -lh "${x64}" "${arm}"
+
+      - name: Select bundle paths
+        id: bundles
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.meta.outputs.bundle_source }}" == "artifacts" ]]; then
+            echo "bundle_x64=${{ steps.bundles-artifacts.outputs.bundle_x64 }}" >> "${GITHUB_OUTPUT}"
+            echo "bundle_aarch64=${{ steps.bundles-artifacts.outputs.bundle_aarch64 }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "bundle_x64=${{ steps.bundles-release.outputs.bundle_x64 }}" >> "${GITHUB_OUTPUT}"
+            echo "bundle_aarch64=${{ steps.bundles-release.outputs.bundle_aarch64 }}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Build Pages site
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x tools/ci/publish-flatpak-repo.sh
+          tools/ci/publish-flatpak-repo.sh \
+            --channel "${{ steps.meta.outputs.channel }}" \
+            --site-dir "${{ github.workspace }}/flatpak-pages-site" \
+            --bundle-x64 "${{ steps.bundles.outputs.bundle_x64 }}" \
+            --bundle-aarch64 "${{ steps.bundles.outputs.bundle_aarch64 }}" \
+            --pages-url "${{ env.PAGES_URL }}" \
+            --homepage "${{ env.HOMEPAGE_URL }}" \
+            --gpg-key-id "${{ steps.import-gpg.outputs.fingerprint }}"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: flatpak-pages-site
+          include-hidden-files: true
+
+      - name: Remove GPG signing key
+        if: always()
+        shell: bash
+        run: |
+          if [[ -n "${GNUPGHOME:-}" && -d "${GNUPGHOME}" ]]; then
+            gpgconf --homedir "${GNUPGHOME}" --kill gpg-agent \
+              2>/dev/null || true
+            rm -rf "${GNUPGHOME}"
+          fi
+
+  deploy:
+    name: Deploy GitHub Pages
+    needs: build-repo
+    if: needs.build-repo.result == 'success'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-flatpak-repo.yml
+++ b/.github/workflows/publish-flatpak-repo.yml
@@ -8,9 +8,9 @@ name: Publish Flatpak Repo
 # Stable: release published, or workflow_dispatch.
 #
 # Repo settings required once: Settings → Pages → Source = GitHub Actions.
-# Secrets required: FLATPAK_GPG_PRIVATE_KEY, optional FLATPAK_GPG_PASSPHRASE.
+# Secrets required: FLATPAK_GPG_PRIVATE_KEY, FLATPAK_GPG_PASSPHRASE.
 #
-# id-token: write is required by actions/deploy-pages (OIDC to GitHub Pages).
+# pages/id-token write are granted only on the deploy job (OIDC for deploy-pages).
 on:
   workflow_run:
     workflows:
@@ -49,8 +49,6 @@ concurrency:
 permissions:
   contents: read
   actions: read
-  pages: write
-  id-token: write
 
 env:
   PAGES_URL: https://dpaulat.github.io/supercell-wx
@@ -76,29 +74,37 @@ jobs:
       - name: Resolve publish metadata
         id: meta
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_BUNDLE_SOURCE: ${{ inputs.bundle_source }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_CI_RUN_ID: ${{ inputs.ci_run_id }}
         run: |
           set -euo pipefail
-          case "${{ github.event_name }}" in
+          case "${EVENT_NAME}" in
             workflow_run)
               channel="nightly"
               bundle_source="artifacts"
               release_tag=""
-              ci_run_id="${{ github.event.workflow_run.id }}"
+              ci_run_id="${WORKFLOW_RUN_ID}"
               ;;
             release)
               channel="stable"
               bundle_source="release"
-              release_tag="${{ github.event.release.tag_name }}"
+              release_tag="${RELEASE_TAG_NAME}"
               ci_run_id=""
               ;;
             workflow_dispatch)
-              channel="${{ inputs.channel }}"
-              bundle_source="${{ inputs.bundle_source }}"
-              release_tag="${{ inputs.release_tag }}"
-              ci_run_id="${{ inputs.ci_run_id }}"
+              channel="${INPUT_CHANNEL}"
+              bundle_source="${INPUT_BUNDLE_SOURCE}"
+              release_tag="${INPUT_RELEASE_TAG}"
+              ci_run_id="${INPUT_CI_RUN_ID}"
               ;;
             *)
-              echo "Unsupported event: ${{ github.event_name }}" >&2
+              echo "Unsupported event: ${EVENT_NAME}" >&2
               exit 1
               ;;
           esac
@@ -111,9 +117,15 @@ jobs:
             echo "Invalid bundle_source: ${bundle_source}" >&2
             exit 1
           fi
-          if [[ "${bundle_source}" == "artifacts" && -z "${ci_run_id}" ]]; then
-            echo "ci_run_id is required when bundle_source=artifacts" >&2
-            exit 1
+          if [[ "${bundle_source}" == "artifacts" ]]; then
+            if [[ -z "${ci_run_id}" ]]; then
+              echo "ci_run_id is required when bundle_source=artifacts" >&2
+              exit 1
+            fi
+            if [[ ! "${ci_run_id}" =~ ^[0-9]+$ ]]; then
+              echo "ci_run_id must be numeric (got: ${ci_run_id})" >&2
+              exit 1
+            fi
           fi
 
           echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
@@ -122,8 +134,20 @@ jobs:
           echo "ci_run_id=${ci_run_id}" >> "${GITHUB_OUTPUT}"
           echo "Publishing channel=${channel} bundle_source=${bundle_source} release_tag=${release_tag:-<none>} ci_run_id=${ci_run_id:-<none>}"
 
-      - name: Checkout
+      - name: Checkout default branch
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v7
+        with:
+          # workflow_run / release: always use default-branch publish tooling.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Checkout workflow branch
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          # Keep the branch selected in the Actions UI for testing publish changes.
+          persist-credentials: false
 
       - name: Install Flatpak tools
         shell: bash
@@ -254,7 +278,7 @@ jobs:
 
       - name: Download CI Flatpak artifacts
         if: steps.meta.outputs.bundle_source == 'artifacts'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: supercell-wx-flatpak-linux-gcc-13-*
           path: bundles
@@ -267,12 +291,14 @@ jobs:
         if: steps.meta.outputs.bundle_source == 'artifacts'
         id: bundles-artifacts
         shell: bash
+        env:
+          CI_RUN_ID: ${{ steps.meta.outputs.ci_run_id }}
         run: |
           set -euo pipefail
           x64="bundles/supercell-wx-flatpak-linux-gcc-13-x64/supercell-wx.flatpak"
           arm="bundles/supercell-wx-flatpak-linux-gcc-13-arm64/supercell-wx.flatpak"
           if [[ ! -f "${x64}" || ! -f "${arm}" ]]; then
-            echo "Expected gcc-13 x64 and arm64 Flatpak artifacts were not found in run ${{ steps.meta.outputs.ci_run_id }}." >&2
+            echo "Expected gcc-13 x64 and arm64 Flatpak artifacts were not found in run ${CI_RUN_ID}." >&2
             find bundles -type f -print >&2 || true
             exit 1
           fi
@@ -286,11 +312,13 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${{ steps.meta.outputs.release_tag }}"
+          tag="${RELEASE_TAG}"
           if [[ -z "${tag}" ]]; then
-            tag="$(gh release view -R "${{ github.repository }}" --json tagName -q .tagName)"
+            tag="$(gh release view -R "${REPOSITORY}" --json tagName -q .tagName)"
           fi
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "Using release tag: ${tag}"
@@ -301,18 +329,20 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           mkdir -p bundles
-          gh release download "${{ steps.release.outputs.tag }}" \
-            -R "${{ github.repository }}" \
+          gh release download "${RELEASE_TAG}" \
+            -R "${REPOSITORY}" \
             -D bundles \
             -p '*-linux-x64.flatpak' \
             -p '*-linux-arm64.flatpak'
           x64="$(find bundles -type f -name '*-linux-x64.flatpak' | head -n1)"
           arm="$(find bundles -type f -name '*-linux-arm64.flatpak' | head -n1)"
           if [[ -z "${x64}" || -z "${arm}" ]]; then
-            echo "Release ${{ steps.release.outputs.tag }} is missing linux-x64/arm64 Flatpak assets." >&2
+            echo "Release ${RELEASE_TAG} is missing linux-x64/arm64 Flatpak assets." >&2
             ls -la bundles >&2 || true
             exit 1
           fi
@@ -348,10 +378,10 @@ jobs:
             --gpg-key-id "${{ steps.import-gpg.outputs.fingerprint }}"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: flatpak-pages-site
           include-hidden-files: true
@@ -371,10 +401,13 @@ jobs:
     needs: build-repo
     if: needs.build-repo.result == 'success'
     runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/scwx-qt/res/linux/net.supercellwx.app.desktop
+++ b/scwx-qt/res/linux/net.supercellwx.app.desktop
@@ -3,5 +3,5 @@ Type=Application
 Name=Supercell Wx
 Comment=Weather Radar and Data Viewer
 Exec=supercell-wx
-Icon=net.supercellwx.app.png
+Icon=net.supercellwx.app
 Categories=Network;Science;

--- a/scwx-qt/res/linux/net.supercellwx.app.metainfo.xml
+++ b/scwx-qt/res/linux/net.supercellwx.app.metainfo.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2021-2026 Dan Paulat -->
+<component type="desktop-application">
+  <id>net.supercellwx.app</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Supercell Wx</name>
+  <summary>Weather radar and data viewer</summary>
+  <developer id="net.supercellwx">
+    <name>Dan Paulat</name>
+  </developer>
+  <description>
+    <p>
+      Supercell Wx is a free, open source application to visualize live and
+      archive NEXRAD Level 2 and Level 3 data, and severe weather alerts. It
+      displays continuously updating weather data on top of a responsive map,
+      providing the capability to monitor weather events using reflectivity,
+      velocity, and other products.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Live and archive NEXRAD Level 2 and Level 3 radar products</li>
+      <li>Severe weather alert display and monitoring</li>
+      <li>Responsive map with multiple product views and layouts</li>
+      <li>Timeline controls for looping historical data</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">net.supercellwx.app.desktop</launchable>
+  <url type="homepage">https://supercell-wx.readthedocs.io/</url>
+  <url type="bugtracker">https://github.com/dpaulat/supercell-wx/issues</url>
+  <url type="help">https://supercell-wx.readthedocs.io/</url>
+  <url type="donation">https://github.com/sponsors/dpaulat</url>
+  <url type="vcs-browser">https://github.com/dpaulat/supercell-wx</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Supercell Wx configured with radar data on the map</caption>
+      <image>https://supercell-wx.readthedocs.io/en/stable/_images/initial-setup-03-initial-configured-small.png</image>
+    </screenshot>
+  </screenshots>
+  <provides>
+    <binary>supercell-wx</binary>
+  </provides>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.6.0" date="2026-06-05"/>
+  </releases>
+</component>

--- a/tools/ci/flatpak-pages/index.html
+++ b/tools/ci/flatpak-pages/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Supercell Wx Flatpak</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #1a1a1a;
+      --muted: #555;
+      --bg: #f6f7f9;
+      --card: #fff;
+      --border: #d8dde6;
+      --accent: #0b57d0;
+      --code-bg: #eef1f6;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #f2f4f8;
+        --muted: #b0b8c4;
+        --bg: #12151a;
+        --card: #1b2028;
+        --border: #2e3642;
+        --accent: #8ab4ff;
+        --code-bg: #0f1318;
+      }
+    }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      line-height: 1.5;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    main {
+      max-width: 44rem;
+      margin: 0 auto;
+      padding: 2.5rem 1.25rem 3rem;
+    }
+    h1 { margin: 0 0 0.35rem; font-size: 1.85rem; }
+    p { margin: 0.75rem 0; }
+    .muted { color: var(--muted); }
+    section {
+      margin-top: 1.5rem;
+      padding: 1.1rem 1.2rem;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+    }
+    h2 { margin: 0 0 0.6rem; font-size: 1.15rem; }
+    pre {
+      margin: 0.75rem 0 0;
+      padding: 0.85rem 1rem;
+      overflow-x: auto;
+      background: var(--code-bg);
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    a { color: var(--accent); }
+    ul { margin: 0.5rem 0 0; padding-left: 1.2rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Supercell Wx Flatpak</h1>
+    <p class="muted">
+      Install and update Supercell Wx from this Flatpak remote
+      (<code>x86_64</code> and <code>aarch64</code>).
+    </p>
+
+    <section>
+      <h2>Stable</h2>
+      <pre>flatpak remote-add --if-not-exists supercell-wx \
+  https://dpaulat.github.io/supercell-wx/supercell-wx.flatpakrepo
+flatpak install supercell-wx net.supercellwx.app
+flatpak update</pre>
+    </section>
+
+    <section>
+      <h2>Nightly</h2>
+      <p class="muted">Development builds from the <code>develop</code> branch.</p>
+      <pre>flatpak remote-add --if-not-exists supercell-wx-nightly \
+  https://dpaulat.github.io/supercell-wx/supercell-wx-nightly.flatpakrepo
+flatpak install supercell-wx-nightly net.supercellwx.app//nightly
+flatpak update</pre>
+    </section>
+
+    <section>
+      <h2>Runtime</h2>
+      <p class="muted">
+        The Freedesktop runtime comes from Flathub. Add it once if needed:
+      </p>
+      <pre>flatpak remote-add --if-not-exists flathub \
+  https://dl.flathub.org/repo/flathub.flatpakrepo</pre>
+    </section>
+
+    <section>
+      <h2>Files</h2>
+      <ul>
+        <li><a href="supercell-wx.flatpakrepo">supercell-wx.flatpakrepo</a></li>
+        <li><a href="supercell-wx-nightly.flatpakrepo">supercell-wx-nightly.flatpakrepo</a></li>
+        <li><a href="supercell-wx.gpg">supercell-wx.gpg</a> (public signing key)</li>
+        <li><a href="repo/">repo/</a> (OSTree repository)</li>
+      </ul>
+      <p class="muted">
+        Project site:
+        <a href="https://supercellwx.net">supercellwx.net</a>
+        · Docs:
+        <a href="https://supercell-wx.readthedocs.io/">readthedocs</a>
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/tools/ci/flatpak-pages/index.html
+++ b/tools/ci/flatpak-pages/index.html
@@ -100,7 +100,7 @@ flatpak update</pre>
       <ul>
         <li><a href="supercell-wx.flatpakrepo">supercell-wx.flatpakrepo</a></li>
         <li><a href="supercell-wx-nightly.flatpakrepo">supercell-wx-nightly.flatpakrepo</a></li>
-        <li><a href="supercell-wx.gpg">supercell-wx.gpg</a> (public signing key)</li>
+        <li><a href="supercell-wx-flatpak.gpg">supercell-wx-flatpak.gpg</a> (public signing key)</li>
         <li><a href="repo/">repo/</a> (OSTree repository)</li>
       </ul>
       <p class="muted">

--- a/tools/ci/publish-flatpak-repo.sh
+++ b/tools/ci/publish-flatpak-repo.sh
@@ -115,23 +115,94 @@ restore_previous_repo() {
 
 restore_previous_repo
 
+# Return the xa.ref binding embedded in a commit (e.g. app/id/arch/master).
+commit_bound_ref() {
+  local commit="$1"
+  ostree show --repo="${REPO_DIR}" --print-metadata-key=xa.ref "${commit}" 2>/dev/null \
+    | tr -d "'\"" \
+    | tr -d '\n' \
+    || true
+}
+
 import_bundle() {
   local arch="$1"
   local bundle="$2"
-  local ref="app/${APP_ID}/${arch}/${CHANNEL}"
+  local update_appstream="${3:-false}"
+  local dest_ref="app/${APP_ID}/${arch}/${CHANNEL}"
+  local src_ref=""
+  local ref rev bound
+  local -A revs_before
+  revs_before=()
 
-  echo "==> Importing ${bundle} as ${ref}"
+  while IFS= read -r ref; do
+    [[ -z "${ref}" ]] && continue
+    revs_before["${ref}"]="$(ostree rev-parse --repo="${REPO_DIR}" "${ref}")"
+  done < <(ostree refs --repo="${REPO_DIR}" | grep "^app/${APP_ID}/${arch}/" || true)
+
+  echo "==> Importing ${bundle} at its native branch (not rewriting xa.ref yet)"
   flatpak build-import-bundle \
     --gpg-sign="${GPG_KEY_ID}" \
-    --ref="${ref}" \
-    --update-appstream \
     --no-update-summary \
     "${REPO_DIR}" \
     "${bundle}"
+
+  # The native bundle branch is the ref whose commit changed (or appeared) and
+  # whose xa.ref binding matches the ref name. Using --ref= on import only moves
+  # the ref pointer and leaves xa.ref as master, which clients reject.
+  while IFS= read -r ref; do
+    [[ -z "${ref}" ]] && continue
+    rev="$(ostree rev-parse --repo="${REPO_DIR}" "${ref}")"
+    if [[ -z "${revs_before[${ref}]:-}" || "${revs_before[${ref}]}" != "${rev}" ]]; then
+      bound="$(commit_bound_ref "${rev}")"
+      if [[ "${bound}" == "${ref}" ]]; then
+        src_ref="${ref}"
+        break
+      fi
+      # Keep a fallback if xa.ref is missing/unexpected.
+      if [[ -z "${src_ref}" ]]; then
+        src_ref="${ref}"
+      fi
+    fi
+  done < <(ostree refs --repo="${REPO_DIR}" | grep "^app/${APP_ID}/${arch}/" || true)
+
+  if [[ -z "${src_ref}" ]]; then
+    echo "Import of ${bundle} did not update any app/${APP_ID}/${arch}/* refs" >&2
+    ostree refs --repo="${REPO_DIR}" >&2 || true
+    exit 1
+  fi
+
+  if [[ "${src_ref}" != "${dest_ref}" ]]; then
+    echo "==> Rebinding ${src_ref} -> ${dest_ref} (new commit with matching xa.ref)"
+    local appstream_args=()
+    if [[ "${update_appstream}" == "true" ]]; then
+      appstream_args+=(--update-appstream)
+    fi
+    flatpak build-commit-from \
+      --gpg-sign="${GPG_KEY_ID}" \
+      --src-ref="${src_ref}" \
+      --no-update-summary \
+      "${appstream_args[@]}" \
+      "${REPO_DIR}" \
+      "${dest_ref}"
+    echo "==> Deleting temporary ref ${src_ref}"
+    ostree refs --repo="${REPO_DIR}" --delete "${src_ref}"
+  else
+    echo "==> Bundle already on ${dest_ref} with matching ref bindings"
+    if [[ "${update_appstream}" == "true" ]]; then
+      # Refresh appstream from current heads without changing the app commit.
+      flatpak build-commit-from \
+        --gpg-sign="${GPG_KEY_ID}" \
+        --src-ref="${dest_ref}" \
+        --update-appstream \
+        --no-update-summary \
+        "${REPO_DIR}" \
+        "${dest_ref}"
+    fi
+  fi
 }
 
-import_bundle "x86_64" "${BUNDLE_X64}"
-import_bundle "aarch64" "${BUNDLE_AARCH64}"
+import_bundle "x86_64" "${BUNDLE_X64}" false
+import_bundle "aarch64" "${BUNDLE_AARCH64}" true
 
 echo "==> Updating repository summary, deltas, and prune"
 flatpak build-update-repo \

--- a/tools/ci/publish-flatpak-repo.sh
+++ b/tools/ci/publish-flatpak-repo.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Build a dual-arch Flatpak OSTree repo site tree for GitHub Pages.
+#
+# Imports x86_64 + aarch64 bundles onto the given channel (nightly|stable),
+# mirrors any existing Pages repo first, then prunes and writes .flatpakrepo
+# metadata.
+set -euo pipefail
+
+APP_ID="net.supercellwx.app"
+CHANNEL=""
+SITE_DIR=""
+BUNDLE_X64=""
+BUNDLE_AARCH64=""
+PAGES_URL=""
+HOMEPAGE_URL="https://supercellwx.net"
+GPG_KEY_ID=""
+MAX_SITE_BYTES=$((900 * 1024 * 1024))
+
+usage() {
+  cat <<'EOF'
+Usage: publish-flatpak-repo.sh [options]
+
+Required:
+  --channel nightly|stable
+  --site-dir DIR
+  --bundle-x64 PATH
+  --bundle-aarch64 PATH
+  --pages-url URL          Base Pages URL (no trailing slash)
+  --gpg-key-id ID          GPG key id/fingerprint for signing
+
+Optional:
+  --homepage URL           Default: https://supercellwx.net
+  --max-site-bytes N       Fail if site exceeds N bytes (default: 900MiB)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel) CHANNEL="$2"; shift 2 ;;
+    --site-dir) SITE_DIR="$2"; shift 2 ;;
+    --bundle-x64) BUNDLE_X64="$2"; shift 2 ;;
+    --bundle-aarch64) BUNDLE_AARCH64="$2"; shift 2 ;;
+    --pages-url) PAGES_URL="${2%/}"; shift 2 ;;
+    --homepage) HOMEPAGE_URL="$2"; shift 2 ;;
+    --gpg-key-id) GPG_KEY_ID="$2"; shift 2 ;;
+    --max-site-bytes) MAX_SITE_BYTES="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${CHANNEL}" || -z "${SITE_DIR}" || -z "${BUNDLE_X64}" || \
+      -z "${BUNDLE_AARCH64}" || -z "${PAGES_URL}" || -z "${GPG_KEY_ID}" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ "${CHANNEL}" != "nightly" && "${CHANNEL}" != "stable" ]]; then
+  echo "Channel must be 'nightly' or 'stable' (got '${CHANNEL}')." >&2
+  exit 2
+fi
+
+for bundle in "${BUNDLE_X64}" "${BUNDLE_AARCH64}"; do
+  if [[ ! -f "${bundle}" ]]; then
+    echo "Bundle not found: ${bundle}" >&2
+    exit 1
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INDEX_HTML="${SCRIPT_DIR}/flatpak-pages/index.html"
+if [[ ! -f "${INDEX_HTML}" ]]; then
+  echo "Missing index template: ${INDEX_HTML}" >&2
+  exit 1
+fi
+
+REPO_DIR="${SITE_DIR}/repo"
+REPO_URL="${PAGES_URL}/repo/"
+
+echo "==> Preparing site directory: ${SITE_DIR}"
+rm -rf "${SITE_DIR}"
+mkdir -p "${SITE_DIR}"
+
+restore_previous_repo() {
+  echo "==> Checking for existing OSTree repo at ${REPO_URL}"
+  if curl -fsI "${PAGES_URL}/repo/config" >/dev/null 2>&1; then
+    echo "==> Mirroring existing repo from Pages (GPG-verified with ${GPG_KEY_ID})"
+    ostree init --repo="${REPO_DIR}" --mode=archive-z2
+    # Verify commits with the same key we use for signing. Export to a keyring
+    # file because ostree remote --gpg-import expects a path.
+    local gpg_import
+    gpg_import="$(mktemp)"
+    gpg --batch --export "${GPG_KEY_ID}" > "${gpg_import}"
+    ostree remote add \
+      --repo="${REPO_DIR}" \
+      --gpg-import="${gpg_import}" \
+      pages "${REPO_URL}"
+    rm -f "${gpg_import}"
+    if ostree pull --repo="${REPO_DIR}" --mirror pages; then
+      ostree remote delete --repo="${REPO_DIR}" pages || true
+      return 0
+    fi
+    echo "Warning: mirror pull failed; initializing a fresh repo" >&2
+    rm -rf "${REPO_DIR}"
+  else
+    echo "==> No existing Pages repo found"
+  fi
+  ostree init --repo="${REPO_DIR}" --mode=archive-z2
+}
+
+restore_previous_repo
+
+import_bundle() {
+  local arch="$1"
+  local bundle="$2"
+  local ref="app/${APP_ID}/${arch}/${CHANNEL}"
+
+  echo "==> Importing ${bundle} as ${ref}"
+  flatpak build-import-bundle \
+    --gpg-sign="${GPG_KEY_ID}" \
+    --ref="${ref}" \
+    --update-appstream \
+    --no-update-summary \
+    "${REPO_DIR}" \
+    "${bundle}"
+}
+
+import_bundle "x86_64" "${BUNDLE_X64}"
+import_bundle "aarch64" "${BUNDLE_AARCH64}"
+
+echo "==> Updating repository summary, deltas, and prune"
+flatpak build-update-repo \
+  --gpg-sign="${GPG_KEY_ID}" \
+  --generate-static-deltas \
+  --prune \
+  --prune-depth=1 \
+  "${REPO_DIR}"
+
+echo "==> Writing public GPG key and .flatpakrepo files"
+gpg --export --armor "${GPG_KEY_ID}" > "${SITE_DIR}/supercell-wx.gpg"
+GPG_KEY_BASE64="$(gpg --export "${GPG_KEY_ID}" | base64 -w0)"
+
+write_flatpakrepo() {
+  local path="$1"
+  local title="$2"
+  local default_branch="$3"
+  cat > "${path}" <<EOF
+[Flatpak Repo]
+Title=${title}
+Url=${REPO_URL}
+Homepage=${HOMEPAGE_URL}
+GPGKey=${GPG_KEY_BASE64}
+DefaultBranch=${default_branch}
+EOF
+}
+
+write_flatpakrepo \
+  "${SITE_DIR}/supercell-wx.flatpakrepo" \
+  "Supercell Wx" \
+  "stable"
+write_flatpakrepo \
+  "${SITE_DIR}/supercell-wx-nightly.flatpakrepo" \
+  "Supercell Wx Nightly" \
+  "nightly"
+
+cp "${INDEX_HTML}" "${SITE_DIR}/index.html"
+# Actions Pages does not run Jekyll, but keep this for safety if hosting changes.
+touch "${SITE_DIR}/.nojekyll"
+
+SITE_BYTES="$(du -sb "${SITE_DIR}" | awk '{print $1}')"
+echo "==> Site size: ${SITE_BYTES} bytes"
+if [[ "${SITE_BYTES}" -gt "${MAX_SITE_BYTES}" ]]; then
+  echo "ERROR: Flatpak Pages site is ${SITE_BYTES} bytes (limit ${MAX_SITE_BYTES})." >&2
+  echo "Prune failed to keep size in check; see the VPS migration runbook." >&2
+  exit 1
+fi
+
+echo "==> Refs in repo:"
+ostree refs --repo="${REPO_DIR}" || true
+echo "==> Flatpak Pages site ready at ${SITE_DIR}"

--- a/tools/ci/publish-flatpak-repo.sh
+++ b/tools/ci/publish-flatpak-repo.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Build a dual-arch Flatpak OSTree repo site tree for GitHub Pages.
 #
-# Imports x86_64 + aarch64 bundles onto the given channel (nightly|stable),
-# mirrors any existing Pages repo first, then prunes and writes .flatpakrepo
-# metadata.
+# Imports x86_64 + aarch64 bundles onto the given channel (nightly|stable):
+# each bundle is unpacked in a scratch OSTree repo, then published into the
+# live repo with build-commit-from so only the channel ref is updated. Mirrors
+# any existing Pages repo first, then prunes and writes .flatpakrepo metadata.
 set -euo pipefail
 
 APP_ID="net.supercellwx.app"
@@ -88,117 +89,101 @@ mkdir -p "${SITE_DIR}"
 
 restore_previous_repo() {
   echo "==> Checking for existing OSTree repo at ${REPO_URL}"
-  if curl -fsI "${PAGES_URL}/repo/config" >/dev/null 2>&1; then
-    echo "==> Mirroring existing repo from Pages (GPG-verified with ${GPG_KEY_ID})"
-    ostree init --repo="${REPO_DIR}" --mode=archive-z2
-    # Verify commits with the same key we use for signing. Export to a keyring
-    # file because ostree remote --gpg-import expects a path.
-    local gpg_import
-    gpg_import="$(mktemp)"
-    gpg --batch --export "${GPG_KEY_ID}" > "${gpg_import}"
-    ostree remote add \
+  local http_code curl_status=0
+  http_code="$(curl -sS -o /dev/null -w "%{http_code}" -I "${PAGES_URL}/repo/config")" \
+    || curl_status=$?
+
+  if (( curl_status != 0 )); then
+    echo "ERROR: Failed to reach ${PAGES_URL}/repo/config (curl exit ${curl_status})." >&2
+    exit 1
+  fi
+
+  case "${http_code}" in
+    404)
+      echo "==> No existing Pages repo found (HTTP 404); initializing a fresh repo"
+      ostree init --repo="${REPO_DIR}" --mode=archive-z2
+      return 0
+      ;;
+    200|301|302|303|307|308)
+      ;;
+    *)
+      echo "ERROR: Unexpected HTTP ${http_code} checking ${PAGES_URL}/repo/config" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "==> Mirroring existing repo from Pages (GPG-verified with ${GPG_KEY_ID})"
+  ostree init --repo="${REPO_DIR}" --mode=archive-z2
+  # Verify commits with the same key we use for signing. Export to a keyring
+  # file because ostree remote --gpg-import expects a path.
+  local gpg_import
+  gpg_import="$(mktemp)"
+  gpg --batch --export "${GPG_KEY_ID}" > "${gpg_import}"
+  if ! ostree remote add \
       --repo="${REPO_DIR}" \
       --gpg-import="${gpg_import}" \
-      pages "${REPO_URL}"
+      pages "${REPO_URL}"; then
     rm -f "${gpg_import}"
-    if ostree pull --repo="${REPO_DIR}" --mirror pages; then
-      ostree remote delete --repo="${REPO_DIR}" pages || true
-      return 0
-    fi
-    echo "Warning: mirror pull failed; initializing a fresh repo" >&2
-    rm -rf "${REPO_DIR}"
-  else
-    echo "==> No existing Pages repo found"
+    echo "ERROR: Failed to add Pages OSTree remote ${REPO_URL}" >&2
+    exit 1
   fi
-  ostree init --repo="${REPO_DIR}" --mode=archive-z2
+  rm -f "${gpg_import}"
+
+  if ! ostree pull --repo="${REPO_DIR}" --mirror pages; then
+    echo "ERROR: Failed to mirror existing Flatpak repo from ${REPO_URL}" >&2
+    exit 1
+  fi
+  ostree remote delete --repo="${REPO_DIR}" pages || true
 }
 
 restore_previous_repo
 
-# Return the xa.ref binding embedded in a commit (e.g. app/id/arch/master).
-commit_bound_ref() {
-  local commit="$1"
-  ostree show --repo="${REPO_DIR}" --print-metadata-key=xa.ref "${commit}" 2>/dev/null \
-    | tr -d "'\"" \
-    | tr -d '\n' \
-    || true
-}
-
+# Import a bundle into a disposable scratch repo, then publish only the channel
+# ref into REPO_DIR via build-commit-from. That keeps temporary native refs
+# (e.g. master, or nightly when publishing stable) out of the live repository
+# so we never delete another channel's published ref.
 import_bundle() {
   local arch="$1"
   local bundle="$2"
   local update_appstream="${3:-false}"
   local dest_ref="app/${APP_ID}/${arch}/${CHANNEL}"
-  local src_ref=""
-  local ref rev bound
-  local -A revs_before
-  revs_before=()
+  local scratch src_ref
+  local appstream_args=()
 
-  while IFS= read -r ref; do
-    [[ -z "${ref}" ]] && continue
-    revs_before["${ref}"]="$(ostree rev-parse --repo="${REPO_DIR}" "${ref}")"
-  done < <(ostree refs --repo="${REPO_DIR}" | grep "^app/${APP_ID}/${arch}/" || true)
+  scratch="$(mktemp -d "${TMPDIR:-/tmp}/flatpak-scratch.XXXXXX")"
+  # shellcheck disable=SC2064
+  trap "rm -rf -- $(printf '%q' "${scratch}")" RETURN
 
-  echo "==> Importing ${bundle} at its native branch (not rewriting xa.ref yet)"
+  echo "==> Importing ${bundle} into scratch repo"
+  ostree init --repo="${scratch}" --mode=archive-z2
   flatpak build-import-bundle \
-    --gpg-sign="${GPG_KEY_ID}" \
     --no-update-summary \
-    "${REPO_DIR}" \
+    "${scratch}" \
     "${bundle}"
 
-  # The native bundle branch is the ref whose commit changed (or appeared) and
-  # whose xa.ref binding matches the ref name. Using --ref= on import only moves
-  # the ref pointer and leaves xa.ref as master, which clients reject.
-  while IFS= read -r ref; do
-    [[ -z "${ref}" ]] && continue
-    rev="$(ostree rev-parse --repo="${REPO_DIR}" "${ref}")"
-    if [[ -z "${revs_before[${ref}]:-}" || "${revs_before[${ref}]}" != "${rev}" ]]; then
-      bound="$(commit_bound_ref "${rev}")"
-      if [[ "${bound}" == "${ref}" ]]; then
-        src_ref="${ref}"
-        break
-      fi
-      # Keep a fallback if xa.ref is missing/unexpected.
-      if [[ -z "${src_ref}" ]]; then
-        src_ref="${ref}"
-      fi
-    fi
-  done < <(ostree refs --repo="${REPO_DIR}" | grep "^app/${APP_ID}/${arch}/" || true)
-
+  src_ref="$(ostree refs --repo="${scratch}" \
+    | grep "^app/${APP_ID}/${arch}/" \
+    | head -n1 \
+    || true)"
   if [[ -z "${src_ref}" ]]; then
-    echo "Import of ${bundle} did not update any app/${APP_ID}/${arch}/* refs" >&2
-    ostree refs --repo="${REPO_DIR}" >&2 || true
-    exit 1
+    echo "Scratch import of ${bundle} produced no app/${APP_ID}/${arch}/* ref" >&2
+    ostree refs --repo="${scratch}" >&2 || true
+    return 1
   fi
 
-  if [[ "${src_ref}" != "${dest_ref}" ]]; then
-    echo "==> Rebinding ${src_ref} -> ${dest_ref} (new commit with matching xa.ref)"
-    local appstream_args=()
-    if [[ "${update_appstream}" == "true" ]]; then
-      appstream_args+=(--update-appstream)
-    fi
-    flatpak build-commit-from \
-      --gpg-sign="${GPG_KEY_ID}" \
-      --src-ref="${src_ref}" \
-      --no-update-summary \
-      "${appstream_args[@]}" \
-      "${REPO_DIR}" \
-      "${dest_ref}"
-    echo "==> Deleting temporary ref ${src_ref}"
-    ostree refs --repo="${REPO_DIR}" --delete "${src_ref}"
-  else
-    echo "==> Bundle already on ${dest_ref} with matching ref bindings"
-    if [[ "${update_appstream}" == "true" ]]; then
-      # Refresh appstream from current heads without changing the app commit.
-      flatpak build-commit-from \
-        --gpg-sign="${GPG_KEY_ID}" \
-        --src-ref="${dest_ref}" \
-        --update-appstream \
-        --no-update-summary \
-        "${REPO_DIR}" \
-        "${dest_ref}"
-    fi
+  if [[ "${update_appstream}" == "true" ]]; then
+    appstream_args+=(--update-appstream)
   fi
+
+  echo "==> Publishing scratch ${src_ref} -> live ${dest_ref}"
+  flatpak build-commit-from \
+    --gpg-sign="${GPG_KEY_ID}" \
+    --src-repo="${scratch}" \
+    --src-ref="${src_ref}" \
+    --no-update-summary \
+    "${appstream_args[@]}" \
+    "${REPO_DIR}" \
+    "${dest_ref}"
 }
 
 import_bundle "x86_64" "${BUNDLE_X64}" false
@@ -213,7 +198,7 @@ flatpak build-update-repo \
   "${REPO_DIR}"
 
 echo "==> Writing public GPG key and .flatpakrepo files"
-gpg --export --armor "${GPG_KEY_ID}" > "${SITE_DIR}/supercell-wx.gpg"
+gpg --export --armor "${GPG_KEY_ID}" > "${SITE_DIR}/supercell-wx-flatpak.gpg"
 GPG_KEY_BASE64="$(gpg --export "${GPG_KEY_ID}" | base64 -w0)"
 
 write_flatpakrepo() {

--- a/tools/net.supercellwx.app.yml
+++ b/tools/net.supercellwx.app.yml
@@ -9,15 +9,18 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 net.supercellwx.app.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 net.supercellwx.app.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 scwx-256.png /app/share/icons/hicolor/256x256/apps/net.supercellwx.app.png
       - install -Dm644 scwx-64.png /app/share/icons/hicolor/64x64/apps/net.supercellwx.app.png
-      - rm net.supercellwx.app.desktop scwx-256.png scwx-64.png
+      - rm net.supercellwx.app.desktop net.supercellwx.app.metainfo.xml scwx-256.png scwx-64.png
       - cp -r * /app/
     sources:
       - type: dir
         path: ../../supercell-wx-flatpak
       - type: file
         path: ../scwx-qt/res/linux/net.supercellwx.app.desktop
+      - type: file
+        path: ../scwx-qt/res/linux/net.supercellwx.app.metainfo.xml
       - type: file
         path: ../scwx-qt/res/icons/scwx-256.png
       - type: file


### PR DESCRIPTION
## New Features

- Added Stable and Nightly Flatpak repositories with dual-architecture support.
- Added GitHub Pages publishing for Flatpak repositories.
- Added installation and update instructions for Flatpak users.
- Added AppStream metadata, including app details, screenshots, links, and release information.

## Improvements

- Flatpak bundles now explicitly target the Nightly branch.
- Improved Linux desktop integration through standardized icon metadata.