### PR TITLE
NixOS Packaging Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,15 +375,19 @@ jobs:
                     GitPython `
                     conan
 
-    - name: Cache Conan Packages
-      uses: actions/cache@v6
+    - name: Restore Conan Packages
+      id: cache-conan
+      uses: actions/cache/restore@v6
       with:
         path: ~/.conan2
         key: build-v2-${{ matrix.conan_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
 
     - name: Install Conan Packages
+      id: conan-install
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         conan config install `
           ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
           -tf profiles
@@ -398,6 +402,13 @@ jobs:
           --output-folder ./conan/ `
           ${{ matrix.conan_package_manager }}
         conan cache clean
+
+    - name: Save Conan Packages
+      if: steps.conan-install.outcome == 'success' && steps.cache-conan.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.conan2
+        key: ${{ steps.cache-conan.outputs.cache-primary-key }}
 
     - name: Build Supercell Wx
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             conan_profile: scwx-linux_gcc-11
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-11-x64
-            compiler_packages: ''
+            compiler_packages: g++-11
           - name: linux_gcc-13_x64
             os: ubuntu-24.04
             build_type: Release
@@ -93,7 +93,61 @@ jobs:
             conan_profile: scwx-linux_gcc-13
             appimage_arch: x86_64
             artifact_suffix: linux-gcc-13-x64
-            compiler_packages: ''
+            compiler_packages: g++-13
+          - name: linux_gcc-14_x64
+            os: ubuntu-24.04
+            build_type: Release
+            env_cc: gcc-14
+            env_cxx: g++-14
+            compiler: gcc
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_gcc-14
+            appimage_arch: x86_64
+            artifact_suffix: linux-gcc-14-x64
+            compiler_packages: g++-14
+          - name: linux_gcc-15_x64
+            os: ubuntu-26.04
+            build_type: Release
+            env_cc: gcc-15
+            env_cxx: g++-15
+            compiler: gcc
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_gcc-15
+            appimage_arch: x86_64
+            artifact_suffix: linux-gcc-15-x64
+            compiler_packages: g++-15
+          - name: linux_gcc-16_x64
+            os: ubuntu-26.04
+            build_type: Release
+            env_cc: gcc-16
+            env_cxx: g++-16
+            compiler: gcc
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_gcc-16
+            appimage_arch: x86_64
+            artifact_suffix: linux-gcc-16-x64
+            compiler_packages: g++-16
           - name: linux_clang-18_x64
             os: ubuntu-24.04
             build_type: Release
@@ -112,6 +166,78 @@ jobs:
             appimage_arch: x86_64
             artifact_suffix: linux-clang-18-x64
             compiler_packages: clang-18
+          - name: linux_clang-19_x64
+            os: ubuntu-24.04
+            build_type: Release
+            env_cc: clang-19
+            env_cxx: clang++-19
+            compiler: clang
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_clang-19
+            appimage_arch: x86_64
+            artifact_suffix: linux-clang-19-x64
+            compiler_packages: clang-19
+          - name: linux_clang-20_x64
+            os: ubuntu-24.04
+            build_type: Release
+            env_cc: clang-20
+            env_cxx: clang++-20
+            compiler: clang
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_clang-20
+            appimage_arch: x86_64
+            artifact_suffix: linux-clang-20-x64
+            compiler_packages: clang-20
+          - name: linux_clang-21_x64
+            os: ubuntu-26.04
+            build_type: Release
+            env_cc: clang-21
+            env_cxx: clang++-21
+            compiler: clang
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_clang-21
+            appimage_arch: x86_64
+            artifact_suffix: linux-clang-21-x64
+            compiler_packages: clang-21
+          - name: linux_clang-22_x64
+            os: ubuntu-26.04
+            build_type: Release
+            env_cc: clang-22
+            env_cxx: clang++-22
+            compiler: clang
+            cppflags: ''
+            ldflags: ''
+            qt_version: 6.11.1
+            qt_arch_aqt: linux_gcc_64
+            qt_arch_dir: gcc_64
+            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
+            qt_tools: ''
+            conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
+            conan_profile: scwx-linux_clang-22
+            appimage_arch: x86_64
+            artifact_suffix: linux-clang-22-x64
+            compiler_packages: clang-22
           - name: linux_gcc-13_arm64
             os: ubuntu-24.04-arm
             build_type: Release

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -86,15 +86,19 @@ jobs:
                     conan
         pip install --break-system-packages clang-tidy-review/post/clang_tidy_review
 
-    - name: Cache Conan Packages
-      uses: actions/cache@v6
+    - name: Restore Conan Packages
+      id: cache-conan
+      uses: actions/cache/restore@v6
       with:
         path: ~/.conan2
         key: build-v2-${{ matrix.conan_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
 
     - name: Install Conan Packages
+      id: conan-install
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         conan config install `
           ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
           -tf profiles
