### PR TITLE
Generate AppStream metainfo version/date from the versions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,9 @@ jobs:
       shell: bash
       run: |
         cp -r ${{ env.INSTALL_DIR }} ${{ env.FLATPAK_DIR }}
+        # Stage generated AppStream metainfo into the Flatpak source dir
+        cp "${{ github.workspace }}/build/scwx-qt/res/linux/net.supercellwx.app.metainfo.xml" \
+           "${{ env.FLATPAK_DIR }}/"
         # Copy krb5 libraries to flatpak
         cp -a /usr/lib/*/libkrb5.so* \
               /usr/lib/*/libkrb5support.so* \

--- a/scwx-qt/res/linux/net.supercellwx.app.metainfo.xml.in
+++ b/scwx-qt/res/linux/net.supercellwx.app.metainfo.xml.in
@@ -42,6 +42,6 @@
   </provides>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="0.6.0" date="2026-06-05"/>
+    <release version="${version_string}" date="${release_date}"/>
   </releases>
 </component>

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -517,6 +517,8 @@ set(COUNTIES_SQLITE_DB ${scwx-qt_BINARY_DIR}/res/db/counties.db)
 
 set(RESOURCE_INPUT  ${scwx-qt_SOURCE_DIR}/res/scwx-qt.rc.in)
 set(RESOURCE_OUTPUT ${scwx-qt_BINARY_DIR}/res/scwx-qt.rc)
+set(METAINFO_INPUT  ${scwx-qt_SOURCE_DIR}/res/linux/net.supercellwx.app.metainfo.xml.in)
+set(METAINFO_OUTPUT ${scwx-qt_BINARY_DIR}/res/linux/net.supercellwx.app.metainfo.xml)
 set(VERSIONS_INPUT  ${scwx-qt_SOURCE_DIR}/source/scwx/qt/main/versions.hpp.in)
 set(VERSIONS_CACHE  ${scwx-qt_BINARY_DIR}/versions_cache.json)
 set(VERSIONS_HEADER ${scwx-qt_BINARY_DIR}/scwx/qt/main/versions.hpp)
@@ -640,7 +642,10 @@ else()
 endif()
 
 if (WIN32)
-    add_custom_command(OUTPUT  ${VERSIONS_HEADER} ${RESOURCE_OUTPUT} ${VERSIONS_HEADER}-ALWAYS_RUN
+    add_custom_command(OUTPUT  ${VERSIONS_HEADER}
+                               ${RESOURCE_OUTPUT}
+                               ${METAINFO_OUTPUT}
+                               ${VERSIONS_HEADER}-ALWAYS_RUN
                        COMMAND ${Python_EXECUTABLE}
                                ${scwx-qt_SOURCE_DIR}/tools/generate_versions.py
                                -g ${SCWX_DIR}
@@ -650,9 +655,13 @@ if (WIN32)
                                -o ${VERSIONS_HEADER}
                                -b ${SCWX_BUILD_NUM}
                                --input-resource ${RESOURCE_INPUT}
-                               --output-resource ${RESOURCE_OUTPUT})
+                               --output-resource ${RESOURCE_OUTPUT}
+                               --input-metainfo ${METAINFO_INPUT}
+                               --output-metainfo ${METAINFO_OUTPUT})
 else()
