### PR TITLE
Installer Shortcut Fix

### DIFF
--- a/scwx-qt/wix.template.in
+++ b/scwx-qt/wix.template.in
@@ -41,6 +41,12 @@
 
         <FeatureRef Id="ProductFeature"/>
 
+        <!-- Keep Start Menu / taskbar pins across major upgrades: do not remove
+             shortcuts while the old product is being replaced. -->
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+        </InstallExecuteSequence>
+
         <UIRef Id="$(var.CPACK_WIX_UI_REF)" />
         <UIRef Id="WixUI_ErrorProgressText" />
 


### PR DESCRIPTION
On .msi upgrade, the shortcut is removed and re-added. This causes pins based on the shortcut to break.