@@ -109,6 +113,13 @@ jobs:
           --output-folder ./conan/ `
           ${{ matrix.conan_package_manager }}
         conan cache clean
+
+    - name: Save Conan Packages
+      if: steps.conan-install.outcome == 'success' && steps.cache-conan.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.conan2
+        key: ${{ steps.cache-conan.outputs.cache-primary-key }}
 
     - name: Autogenerate
       shell: pwsh

--- a/.github/workflows/sign-windows-packages.yml
+++ b/.github/workflows/sign-windows-packages.yml
@@ -90,6 +90,8 @@ jobs:
     - name: Install Conan Packages
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         conan config install `
           ./source/tools/conan/profiles/${{ matrix.conan_profile }} `
           -tf profiles

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -792,12 +792,14 @@ target_compile_options(supercell-wx PRIVATE
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14>>:-Wno-maybe-uninitialized>
 )
 
-# Temporary workaround for Boost and GCC 16+ where -Warray-bounds causes false positives
+# Temporary workaround for Boost and GCC 16+ where -Warray-bounds and -Wstringop-overflow cause false positives
 target_compile_options(scwx-qt PRIVATE
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-array-bounds>
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-stringop-overflow>
 )
 target_compile_options(supercell-wx PRIVATE
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-array-bounds>
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-stringop-overflow>
 )
 
 if (MSVC)

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -13,13 +13,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 OPTION(SCWX_DISABLE_CONSOLE "Disables the Windows console in release mode" ON)
 
-find_package(Boost)
+find_package(Boost
+             COMPONENTS atomic
+                        json
+                        program_options
+                        timer
+             REQUIRED)
 find_package(Fontconfig)
-find_package(geographiclib)
+find_package(GeographicLib)
 find_package(geos)
 find_package(glm)
 find_package(JPEG)
 find_package(OpenGL REQUIRED)
+find_package(PNG)
 find_package(Python COMPONENTS Interpreter)
 find_package(SQLite3)
 find_package(TIFF)
@@ -869,6 +875,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
                                      glm::glm
                                      imgui
                                      JPEG::JPEG
+                                     PNG::PNG
                                      qt6ct-common
                                      qt6ct-widgets
                                      SQLite::SQLite3

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -19,16 +19,16 @@ find_package(Boost
                         program_options
                         timer
              REQUIRED)
-find_package(Fontconfig)
-find_package(GeographicLib)
-find_package(geos)
-find_package(glm)
-find_package(JPEG)
+find_package(Fontconfig REQUIRED)
+find_package(GeographicLib REQUIRED)
+find_package(geos REQUIRED)
+find_package(glm REQUIRED)
+find_package(JPEG REQUIRED)
 find_package(OpenGL REQUIRED)
-find_package(PNG)
+find_package(PNG REQUIRED)
 find_package(Python COMPONENTS Interpreter)
-find_package(SQLite3)
-find_package(TIFF)
+find_package(SQLite3 REQUIRED)
+find_package(TIFF REQUIRED)
 
 find_package(QT NAMES Qt6
              COMPONENTS Gui

--- a/wxdata/source/scwx/provider/nws_level3_behavior.cpp
+++ b/wxdata/source/scwx/provider/nws_level3_behavior.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
+#include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
 #include <cpr/cpr.h>
 #include <range/v3/range/conversion.hpp>

--- a/wxdata/wxdata.cmake
+++ b/wxdata/wxdata.cmake
@@ -4,7 +4,11 @@ project(scwx-data)
 
 include(CheckCXXSymbolExists)
 
-find_package(Boost)
+find_package(Boost
+             COMPONENTS iostreams
+                        url
+             REQUIRED)
+find_package(BZip2)
 find_package(cpr)
 find_package(LibXml2)
 find_package(libzip)
@@ -362,6 +366,7 @@ endif()
 
 target_link_libraries(wxdata PUBLIC aws-cpp-sdk-core
                                     aws-cpp-sdk-s3
+                                    aws-crt-cpp
                                     cpr::cpr
                                     LibXml2::LibXml2
                                     libzip::zip

--- a/wxdata/wxdata.cmake
+++ b/wxdata/wxdata.cmake
@@ -344,9 +344,10 @@ target_compile_options(wxdata PRIVATE
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14>>:-Wno-maybe-uninitialized>
 )
 
-# Temporary workaround for Boost and GCC 16+ where -Warray-bounds causes false positives
+# Temporary workaround for Boost and GCC 16+ where -Warray-bounds and -Wstringop-overflow cause false positives
 target_compile_options(wxdata PRIVATE
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-array-bounds>
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16>>:-Wno-stringop-overflow>
 )
 
 if (MSVC)

--- a/wxdata/wxdata.cmake
+++ b/wxdata/wxdata.cmake
@@ -8,19 +8,19 @@ find_package(Boost
              COMPONENTS iostreams
                         url
              REQUIRED)
-find_package(BZip2)
-find_package(cpr)
-find_package(LibXml2)
-find_package(libzip)
-find_package(OpenSSL)
-find_package(range-v3)
-find_package(re2)
-find_package(spdlog)
+find_package(BZip2 REQUIRED)
+find_package(cpr REQUIRED)
+find_package(LibXml2 REQUIRED)
+find_package(libzip REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(range-v3 REQUIRED)
+find_package(re2 REQUIRED)
+find_package(spdlog REQUIRED)
 
 check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
 
 if (LINUX)
-    find_package(TBB)
+    find_package(TBB REQUIRED)
 endif()
 
 set(HDR_AWIPS include/scwx/awips/coded_location.hpp


### PR DESCRIPTION
Compatibility fixes for downstream NixOS packaging, reducing the number of patches required to build for nixpkgs

- boost::url parsing requires parse.hpp (boost 1.89 vs. 1.91)
- boost packages need components listing
- Missing find_package for BZip2 and PNG
- Explicit linking required for aws-crt-cpp and PNG
- GeographicLib should be passed camelcase to find_package

Also fixing incidental finding with GCC 16 and Boost, with -Wstringop-overflow false positives