-    add_custom_command(OUTPUT  ${VERSIONS_HEADER} ${VERSIONS_HEADER}-ALWAYS_RUN
+    add_custom_command(OUTPUT  ${VERSIONS_HEADER}
+                               ${METAINFO_OUTPUT}
+                               ${VERSIONS_HEADER}-ALWAYS_RUN
                        COMMAND ${Python_EXECUTABLE}
                                ${scwx-qt_SOURCE_DIR}/tools/generate_versions.py
                                -g ${SCWX_DIR}
@@ -660,7 +669,9 @@ else()
                                -c ${VERSIONS_CACHE}
                                -i ${VERSIONS_INPUT}
                                -o ${VERSIONS_HEADER}
-                               -b ${SCWX_BUILD_NUM})
+                               -b ${SCWX_BUILD_NUM}
+                               --input-metainfo ${METAINFO_INPUT}
+                               --output-metainfo ${METAINFO_OUTPUT})
 endif()
 
 add_custom_target(scwx-qt_generate_versions ALL
@@ -723,7 +734,7 @@ elseif (APPLE)
                           MACOSX_BUNDLE_INFO_PLIST           "${scwx-qt_SOURCE_DIR}/res/scwx-qt.plist.in"
                           MACOSX_BUNDLE_GUI_IDENTIFIER       "net.supercellwx.app"
                           MACOSX_BUNDLE_BUNDLE_NAME          "Supercell Wx"
-                          MACOSX_BUNDLE_BUNDLE_VERSION       "${SCWX_VERSION}"
+                          MACOSX_BUNDLE_BUNDLE_VERSION       "${SCWX_BUILD_NUM}"
                           MACOSX_BUNDLE_SHORT_VERSION_STRING "${SCWX_VERSION}"
                           MACOSX_BUNDLE_COPYRIGHT            "Copyright ${CURRENT_YEAR} Dan Paulat"
                           MACOSX_BUNDLE_ICON_FILE            "scwx.icns"

--- a/scwx-qt/tools/generate_versions.py
+++ b/scwx-qt/tools/generate_versions.py
@@ -137,7 +137,7 @@ def CollectVersionInfo(args):
 
     commitString = str(repo.head.commit)[:10]
     releaseDate  = datetime.datetime.fromtimestamp(
-        repo.head.commit.committed_date).strftime("%Y-%m-%d")
+        repo.head.commit.committed_date, tz=datetime.timezone.utc).strftime("%Y-%m-%d")
 
     if not repo.is_dirty(submodules = False):
         copyrightYear = datetime.datetime.fromtimestamp(repo.head.commit.committed_date).year
@@ -211,13 +211,13 @@ def WriteHeader(versionInfo: VersionInfo, args):
     return WriteTemplate(versionInfo, args.inputHeader_, args.outputHeader_)
 
 def WriteResource(versionInfo: VersionInfo, args):
-    if args.inputResource_ == None or args.outputResource_ == None:
+    if args.inputResource_ is None or args.outputResource_ is None:
         return None
     print("Writing resource")
     return WriteTemplate(versionInfo, args.inputResource_, args.outputResource_)
 
 def WriteMetainfo(versionInfo: VersionInfo, args):
-    if args.inputMetainfo_ == None or args.outputMetainfo_ == None:
+    if args.inputMetainfo_ is None or args.outputMetainfo_ is None:
         return None
     print("Writing metainfo")
     return WriteTemplate(versionInfo, args.inputMetainfo_, args.outputMetainfo_)
@@ -259,9 +259,9 @@ def main() -> int:
 
         if writeHeaderStatus or writeResourceStatus or writeMetainfoStatus:
             UpdateCache(versionInfo, args)
-        if writeHeaderStatus == False or \
-           writeResourceStatus == False or \
-           writeMetainfoStatus == False:
+        if not writeHeaderStatus or \
+           not writeResourceStatus or \
+           not writeMetainfoStatus:
             status = -1
 
     return status

--- a/scwx-qt/tools/generate_versions.py
+++ b/scwx-qt/tools/generate_versions.py
@@ -10,6 +10,7 @@ class Keys:
     BuildNumber   = "build_number"
     CommitString  = "commit_string"
     CopyrightYear = "copyright_year"
+    ReleaseDate   = "release_date"
     ResourceDir   = "resource_dir"
     VersionCommas = "version_commas"
     VersionString = "version_string"
@@ -19,6 +20,7 @@ class VersionInfo:
         self.buildNumber_   = None
         self.commitString_  = None
         self.copyrightYear_ = None
+        self.releaseDate_   = None
         self.resourceDir_   = None
         self.versionCommas_ = None
         self.versionString_ = None
@@ -28,6 +30,7 @@ class VersionInfo:
             return self.buildNumber_ == other.buildNumber_ and \
                 self.commitString_ == other.commitString_ and \
                 self.copyrightYear_ == other.copyrightYear_ and \
+                self.releaseDate_ == other.releaseDate_ and \
                 self.resourceDir_ == other.resourceDir_ and \
                 self.versionString_ == other.versionString_
 
@@ -42,6 +45,8 @@ class VersionInfo:
                 return self.commitString_
             case Keys.CopyrightYear:
                 return self.copyrightYear_
+            case Keys.ReleaseDate:
+                return self.releaseDate_
             case Keys.ResourceDir:
                 return self.resourceDir_
             case Keys.VersionCommas:
@@ -54,6 +59,7 @@ class VersionInfo:
 kKeys_ = [Keys.BuildNumber,
           Keys.CommitString,
           Keys.CopyrightYear,
+          Keys.ReleaseDate,
           Keys.ResourceDir,
           Keys.VersionCommas,
           Keys.VersionString]
@@ -102,6 +108,18 @@ def ParseArguments():
                         dest     = "outputResource_",
                         default  = None,
                         type     = pathlib.Path)
+    parser.add_argument("--input-metainfo",
+                        metavar  = "filename",
+                        help     = "input metainfo template",
+                        dest     = "inputMetainfo_",
+                        default  = None,
+                        type     = pathlib.Path)
+    parser.add_argument("--output-metainfo",
+                        metavar  = "filename",
+                        help     = "output metainfo",
+                        dest     = "outputMetainfo_",
+                        default  = None,
+                        type     = pathlib.Path)
     parser.add_argument("-v", "--version",
                         metavar  = "version",
                         help     = "version string",
@@ -118,6 +136,8 @@ def CollectVersionInfo(args):
     repo = git.Repo(args.gitRepo_, search_parent_directories = True)
 
     commitString = str(repo.head.commit)[:10]
+    releaseDate  = datetime.datetime.fromtimestamp(
+        repo.head.commit.committed_date).strftime("%Y-%m-%d")
 
     if not repo.is_dirty(submodules = False):
         copyrightYear = datetime.datetime.fromtimestamp(repo.head.commit.committed_date).year
@@ -130,6 +150,7 @@ def CollectVersionInfo(args):
     versionInfo.buildNumber_   = args.buildNumber_
     versionInfo.commitString_  = commitString
     versionInfo.copyrightYear_ = copyrightYear
+    versionInfo.releaseDate_   = releaseDate
     versionInfo.resourceDir_   = resourceDir
     versionInfo.versionString_ = args.version_
 
@@ -138,6 +159,7 @@ def CollectVersionInfo(args):
     print("Build Number: " + str(versionInfo.buildNumber_))
     print("Commit String: " + str(versionInfo.commitString_))
     print("Copyright Year: " + str(versionInfo.copyrightYear_))
+    print("Release Date: " + str(versionInfo.releaseDate_))
     print("Version String: " + str(versionInfo.versionString_))
 
     return versionInfo
@@ -157,6 +179,8 @@ def LoadCache(args):
                 cache.commitString_ = data[Keys.CommitString]
             if Keys.CopyrightYear in data:
                 cache.copyrightYear_ = data[Keys.CopyrightYear]
+            if Keys.ReleaseDate in data:
+                cache.releaseDate_ = data[Keys.ReleaseDate]
             if Keys.ResourceDir in data:
                 cache.resourceDir_ = data[Keys.ResourceDir]
             if Keys.VersionString in data:
@@ -177,7 +201,7 @@ def WriteTemplate(versionInfo: VersionInfo, inputFile, outputFile):
                     line = line.replace("${" + key + "}", str(versionInfo.Value(key)))
                 fo.write(line)
     except Exception as ex:
-        print("Error writing header: " + repr(ex))
+        print("Error writing template: " + repr(ex))
         return False
 
     return True
@@ -192,6 +216,12 @@ def WriteResource(versionInfo: VersionInfo, args):
     print("Writing resource")
     return WriteTemplate(versionInfo, args.inputResource_, args.outputResource_)
 
+def WriteMetainfo(versionInfo: VersionInfo, args):
+    if args.inputMetainfo_ == None or args.outputMetainfo_ == None:
+        return None
+    print("Writing metainfo")
+    return WriteTemplate(versionInfo, args.inputMetainfo_, args.outputMetainfo_)
+
 def UpdateCache(versionInfo: VersionInfo, args):
     print("Updating cache")
 
@@ -199,6 +229,7 @@ def UpdateCache(versionInfo: VersionInfo, args):
     data[Keys.BuildNumber]   = versionInfo.buildNumber_
     data[Keys.CommitString]  = versionInfo.commitString_
     data[Keys.CopyrightYear] = versionInfo.copyrightYear_
+    data[Keys.ReleaseDate]   = versionInfo.releaseDate_
     data[Keys.ResourceDir]   = versionInfo.resourceDir_
     data[Keys.VersionString] = versionInfo.versionString_
 
@@ -218,15 +249,19 @@ def main() -> int:
 
     if versionInfo == cache and \
        (args.outputHeader_ is None or os.path.exists(args.outputHeader_)) and \
-       (args.outputResource_ is None or os.path.exists(args.outputResource_)):
+       (args.outputResource_ is None or os.path.exists(args.outputResource_)) and \
+       (args.outputMetainfo_ is None or os.path.exists(args.outputMetainfo_)):
         print("No version changes detected")
     else:
         writeHeaderStatus   = WriteHeader(versionInfo, args)
         writeResourceStatus = WriteResource(versionInfo, args)
+        writeMetainfoStatus = WriteMetainfo(versionInfo, args)
 
-        if writeHeaderStatus or writeResourceStatus:
+        if writeHeaderStatus or writeResourceStatus or writeMetainfoStatus:
             UpdateCache(versionInfo, args)
-        if writeHeaderStatus == False or writeResourceStatus == False:
+        if writeHeaderStatus == False or \
+           writeResourceStatus == False or \
+           writeMetainfoStatus == False:
             status = -1
 
     return status

--- a/scwx-qt/tools/generate_versions.py
+++ b/scwx-qt/tools/generate_versions.py
@@ -259,9 +259,9 @@ def main() -> int:
 
         if writeHeaderStatus or writeResourceStatus or writeMetainfoStatus:
             UpdateCache(versionInfo, args)
-        if not writeHeaderStatus or \
-           not writeResourceStatus or \
-           not writeMetainfoStatus:
+        if writeHeaderStatus == False or \
+           writeResourceStatus == False or \
+           writeMetainfoStatus == False:
             status = -1
 
     return status

--- a/tools/net.supercellwx.app.yml
+++ b/tools/net.supercellwx.app.yml
@@ -16,11 +16,10 @@ modules:
       - cp -r * /app/
     sources:
       - type: dir
+        # Includes generated net.supercellwx.app.metainfo.xml staged by CI
         path: ../../supercell-wx-flatpak
       - type: file
         path: ../scwx-qt/res/linux/net.supercellwx.app.desktop
-      - type: file
-        path: ../scwx-qt/res/linux/net.supercellwx.app.metainfo.xml
       - type: file
         path: ../scwx-qt/res/icons/scwx-256.png
       - type: file


### PR DESCRIPTION
Use the git HEAD commit date for release_date, stage the generated metainfo for Flatpak in CI, and set macOS CFBundleVersion to SCWX_BUILD_NUM.