### PR TITLE
Add radar and overlay layer opacity control

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks:
   - '-bugprone-easily-swappable-parameters'
   - '-cppcoreguidelines-avoid-do-while'
   - '-cppcoreguidelines-avoid-non-const-global-variables'
+  - '-cppcoreguidelines-owning-memory'
   - '-cppcoreguidelines-pro-type-reinterpret-cast'
   - '-cppcoreguidelines-pro-type-union-access'
   - '-cppcoreguidelines-pro-type-vararg'

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -91,7 +91,14 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.conan2
-        key: build-v2-${{ matrix.conan_profile }}-${{ hashFiles('./source/conanfile.py', './source/tools/conan/profiles/*') }}
+        key: >-
+          build-v2-${{ matrix.conan_profile }}-${{
+            hashFiles(
+              './source/conanfile.py',
+              format('./source/tools/conan/profiles/{0}', matrix.conan_profile),
+              format('./source/tools/conan/profiles/{0}', matrix.conan_profile)
+            )
+          }}
 
     - name: Install Conan Packages
       id: conan-install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,9 @@ Q_EMIT DataReloaded();  // Correct
 emit DataReloaded();    // Incorrect - will cause build issues
 ```
 
+### Qt Designer / `.ui` Files
+Define widgets, layouts, and static properties (labels, ranges, tooltips, suffixes, size policies) in `.ui` files so they remain editable in Qt Designer. Use C++ for behavior only: signal/slot connections, dynamic enablement, and runtime state. Promote custom widgets in the `.ui` file (`<customwidgets>`) rather than constructing them in code. When a dialog already has a `.ui` file, add new static UI there instead of `new QWidget(...)` in the `.cpp`.
+
 ## Common Tasks
 
 ### Adding New Radar Product Support

--- a/scwx-qt/gl/annotation_stroke.frag
+++ b/scwx-qt/gl/annotation_stroke.frag
@@ -7,7 +7,10 @@ smooth in float vDashPeriod;
 smooth in float vDashDuty;
 
 uniform int uHatchMode;
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 layout(location = 0) out vec4 fragColor;
 

--- a/scwx-qt/gl/annotation_stroke.frag
+++ b/scwx-qt/gl/annotation_stroke.frag
@@ -7,6 +7,7 @@ smooth in float vDashPeriod;
 smooth in float vDashDuty;
 
 uniform int uHatchMode;
+uniform float uOpacity;
 
 layout(location = 0) out vec4 fragColor;
 
@@ -32,4 +33,5 @@ void main()
    }
 
    fragColor = color;
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/color.frag
+++ b/scwx-qt/gl/color.frag
@@ -1,7 +1,10 @@
 #version 330 core
 smooth in vec4 color;
 
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 layout (location = 0) out vec4 fragColor;
 

--- a/scwx-qt/gl/color.frag
+++ b/scwx-qt/gl/color.frag
@@ -1,9 +1,12 @@
 #version 330 core
 smooth in vec4 color;
 
+uniform float uOpacity;
+
 layout (location = 0) out vec4 fragColor;
 
 void main()
 {
    fragColor = color;
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/radar.frag
+++ b/scwx-qt/gl/radar.frag
@@ -6,6 +6,7 @@ precision mediump float;
 uniform sampler1D uTexture;
 uniform uint uDataMomentOffset;
 uniform float uDataMomentScale;
+uniform float uOpacity;
 
 uniform bool uCFPEnabled;
 
@@ -24,4 +25,5 @@ void main()
    }
 
    fragColor = texture(uTexture, texCoord);
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/radar.frag
+++ b/scwx-qt/gl/radar.frag
@@ -6,7 +6,10 @@ precision mediump float;
 uniform sampler1D uTexture;
 uniform uint uDataMomentOffset;
 uniform float uDataMomentScale;
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 uniform bool uCFPEnabled;
 

--- a/scwx-qt/gl/texture1d.frag
+++ b/scwx-qt/gl/texture1d.frag
@@ -4,7 +4,10 @@
 precision mediump float;
 
 uniform sampler1D uTexture;
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 in float texCoord;
 

--- a/scwx-qt/gl/texture1d.frag
+++ b/scwx-qt/gl/texture1d.frag
@@ -4,6 +4,7 @@
 precision mediump float;
 
 uniform sampler1D uTexture;
+uniform float uOpacity;
 
 in float texCoord;
 
@@ -12,4 +13,5 @@ layout (location = 0) out vec4 fragColor;
 void main()
 {
    fragColor = texture(uTexture, texCoord);
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/texture2d.frag
+++ b/scwx-qt/gl/texture2d.frag
@@ -4,7 +4,10 @@
 precision mediump float;
 
 uniform sampler2D uTexture;
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 smooth in vec2 texCoord;
 smooth in vec4 color;

--- a/scwx-qt/gl/texture2d.frag
+++ b/scwx-qt/gl/texture2d.frag
@@ -4,6 +4,7 @@
 precision mediump float;
 
 uniform sampler2D uTexture;
+uniform float uOpacity;
 
 smooth in vec2 texCoord;
 smooth in vec4 color;
@@ -13,4 +14,5 @@ layout (location = 0) out vec4 fragColor;
 void main()
 {
    fragColor = texture(uTexture, texCoord) * color;
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/texture2d_array.frag
+++ b/scwx-qt/gl/texture2d_array.frag
@@ -4,6 +4,7 @@
 precision mediump float;
 
 uniform sampler2DArray uTexture;
+uniform float uOpacity;
 
 smooth in vec3 texCoord;
 smooth in vec4 color;
@@ -13,4 +14,5 @@ layout (location = 0) out vec4 fragColor;
 void main()
 {
    fragColor = texture(uTexture, texCoord) * color;
+   fragColor.a *= uOpacity;
 }

--- a/scwx-qt/gl/texture2d_array.frag
+++ b/scwx-qt/gl/texture2d_array.frag
@@ -4,7 +4,10 @@
 precision mediump float;
 
 uniform sampler2DArray uTexture;
-uniform float uOpacity;
+layout(std140) uniform LayerState
+{
+   float uOpacity;
+};
 
 smooth in vec3 texCoord;
 smooth in vec4 color;

--- a/scwx-qt/scwx-qt.cmake
+++ b/scwx-qt/scwx-qt.cmake
@@ -327,6 +327,7 @@ set(HDR_UI source/scwx/qt/ui/about_dialog.hpp
            source/scwx/qt/ui/imgui_debug_dialog.hpp
            source/scwx/qt/ui/imgui_debug_widget.hpp
            source/scwx/qt/ui/layer_dialog.hpp
+           source/scwx/qt/ui/layer_opacity_delegate.hpp
            source/scwx/qt/ui/left_elided_item_delegate.hpp
            source/scwx/qt/ui/level2_products_widget.hpp
            source/scwx/qt/ui/level2_settings_widget.hpp
@@ -366,6 +367,7 @@ set(SRC_UI source/scwx/qt/ui/about_dialog.cpp
            source/scwx/qt/ui/imgui_debug_dialog.cpp
            source/scwx/qt/ui/imgui_debug_widget.cpp
            source/scwx/qt/ui/layer_dialog.cpp
+           source/scwx/qt/ui/layer_opacity_delegate.cpp
            source/scwx/qt/ui/left_elided_item_delegate.cpp
            source/scwx/qt/ui/level2_products_widget.cpp
            source/scwx/qt/ui/level2_settings_widget.cpp

--- a/scwx-qt/source/scwx/qt/gl/gl_context.cpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <boost/container_hash/hash.hpp>
 #include <QMessageBox>
+#include <QOpenGLContext>
 
 namespace scwx::qt::gl
 {
@@ -18,7 +19,7 @@ public:
    explicit Impl() = default;
    ~Impl()
    {
-      if (layerStateUbo_ != 0)
+      if (layerStateUbo_ != 0 && QOpenGLContext::currentContext() != nullptr)
       {
          glDeleteBuffers(1, &layerStateUbo_);
          layerStateUbo_ = 0;
@@ -126,7 +127,7 @@ void GlContext::Impl::InitializeGL()
    glInitialized_ = true;
 }
 
-void BindLayerStateBlock(GLuint programId)
+static void BindLayerStateBlock(GLuint programId)
 {
    const GLuint index = glGetUniformBlockIndex(programId, kLayerStateBlockName);
    if (index != GL_INVALID_INDEX)

--- a/scwx-qt/source/scwx/qt/gl/gl_context.cpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.cpp
@@ -17,14 +17,7 @@ class GlContext::Impl
 {
 public:
    explicit Impl() = default;
-   ~Impl()
-   {
-      if (layerStateUbo_ != 0 && QOpenGLContext::currentContext() != nullptr)
-      {
-         glDeleteBuffers(1, &layerStateUbo_);
-         layerStateUbo_ = 0;
-      }
-   }
+   ~Impl()         = default;
 
    Impl(const Impl&)             = delete;
    Impl& operator=(const Impl&)  = delete;

--- a/scwx-qt/source/scwx/qt/gl/gl_context.cpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.cpp
@@ -2,6 +2,7 @@
 #include <scwx/qt/util/texture_atlas.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <algorithm>
 #include <boost/container_hash/hash.hpp>
 #include <QMessageBox>
 
@@ -15,7 +16,14 @@ class GlContext::Impl
 {
 public:
    explicit Impl() = default;
-   ~Impl()         = default;
+   ~Impl()
+   {
+      if (layerStateUbo_ != 0)
+      {
+         glDeleteBuffers(1, &layerStateUbo_);
+         layerStateUbo_ = 0;
+      }
+   }
 
    Impl(const Impl&)             = delete;
    Impl& operator=(const Impl&)  = delete;
@@ -34,6 +42,8 @@ public:
    std::mutex shaderProgramMutex_ {};
 
    GLuint     textureAtlas_ {GL_INVALID_INDEX};
+   GLuint     layerStateUbo_ {0};
+   float      layerOpacity_ {1.0f};
    std::mutex textureMutex_ {};
 
    std::uint64_t textureBufferCount_ {};
@@ -106,7 +116,23 @@ void GlContext::Impl::InitializeGL()
 
    glGenTextures(1, &textureAtlas_);
 
+   glGenBuffers(1, &layerStateUbo_);
+   glBindBuffer(GL_UNIFORM_BUFFER, layerStateUbo_);
+   const LayerStateBlock initialBlock {};
+   glBufferData(
+      GL_UNIFORM_BUFFER, sizeof(initialBlock), &initialBlock, GL_DYNAMIC_DRAW);
+   glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
    glInitialized_ = true;
+}
+
+void BindLayerStateBlock(GLuint programId)
+{
+   const GLuint index = glGetUniformBlockIndex(programId, kLayerStateBlockName);
+   if (index != GL_INVALID_INDEX)
+   {
+      glUniformBlockBinding(programId, index, kLayerStateBindingPoint);
+   }
 }
 
 std::shared_ptr<gl::ShaderProgram>
@@ -131,6 +157,7 @@ std::shared_ptr<gl::ShaderProgram> GlContext::GetShaderProgram(
    {
       shaderProgram = std::make_shared<gl::ShaderProgram>();
       shaderProgram->Load(shaders);
+      BindLayerStateBlock(shaderProgram->id());
       p->shaderProgramMap_[key] = shaderProgram;
    }
    else
@@ -156,6 +183,26 @@ GLuint GlContext::GetTextureAtlas()
    }
 
    return p->textureAtlas_;
+}
+
+void GlContext::set_layer_opacity(float opacity)
+{
+   p->InitializeGL();
+   p->layerOpacity_ = std::clamp(opacity, 0.0f, 1.0f);
+
+   LayerStateBlock block {};
+   block.opacity = p->layerOpacity_;
+
+   glBindBuffer(GL_UNIFORM_BUFFER, p->layerStateUbo_);
+   glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(block), &block);
+   glBindBuffer(GL_UNIFORM_BUFFER, 0);
+   glBindBufferBase(
+      GL_UNIFORM_BUFFER, kLayerStateBindingPoint, p->layerStateUbo_);
+}
+
+float GlContext::layer_opacity() const
+{
+   return p->layerOpacity_;
 }
 
 void GlContext::Initialize()

--- a/scwx-qt/source/scwx/qt/gl/gl_context.hpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.hpp
@@ -45,6 +45,9 @@ public:
 
    GLuint GetTextureAtlas();
 
+   void  set_layer_opacity(float opacity);
+   float layer_opacity() const;
+
    void Initialize();
    void StartFrame();
 

--- a/scwx-qt/source/scwx/qt/gl/gl_context.hpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.hpp
@@ -3,6 +3,7 @@
 #include <scwx/qt/gl/gl.hpp>
 #include <scwx/qt/gl/shader_program.hpp>
 
+#include <array>
 #include <cstdint>
 
 namespace scwx
@@ -17,8 +18,8 @@ inline constexpr const char* kLayerStateBlockName {"LayerState"};
 
 struct alignas(16) LayerStateBlock
 {
-   float opacity {1.0f};
-   float pad[3] {};
+   float                opacity {1.0f};
+   std::array<float, 3> pad {};
 };
 
 static_assert(sizeof(LayerStateBlock) == 16);

--- a/scwx-qt/source/scwx/qt/gl/gl_context.hpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.hpp
@@ -16,6 +16,7 @@ namespace gl
 inline constexpr GLuint      kLayerStateBindingPoint {16};
 inline constexpr const char* kLayerStateBlockName {"LayerState"};
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): Readability
 struct alignas(16) LayerStateBlock
 {
    float                opacity {1.0f};
@@ -23,6 +24,7 @@ struct alignas(16) LayerStateBlock
 };
 
 static_assert(sizeof(LayerStateBlock) == 16);
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
 class GlContext
 {
@@ -46,8 +48,8 @@ public:
 
    GLuint GetTextureAtlas();
 
-   void  set_layer_opacity(float opacity);
-   float layer_opacity() const;
+   void                set_layer_opacity(float opacity);
+   [[nodiscard]] float layer_opacity() const;
 
    void Initialize();
    void StartFrame();

--- a/scwx-qt/source/scwx/qt/gl/gl_context.hpp
+++ b/scwx-qt/source/scwx/qt/gl/gl_context.hpp
@@ -12,6 +12,17 @@ namespace qt
 namespace gl
 {
 
+inline constexpr GLuint      kLayerStateBindingPoint {16};
+inline constexpr const char* kLayerStateBlockName {"LayerState"};
+
+struct alignas(16) LayerStateBlock
+{
+   float opacity {1.0f};
+   float pad[3] {};
+};
+
+static_assert(sizeof(LayerStateBlock) == 16);
+
 class GlContext
 {
 public:

--- a/scwx-qt/source/scwx/qt/gl/shader_program.cpp
+++ b/scwx-qt/source/scwx/qt/gl/shader_program.cpp
@@ -1,6 +1,9 @@
 #include <scwx/qt/gl/shader_program.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <algorithm>
+#include <unordered_map>
+
 #include <QFile>
 #include <QTextStream>
 
@@ -16,6 +19,8 @@ static const std::unordered_map<GLenum, std::string> kShaderNames_ {
    {GL_VERTEX_SHADER, "vertex"},
    {GL_GEOMETRY_SHADER, "geometry"},
    {GL_FRAGMENT_SHADER, "fragment"}};
+
+float currentLayerOpacity_ {1.0f};
 
 class ShaderProgram::Impl
 {
@@ -36,6 +41,7 @@ public:
    static std::string ShaderName(GLenum type);
 
    GLuint id_;
+   GLint  uOpacityLocation_ {-1};
 };
 
 ShaderProgram::ShaderProgram() : p(std::make_unique<Impl>()) {}
@@ -57,6 +63,11 @@ GLint ShaderProgram::GetUniformLocation(const std::string& name)
       logger_->warn("Could not find {}", name);
    }
    return location;
+}
+
+void ShaderProgram::SetCurrentLayerOpacity(float opacity)
+{
+   currentLayerOpacity_ = std::clamp(opacity, 0.0f, 1.0f);
 }
 
 std::string ShaderProgram::Impl::ShaderName(GLenum type)
@@ -156,6 +167,8 @@ bool ShaderProgram::Load(
       {
          logger_->warn("Shader program linked with warnings: {}", infoLog);
       }
+
+      p->uOpacityLocation_ = glGetUniformLocation(p->id_, "uOpacity");
    }
 
    // Delete shaders
@@ -170,6 +183,10 @@ bool ShaderProgram::Load(
 void ShaderProgram::Use() const
 {
    glUseProgram(p->id_);
+   if (p->uOpacityLocation_ != -1)
+   {
+      glUniform1f(p->uOpacityLocation_, currentLayerOpacity_);
+   }
 }
 
 } // namespace scwx::qt::gl

--- a/scwx-qt/source/scwx/qt/gl/shader_program.cpp
+++ b/scwx-qt/source/scwx/qt/gl/shader_program.cpp
@@ -1,7 +1,6 @@
 #include <scwx/qt/gl/shader_program.hpp>
 #include <scwx/util/logger.hpp>
 
-#include <algorithm>
 #include <unordered_map>
 
 #include <QFile>
@@ -19,8 +18,6 @@ static const std::unordered_map<GLenum, std::string> kShaderNames_ {
    {GL_VERTEX_SHADER, "vertex"},
    {GL_GEOMETRY_SHADER, "geometry"},
    {GL_FRAGMENT_SHADER, "fragment"}};
-
-float currentLayerOpacity_ {1.0f};
 
 class ShaderProgram::Impl
 {
@@ -41,7 +38,6 @@ public:
    static std::string ShaderName(GLenum type);
 
    GLuint id_;
-   GLint  uOpacityLocation_ {-1};
 };
 
 ShaderProgram::ShaderProgram() : p(std::make_unique<Impl>()) {}
@@ -63,11 +59,6 @@ GLint ShaderProgram::GetUniformLocation(const std::string& name)
       logger_->warn("Could not find {}", name);
    }
    return location;
-}
-
-void ShaderProgram::SetCurrentLayerOpacity(float opacity)
-{
-   currentLayerOpacity_ = std::clamp(opacity, 0.0f, 1.0f);
 }
 
 std::string ShaderProgram::Impl::ShaderName(GLenum type)
@@ -167,8 +158,6 @@ bool ShaderProgram::Load(
       {
          logger_->warn("Shader program linked with warnings: {}", infoLog);
       }
-
-      p->uOpacityLocation_ = glGetUniformLocation(p->id_, "uOpacity");
    }
 
    // Delete shaders
@@ -183,10 +172,6 @@ bool ShaderProgram::Load(
 void ShaderProgram::Use() const
 {
    glUseProgram(p->id_);
-   if (p->uOpacityLocation_ != -1)
-   {
-      glUniform1f(p->uOpacityLocation_, currentLayerOpacity_);
-   }
 }
 
 } // namespace scwx::qt::gl

--- a/scwx-qt/source/scwx/qt/gl/shader_program.hpp
+++ b/scwx-qt/source/scwx/qt/gl/shader_program.hpp
@@ -32,6 +32,8 @@ public:
 
    GLint GetUniformLocation(const std::string& name);
 
+   static void SetCurrentLayerOpacity(float opacity);
+
    bool Load(const std::string& vertexPath, const std::string& fragmentPath);
    bool Load(std::initializer_list<std::pair<GLenum, std::string>> shaderPaths);
 

--- a/scwx-qt/source/scwx/qt/gl/shader_program.hpp
+++ b/scwx-qt/source/scwx/qt/gl/shader_program.hpp
@@ -32,8 +32,6 @@ public:
 
    GLint GetUniformLocation(const std::string& name);
 
-   static void SetCurrentLayerOpacity(float opacity);
-
    bool Load(const std::string& vertexPath, const std::string& fragmentPath);
    bool Load(std::initializer_list<std::pair<GLenum, std::string>> shaderPaths);
 

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -29,6 +29,7 @@
 #include <scwx/qt/settings/map_settings.hpp>
 #include <scwx/qt/settings/product_settings.hpp>
 #include <scwx/qt/settings/ui_settings.hpp>
+#include <scwx/qt/types/layer_types.hpp>
 #include <scwx/qt/ui/about_dialog.hpp>
 #include <scwx/qt/ui/alert_dock_widget.hpp>
 #include <scwx/qt/ui/animation_dock_widget.hpp>
@@ -49,6 +50,7 @@
 #include <scwx/qt/ui/settings_dialog.hpp>
 #include <scwx/qt/ui/update_dialog.hpp>
 #include <scwx/qt/ui/import/import_settings_wizard.hpp>
+#include <scwx/qt/ui/widgets/focused_spin_box.hpp>
 #include <scwx/common/characters.hpp>
 #include <scwx/common/products.hpp>
 #include <scwx/common/sites.hpp>
@@ -85,9 +87,12 @@
 #include <QScreen>
 #include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QSlider>
 #include <QSplitter>
 #include <QTimer>
 #include <QToolButton>
+#include <QHBoxLayout>
+#include <QWidget>
 #include <QWindow>
 
 namespace scwx::qt::main
@@ -317,6 +322,9 @@ public:
    void ConnectMapAnnotationLayerReady(map::MapWidget* mw);
    /// Layer broadcast, floating host resolver, deferred float-from-settings.
    void ConfigureMapAnnotationDock();
+   void ConfigureRadarOpacityControls();
+   void SyncRadarOpacityControls();
+   void SetRadarOpacityPercent(int percent);
 
    boost::asio::thread_pool threadPool_ {1u};
 
@@ -338,6 +346,10 @@ public:
 
    ui::Level3ProductsWidget* level3ProductsWidget_ {nullptr};
    ui::Level3SettingsWidget* level3SettingsWidget_ {nullptr};
+
+   QSlider*         radarOpacitySlider_ {nullptr};
+   QFocusedSpinBox* radarOpacitySpinBox_ {nullptr};
+   bool             updatingRadarOpacityControls_ {false};
 
    QLabel* coordinateLabel_ {nullptr};
    QLabel* timeLabel_ {nullptr};
@@ -528,6 +540,9 @@ MainWindow::MainWindow(QWidget* parent) :
    p->mapSettingsGroup_ = new ui::CollapsibleGroup(tr("Map Settings"), this);
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->mapStyleLabel);
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->mapStyleComboBox);
+
+   p->ConfigureRadarOpacityControls();
+
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(
       ui->smoothRadarDataCheckBox);
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(
@@ -2514,6 +2529,95 @@ void MainWindowImpl::OnPanesMatchMapStyleToggled(bool checked)
       RestoreAllPanesFromSavedMapSettings();
    }
    UpdateMatchMapStyleFromPanesState(false);
+}
+
+void MainWindowImpl::ConfigureRadarOpacityControls()
+{
+   auto* opacityWidget = new QWidget(mapSettingsGroup_);
+   auto* opacityLayout = new QHBoxLayout(opacityWidget);
+   opacityLayout->setContentsMargins(0, 0, 0, 0);
+
+   auto* opacityLabel = new QLabel(QObject::tr("Radar Opacity"), opacityWidget);
+   radarOpacitySlider_ =
+      new QSlider(Qt::Orientation::Horizontal, opacityWidget);
+   radarOpacitySlider_->setRange(0, 100);
+   radarOpacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
+   radarOpacitySlider_->setTickInterval(25);
+   radarOpacitySlider_->setToolTip(
+      QObject::tr("Radar product opacity. Map styles stay opaque."));
+
+   radarOpacitySpinBox_ = new QFocusedSpinBox(opacityWidget);
+   radarOpacitySpinBox_->setRange(0, 100);
+   radarOpacitySpinBox_->setSuffix(QObject::tr("%"));
+   radarOpacitySpinBox_->setKeyboardTracking(false);
+
+   opacityLayout->addWidget(opacityLabel);
+   opacityLayout->addWidget(radarOpacitySlider_);
+   opacityLayout->addWidget(radarOpacitySpinBox_);
+   mapSettingsGroup_->GetContentsLayout()->addWidget(opacityWidget);
+
+   QObject::connect(radarOpacitySlider_,
+                    &QSlider::valueChanged,
+                    mainWindow_,
+                    [this](int value) { SetRadarOpacityPercent(value); });
+   QObject::connect(radarOpacitySpinBox_,
+                    &QSpinBox::valueChanged,
+                    mainWindow_,
+                    [this](int value) { SetRadarOpacityPercent(value); });
+   QObject::connect(
+      layerModel_.get(),
+      &QAbstractItemModel::dataChanged,
+      mainWindow_,
+      [this](const QModelIndex& topLeft, const QModelIndex& bottomRight)
+      {
+         const int opacityColumn =
+            static_cast<int>(model::LayerModel::Column::Opacity);
+         if (topLeft.column() <= opacityColumn &&
+             opacityColumn <= bottomRight.column())
+         {
+            SyncRadarOpacityControls();
+         }
+      });
+   QObject::connect(layerModel_.get(),
+                    &QAbstractItemModel::modelReset,
+                    mainWindow_,
+                    [this]() { SyncRadarOpacityControls(); });
+
+   SyncRadarOpacityControls();
+}
+
+void MainWindowImpl::SyncRadarOpacityControls()
+{
+   if (radarOpacitySlider_ == nullptr || radarOpacitySpinBox_ == nullptr)
+   {
+      return;
+   }
+
+   const types::LayerInfo radarLayer =
+      layerModel_->GetLayerInfo(types::LayerType::Radar, std::monostate {});
+   const int percent = types::LayerOpacityToPercent(radarLayer.opacity_);
+
+   updatingRadarOpacityControls_ = true;
+   radarOpacitySlider_->setValue(percent);
+   radarOpacitySpinBox_->setValue(percent);
+   updatingRadarOpacityControls_ = false;
+}
+
+void MainWindowImpl::SetRadarOpacityPercent(int percent)
+{
+   if (updatingRadarOpacityControls_)
+   {
+      return;
+   }
+
+   updatingRadarOpacityControls_ = true;
+   radarOpacitySlider_->setValue(percent);
+   radarOpacitySpinBox_->setValue(percent);
+   updatingRadarOpacityControls_ = false;
+
+   layerModel_->SetLayerOpacity(types::LayerType::Radar,
+                                std::monostate {},
+                                types::LayerOpacityFromPercent(percent));
 }
 
 void MainWindowImpl::ConfigureUiSettings()

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -50,7 +50,6 @@
 #include <scwx/qt/ui/settings_dialog.hpp>
 #include <scwx/qt/ui/update_dialog.hpp>
 #include <scwx/qt/ui/import/import_settings_wizard.hpp>
-#include <scwx/qt/ui/widgets/focused_spin_box.hpp>
 #include <scwx/common/characters.hpp>
 #include <scwx/common/products.hpp>
 #include <scwx/common/sites.hpp>
@@ -88,10 +87,10 @@
 #include <QSignalBlocker>
 #include <QSizePolicy>
 #include <QSlider>
+#include <QSpinBox>
 #include <QSplitter>
 #include <QTimer>
 #include <QToolButton>
-#include <QHBoxLayout>
 #include <QWidget>
 #include <QWindow>
 
@@ -347,9 +346,7 @@ public:
    ui::Level3ProductsWidget* level3ProductsWidget_ {nullptr};
    ui::Level3SettingsWidget* level3SettingsWidget_ {nullptr};
 
-   QSlider*         radarOpacitySlider_ {nullptr};
-   QFocusedSpinBox* radarOpacitySpinBox_ {nullptr};
-   bool             updatingRadarOpacityControls_ {false};
+   bool updatingRadarOpacityControls_ {false};
 
    QLabel* coordinateLabel_ {nullptr};
    QLabel* timeLabel_ {nullptr};
@@ -540,6 +537,8 @@ MainWindow::MainWindow(QWidget* parent) :
    p->mapSettingsGroup_ = new ui::CollapsibleGroup(tr("Map Settings"), this);
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->mapStyleLabel);
    p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->mapStyleComboBox);
+   p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->radarOpacityLabel);
+   p->mapSettingsGroup_->GetContentsLayout()->addWidget(ui->radarOpacityWidget);
 
    p->ConfigureRadarOpacityControls();
 
@@ -2533,38 +2532,11 @@ void MainWindowImpl::OnPanesMatchMapStyleToggled(bool checked)
 
 void MainWindowImpl::ConfigureRadarOpacityControls()
 {
-   static constexpr int kMinOpacity   = 0;
-   static constexpr int kMaxOpacity   = 100;
-   static constexpr int kTickInterval = 25;
-
-   auto* opacityWidget = new QWidget(mapSettingsGroup_);
-   auto* opacityLayout = new QHBoxLayout(opacityWidget);
-   opacityLayout->setContentsMargins(0, 0, 0, 0);
-
-   auto* opacityLabel = new QLabel(QObject::tr("Radar Opacity"), opacityWidget);
-   radarOpacitySlider_ =
-      new QSlider(Qt::Orientation::Horizontal, opacityWidget);
-   radarOpacitySlider_->setRange(kMinOpacity, kMaxOpacity);
-   radarOpacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
-   radarOpacitySlider_->setTickInterval(kTickInterval);
-   radarOpacitySlider_->setToolTip(
-      QObject::tr("Radar product opacity. Map styles stay opaque."));
-
-   radarOpacitySpinBox_ = new QFocusedSpinBox(opacityWidget);
-   radarOpacitySpinBox_->setRange(kMinOpacity, kMaxOpacity);
-   radarOpacitySpinBox_->setSuffix(QObject::tr("%"));
-   radarOpacitySpinBox_->setKeyboardTracking(false);
-
-   opacityLayout->addWidget(opacityLabel);
-   opacityLayout->addWidget(radarOpacitySlider_);
-   opacityLayout->addWidget(radarOpacitySpinBox_);
-   mapSettingsGroup_->GetContentsLayout()->addWidget(opacityWidget);
-
-   QObject::connect(radarOpacitySlider_,
+   QObject::connect(mainWindow_->ui->radarOpacitySlider,
                     &QSlider::valueChanged,
                     mainWindow_,
                     [this](int value) { SetRadarOpacityPercent(value); });
-   QObject::connect(radarOpacitySpinBox_,
+   QObject::connect(mainWindow_->ui->radarOpacitySpinBox,
                     &QSpinBox::valueChanged,
                     mainWindow_,
                     [this](int value) { SetRadarOpacityPercent(value); });
@@ -2592,18 +2564,13 @@ void MainWindowImpl::ConfigureRadarOpacityControls()
 
 void MainWindowImpl::SyncRadarOpacityControls()
 {
-   if (radarOpacitySlider_ == nullptr || radarOpacitySpinBox_ == nullptr)
-   {
-      return;
-   }
-
    const types::LayerInfo radarLayer =
       layerModel_->GetLayerInfo(types::LayerType::Radar, std::monostate {});
    const int percent = types::LayerOpacityToPercent(radarLayer.opacity_);
 
    updatingRadarOpacityControls_ = true;
-   radarOpacitySlider_->setValue(percent);
-   radarOpacitySpinBox_->setValue(percent);
+   mainWindow_->ui->radarOpacitySlider->setValue(percent);
+   mainWindow_->ui->radarOpacitySpinBox->setValue(percent);
    updatingRadarOpacityControls_ = false;
 }
 
@@ -2615,8 +2582,8 @@ void MainWindowImpl::SetRadarOpacityPercent(int percent)
    }
 
    updatingRadarOpacityControls_ = true;
-   radarOpacitySlider_->setValue(percent);
-   radarOpacitySpinBox_->setValue(percent);
+   mainWindow_->ui->radarOpacitySlider->setValue(percent);
+   mainWindow_->ui->radarOpacitySpinBox->setValue(percent);
    updatingRadarOpacityControls_ = false;
 
    layerModel_->SetLayerOpacity(types::LayerType::Radar,

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -2533,6 +2533,10 @@ void MainWindowImpl::OnPanesMatchMapStyleToggled(bool checked)
 
 void MainWindowImpl::ConfigureRadarOpacityControls()
 {
+   static constexpr int kMinOpacity   = 0;
+   static constexpr int kMaxOpacity   = 100;
+   static constexpr int kTickInterval = 25;
+
    auto* opacityWidget = new QWidget(mapSettingsGroup_);
    auto* opacityLayout = new QHBoxLayout(opacityWidget);
    opacityLayout->setContentsMargins(0, 0, 0, 0);
@@ -2540,14 +2544,14 @@ void MainWindowImpl::ConfigureRadarOpacityControls()
    auto* opacityLabel = new QLabel(QObject::tr("Radar Opacity"), opacityWidget);
    radarOpacitySlider_ =
       new QSlider(Qt::Orientation::Horizontal, opacityWidget);
-   radarOpacitySlider_->setRange(0, 100);
+   radarOpacitySlider_->setRange(kMinOpacity, kMaxOpacity);
    radarOpacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
-   radarOpacitySlider_->setTickInterval(25);
+   radarOpacitySlider_->setTickInterval(kTickInterval);
    radarOpacitySlider_->setToolTip(
       QObject::tr("Radar product opacity. Map styles stay opaque."));
 
    radarOpacitySpinBox_ = new QFocusedSpinBox(opacityWidget);
-   radarOpacitySpinBox_->setRange(0, 100);
+   radarOpacitySpinBox_->setRange(kMinOpacity, kMaxOpacity);
    radarOpacitySpinBox_->setSuffix(QObject::tr("%"));
    radarOpacitySpinBox_->setKeyboardTracking(false);
 

--- a/scwx-qt/source/scwx/qt/main/main_window.ui
+++ b/scwx-qt/source/scwx/qt/main/main_window.ui
@@ -359,6 +359,63 @@
              <widget class="QComboBox" name="mapStyleComboBox"/>
             </item>
             <item>
+             <widget class="QLabel" name="radarOpacityLabel">
+              <property name="text">
+               <string>Radar Opacity</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="radarOpacityWidget" native="true">
+              <layout class="QHBoxLayout" name="radarOpacityLayout">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QSlider" name="radarOpacitySlider">
+                 <property name="toolTip">
+                  <string>Radar product opacity. Map styles stay opaque.</string>
+                 </property>
+                 <property name="maximum">
+                  <number>100</number>
+                 </property>
+                 <property name="value">
+                  <number>100</number>
+                 </property>
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFocusedSpinBox" name="radarOpacitySpinBox">
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string>%</string>
+                 </property>
+                 <property name="maximum">
+                  <number>100</number>
+                 </property>
+                 <property name="value">
+                  <number>100</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="smoothRadarDataCheckBox">
               <property name="text">
                <string>Smooth Radar Data</string>
@@ -654,6 +711,13 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QFocusedSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>scwx/qt/ui/widgets/focused_spin_box.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../../../scwx-qt.qrc"/>
  </resources>

--- a/scwx-qt/source/scwx/qt/map/draw_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/draw_layer.cpp
@@ -1,7 +1,6 @@
 #include <scwx/qt/manager/font_manager.hpp>
 #include <scwx/qt/map/draw_layer.hpp>
 #include <scwx/qt/model/imgui_context_model.hpp>
-#include <scwx/qt/gl/shader_program.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <ranges>
@@ -103,11 +102,13 @@ void DrawLayer::ImGuiFrameStart(const std::shared_ptr<MapContext>& mapContext)
    ImGui_ImplOpenGL3_NewFrame();
    ImGui::NewFrame();
    ImGui::PushFont(defaultFont.first->font(), defaultFont.second.value());
+   ImGui::PushStyleVar(ImGuiStyleVar_Alpha, opacity());
 }
 
 void DrawLayer::ImGuiFrameEnd()
 {
-   // Pop default font
+   // Pop default style and font
+   ImGui::PopStyleVar();
    ImGui::PopFont();
 
    // Render ImGui Frame

--- a/scwx-qt/source/scwx/qt/map/generic_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.cpp
@@ -58,4 +58,14 @@ float GenericLayer::opacity() const
    return p->opacity_;
 }
 
+void GenericLayer::BindLayerState()
+{
+   p->glContext_->set_layer_opacity(p->opacity_);
+}
+
+void GenericLayer::ResetLayerState()
+{
+   p->glContext_->set_layer_opacity(1.0f);
+}
+
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.cpp
@@ -1,5 +1,7 @@
 #include <scwx/qt/map/generic_layer.hpp>
 
+#include <algorithm>
+
 namespace scwx::qt::map
 {
 
@@ -19,6 +21,7 @@ public:
    Impl& operator=(const Impl&&) = delete;
 
    std::shared_ptr<gl::GlContext> glContext_;
+   float                          opacity_ {1.0f};
 };
 
 GenericLayer::GenericLayer(std::shared_ptr<gl::GlContext> glContext) :
@@ -43,6 +46,16 @@ bool GenericLayer::RunMousePicking(
 std::shared_ptr<gl::GlContext> GenericLayer::gl_context() const
 {
    return p->glContext_;
+}
+
+void GenericLayer::set_opacity(float opacity)
+{
+   p->opacity_ = std::clamp(opacity, 0.0f, 1.0f);
+}
+
+float GenericLayer::opacity() const
+{
+   return p->opacity_;
 }
 
 } // namespace scwx::qt::map

--- a/scwx-qt/source/scwx/qt/map/generic_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.hpp
@@ -50,6 +50,9 @@ public:
                    const common::Coordinate&                     mouseGeoCoords,
                    std::shared_ptr<types::EventHandler>&         eventHandler);
 
+   void                set_opacity(float opacity);
+   [[nodiscard]] float opacity() const;
+
 signals:
    void NeedsRendering();
 

--- a/scwx-qt/source/scwx/qt/map/generic_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/generic_layer.hpp
@@ -53,6 +53,9 @@ public:
    void                set_opacity(float opacity);
    [[nodiscard]] float opacity() const;
 
+   void BindLayerState();
+   void ResetLayerState();
+
 signals:
    void NeedsRendering();
 

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
@@ -1,4 +1,5 @@
 #include <scwx/qt/map/layer_wrapper.hpp>
+#include <scwx/qt/gl/shader_program.hpp>
 
 namespace scwx::qt::map
 {
@@ -47,7 +48,9 @@ void LayerWrapper::render(const QMapLibre::CustomLayerRenderParameters& params)
    auto& layer = p->layer_;
    if (layer != nullptr)
    {
+      gl::ShaderProgram::SetCurrentLayerOpacity(layer->opacity());
       layer->Render(p->mapContext_, params);
+      gl::ShaderProgram::SetCurrentLayerOpacity(1.0f);
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
+++ b/scwx-qt/source/scwx/qt/map/layer_wrapper.cpp
@@ -1,5 +1,4 @@
 #include <scwx/qt/map/layer_wrapper.hpp>
-#include <scwx/qt/gl/shader_program.hpp>
 
 namespace scwx::qt::map
 {
@@ -48,9 +47,9 @@ void LayerWrapper::render(const QMapLibre::CustomLayerRenderParameters& params)
    auto& layer = p->layer_;
    if (layer != nullptr)
    {
-      gl::ShaderProgram::SetCurrentLayerOpacity(layer->opacity());
+      layer->BindLayerState();
       layer->Render(p->mapContext_, params);
-      gl::ShaderProgram::SetCurrentLayerOpacity(1.0f);
+      layer->ResetLayerState();
    }
 }
 

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -89,6 +89,25 @@ namespace
 
 constexpr int kFallbackEraseCursorRadiusPx {8};
 
+std::string CustomLayerId(types::LayerType        type,
+                          types::LayerDescription description)
+{
+   if (type == types::LayerType::Alert &&
+       std::holds_alternative<awips::Phenomenon>(description))
+   {
+      return fmt::format(
+         "alert.{}",
+         awips::GetPhenomenonCode(std::get<awips::Phenomenon>(description)));
+   }
+
+   return types::GetLayerName(type, description);
+}
+
+float LayerOpacity(const types::LayerInfo& info)
+{
+   return types::LayerSupportsOpacity(info.type_) ? info.opacity_ : 1.0f;
+}
+
 /** Ring + eraser in pixmap so KDE/Wayland compositor tracks cursor with zero
  * lag. Pixmap radius is capped (~124px) for display only; geographic erase pick
  * and `EraseCursorRadiusPx` use the full brush width in ground meters. */
@@ -285,6 +304,7 @@ public:
                           const std::string& before);
    void ConnectMapSignals();
    void ConnectSignals();
+   void UpdateLayerOpacities();
    void HandleHotkeyPressed(types::Hotkey hotkey, bool isAutoRepeat);
    void HandleHotkeyReleased(types::Hotkey hotkey);
    void HandleHotkeyUpdates();
@@ -346,6 +366,8 @@ public:
    std::list<std::string>          layerList_;
 
    std::vector<std::shared_ptr<GenericLayer>> genericLayers_ {};
+   std::unordered_map<std::string, std::shared_ptr<GenericLayer>>
+      genericLayerMap_ {};
 
    const std::vector<MapStyle> emptyStyles_ {};
    const std::vector<MapStyle> noneStyles_ {
@@ -553,6 +575,8 @@ void MapWidgetImpl::ConnectSignals()
            {
               static const int enabledColumn =
                  static_cast<int>(model::LayerModel::Column::Enabled);
+              static const int opacityColumn =
+                 static_cast<int>(model::LayerModel::Column::Opacity);
               const int displayColumn =
                  static_cast<int>(model::LayerModel::Column::DisplayMap1) +
                  static_cast<int>(id_);
@@ -565,6 +589,11 @@ void MapWidgetImpl::ConnectSignals()
                    enabledColumn <= bottomRight.column()))
               {
                  AddLayers();
+              }
+              else if (topLeft.column() <= opacityColumn &&
+                       opacityColumn <= bottomRight.column())
+              {
+                 UpdateLayerOpacities();
               }
            });
    connect(layerModel_.get(),
@@ -1605,6 +1634,7 @@ void MapWidgetImpl::AddLayers()
    }
    layerList_.clear();
    genericLayers_.clear();
+   genericLayerMap_.clear();
    placefileLayers_.clear();
 
    // Update custom layer list from model
@@ -1667,6 +1697,8 @@ void MapWidgetImpl::AddLayers()
    {
       context_->set_color_table_margins({});
    }
+
+   UpdateLayerOpacities();
 }
 
 void MapWidgetImpl::AddLayer(types::LayerType        type,
@@ -1786,7 +1818,8 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
                map_,
                radarProductView->range(),
                {radarSite->latitude(), radarSite->longitude()},
-               QString::fromStdString(before));
+               QString::fromStdString(before),
+               LayerOpacity(layerModel_->GetLayerInfo(type, description)));
             layerList_.push_back(types::GetLayerName(type, description));
          }
          break;
@@ -1832,6 +1865,7 @@ void MapWidgetImpl::AddLayer(const std::string&                   id,
 
       layerList_.push_back(id);
       genericLayers_.push_back(layer);
+      genericLayerMap_[id] = layer;
 
       connect(layer.get(),
               &GenericLayer::NeedsRendering,
@@ -1842,6 +1876,33 @@ void MapWidgetImpl::AddLayer(const std::string&                   id,
    {
       // When dragging and dropping, a temporary duplicate layer exists
    }
+}
+
+void MapWidgetImpl::UpdateLayerOpacities()
+{
+   const types::LayerVector layers = layerModel_->GetLayers();
+   for (const auto& info : layers)
+   {
+      const float opacity = LayerOpacity(info);
+
+      if (info.type_ == types::LayerType::Data &&
+          std::holds_alternative<types::DataLayer>(info.description_) &&
+          std::get<types::DataLayer>(info.description_) ==
+             types::DataLayer::RadarRange)
+      {
+         RadarRangeLayer::SetOpacity(map_, opacity);
+         continue;
+      }
+
+      const std::string id = CustomLayerId(info.type_, info.description_);
+      auto              it = genericLayerMap_.find(id);
+      if (it != genericLayerMap_.end() && it->second != nullptr)
+      {
+         it->second->set_opacity(opacity);
+      }
+   }
+
+   widget_->update();
 }
 
 bool MapWidget::event(QEvent* e)
@@ -2448,9 +2509,9 @@ MapWidgetImpl::ResolveMapStyleName(const std::string& preferredStyleName) const
    if ((customStyles_[0].IsValid() && preferredStyleName == "Custom") ||
        preferredStyleName == "None" ||
        std::ranges::find_if(mapProviderInfo.mapStyles_,
-                            [&](const auto& mapStyle)
-                            { return mapStyle.name_ == preferredStyleName; }) !=
-          mapProviderInfo.mapStyles_.cend())
+                            [&](const auto& mapStyle) {
+                               return mapStyle.name_ == preferredStyleName;
+                            }) != mapProviderInfo.mapStyles_.cend())
    {
       return preferredStyleName;
    }
@@ -2693,8 +2754,7 @@ void MapWidgetImpl::RadarProductManagerConnect()
       connect(radarProductManager_.get(),
               &manager::RadarProductManager::IncomingLevel2ElevationChanged,
               this,
-              [this](std::optional<float> incomingElevation)
-              {
+              [this](std::optional<float> incomingElevation) {
                  Q_EMIT widget_->IncomingLevel2ElevationChanged(
                     incomingElevation);
               });

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -89,15 +89,18 @@ namespace
 
 constexpr int kFallbackEraseCursorRadiusPx {8};
 
+std::string CustomAlertLayerId(awips::Phenomenon phenomenon)
+{
+   return fmt::format("alert.{}", awips::GetPhenomenonCode(phenomenon));
+}
+
 std::string CustomLayerId(types::LayerType        type,
                           types::LayerDescription description)
 {
    if (type == types::LayerType::Alert &&
        std::holds_alternative<awips::Phenomenon>(description))
    {
-      return fmt::format(
-         "alert.{}",
-         awips::GetPhenomenonCode(std::get<awips::Phenomenon>(description)));
+      return CustomAlertLayerId(std::get<awips::Phenomenon>(description));
    }
 
    return types::GetLayerName(type, description);
@@ -1724,9 +1727,7 @@ void MapWidgetImpl::AddLayer(types::LayerType        type,
 
       std::shared_ptr<AlertLayer> alertLayer =
          std::make_shared<AlertLayer>(glContext_, phenomenon);
-      AddLayer(fmt::format("alert.{}", awips::GetPhenomenonCode(phenomenon)),
-               alertLayer,
-               before);
+      AddLayer(CustomAlertLayerId(phenomenon), alertLayer, before);
       connect(alertLayer.get(),
               &AlertLayer::AlertSelected,
               widget_,
@@ -1865,7 +1866,7 @@ void MapWidgetImpl::AddLayer(const std::string&                   id,
 
       layerList_.push_back(id);
       genericLayers_.push_back(layer);
-      genericLayerMap_[id] = layer;
+      genericLayerMap_.insert_or_assign(id, layer);
 
       connect(layer.get(),
               &GenericLayer::NeedsRendering,

--- a/scwx-qt/source/scwx/qt/map/map_widget.cpp
+++ b/scwx-qt/source/scwx/qt/map/map_widget.cpp
@@ -2509,9 +2509,9 @@ MapWidgetImpl::ResolveMapStyleName(const std::string& preferredStyleName) const
    if ((customStyles_[0].IsValid() && preferredStyleName == "Custom") ||
        preferredStyleName == "None" ||
        std::ranges::find_if(mapProviderInfo.mapStyles_,
-                            [&](const auto& mapStyle) {
-                               return mapStyle.name_ == preferredStyleName;
-                            }) != mapProviderInfo.mapStyles_.cend())
+                            [&](const auto& mapStyle)
+                            { return mapStyle.name_ == preferredStyleName; }) !=
+          mapProviderInfo.mapStyles_.cend())
    {
       return preferredStyleName;
    }
@@ -2754,7 +2754,8 @@ void MapWidgetImpl::RadarProductManagerConnect()
       connect(radarProductManager_.get(),
               &manager::RadarProductManager::IncomingLevel2ElevationChanged,
               this,
-              [this](std::optional<float> incomingElevation) {
+              [this](std::optional<float> incomingElevation)
+              {
                  Q_EMIT widget_->IncomingLevel2ElevationChanged(
                     incomingElevation);
               });

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
@@ -17,7 +17,8 @@ GetRangeCircle(float range, QMapLibre::Coordinate center);
 void RadarRangeLayer::Add(std::shared_ptr<QMapLibre::Map> map,
                           float                           range,
                           QMapLibre::Coordinate           center,
-                          const QString&                  before)
+                          const QString&                  before,
+                          float                           opacity)
 {
    static const QString layerId = QString::fromStdString(types::GetLayerName(
       types::LayerType::Data, types::DataLayer::RadarRange));
@@ -42,6 +43,19 @@ void RadarRangeLayer::Add(std::shared_ptr<QMapLibre::Map> map,
    map->addLayer(
       layerId, {{"type", "line"}, {"source", "rangeCircleSource"}}, before);
    map->setPaintProperty(layerId, "line-color", "rgba(128, 128, 128, 128)");
+   map->setPaintProperty(layerId, "line-opacity", opacity);
+}
+
+void RadarRangeLayer::SetOpacity(std::shared_ptr<QMapLibre::Map> map,
+                                 float                           opacity)
+{
+   static const QString layerId = QString::fromStdString(types::GetLayerName(
+      types::LayerType::Data, types::DataLayer::RadarRange));
+
+   if (map != nullptr && map->layerExists(layerId))
+   {
+      map->setPaintProperty(layerId, "line-opacity", opacity);
+   }
 }
 
 void RadarRangeLayer::Update(std::shared_ptr<QMapLibre::Map> map,

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.cpp
@@ -14,11 +14,11 @@ static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 static std::shared_ptr<QMapLibre::Feature>
 GetRangeCircle(float range, QMapLibre::Coordinate center);
 
-void RadarRangeLayer::Add(std::shared_ptr<QMapLibre::Map> map,
-                          float                           range,
-                          QMapLibre::Coordinate           center,
-                          const QString&                  before,
-                          float                           opacity)
+void RadarRangeLayer::Add(const std::shared_ptr<QMapLibre::Map>& map,
+                          float                                  range,
+                          QMapLibre::Coordinate                  center,
+                          const QString&                         before,
+                          float                                  opacity)
 {
    static const QString layerId = QString::fromStdString(types::GetLayerName(
       types::LayerType::Data, types::DataLayer::RadarRange));
@@ -46,8 +46,8 @@ void RadarRangeLayer::Add(std::shared_ptr<QMapLibre::Map> map,
    map->setPaintProperty(layerId, "line-opacity", opacity);
 }
 
-void RadarRangeLayer::SetOpacity(std::shared_ptr<QMapLibre::Map> map,
-                                 float                           opacity)
+void RadarRangeLayer::SetOpacity(const std::shared_ptr<QMapLibre::Map>& map,
+                                 float                                  opacity)
 {
    static const QString layerId = QString::fromStdString(types::GetLayerName(
       types::LayerType::Data, types::DataLayer::RadarRange));
@@ -58,9 +58,9 @@ void RadarRangeLayer::SetOpacity(std::shared_ptr<QMapLibre::Map> map,
    }
 }
 
-void RadarRangeLayer::Update(std::shared_ptr<QMapLibre::Map> map,
-                             float                           range,
-                             QMapLibre::Coordinate           center)
+void RadarRangeLayer::Update(const std::shared_ptr<QMapLibre::Map>& map,
+                             float                                  range,
+                             QMapLibre::Coordinate                  center)
 {
    std::shared_ptr<QMapLibre::Feature> rangeCircle =
       GetRangeCircle(range, center);

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
@@ -5,14 +5,14 @@
 namespace scwx::qt::map::RadarRangeLayer
 {
 
-void Add(std::shared_ptr<QMapLibre::Map> map,
-         float                           range,
-         QMapLibre::Coordinate           center,
-         const QString&                  before  = QString(),
-         float                           opacity = 1.0f);
-void Update(std::shared_ptr<QMapLibre::Map> map,
-            float                           range,
-            QMapLibre::Coordinate           center);
-void SetOpacity(std::shared_ptr<QMapLibre::Map> map, float opacity);
+void Add(const std::shared_ptr<QMapLibre::Map>& map,
+         float                                  range,
+         QMapLibre::Coordinate                  center,
+         const QString&                         before  = QString(),
+         float                                  opacity = 1.0f);
+void Update(const std::shared_ptr<QMapLibre::Map>& map,
+            float                                  range,
+            QMapLibre::Coordinate                  center);
+void SetOpacity(const std::shared_ptr<QMapLibre::Map>& map, float opacity);
 
 } // namespace scwx::qt::map::RadarRangeLayer

--- a/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
+++ b/scwx-qt/source/scwx/qt/map/radar_range_layer.hpp
@@ -8,9 +8,11 @@ namespace scwx::qt::map::RadarRangeLayer
 void Add(std::shared_ptr<QMapLibre::Map> map,
          float                           range,
          QMapLibre::Coordinate           center,
-         const QString&                  before = QString());
+         const QString&                  before  = QString(),
+         float                           opacity = 1.0f);
 void Update(std::shared_ptr<QMapLibre::Map> map,
             float                           range,
             QMapLibre::Coordinate           center);
+void SetOpacity(std::shared_ptr<QMapLibre::Map> map, float opacity);
 
 } // namespace scwx::qt::map::RadarRangeLayer

--- a/scwx-qt/source/scwx/qt/model/layer_model.cpp
+++ b/scwx-qt/source/scwx/qt/model/layer_model.cpp
@@ -280,6 +280,15 @@ void LayerModel::Impl::ValidateLayerSettings(types::LayerVector& layers)
       it->movable_ = (it->type_ != types::LayerType::Information &&
                       it->type_ != types::LayerType::Map);
 
+      if (types::LayerSupportsOpacity(it->type_))
+      {
+         it->opacity_ = types::ClampLayerOpacity(it->opacity_);
+      }
+      else
+      {
+         it->opacity_ = 1.0f;
+      }
+
       // Continue to the next layer
       ++it;
    }
@@ -383,11 +392,12 @@ LayerModel::GetLayerInfo(types::LayerType        type,
                          types::LayerDescription description) const
 {
    // Find the matching layer
-   auto it = std::find_if(
-      p->layers_.begin(),
-      p->layers_.end(),
-      [&](const types::LayerInfo& layer)
-      { return layer.type_ == type && layer.description_ == description; });
+   auto it = std::find_if(p->layers_.begin(),
+                          p->layers_.end(),
+                          [&](const types::LayerInfo& layer) {
+                             return layer.type_ == type &&
+                                    layer.description_ == description;
+                          });
    if (it != p->layers_.end())
    {
       // Return the layer info
@@ -407,11 +417,12 @@ void LayerModel::SetLayerDisplayed(types::LayerType        type,
                                    bool                    displayed)
 {
    // Find the matching layer
-   auto it = std::find_if(
-      p->layers_.begin(),
-      p->layers_.end(),
-      [&](const types::LayerInfo& layer)
-      { return layer.type_ == type && layer.description_ == description; });
+   auto it = std::find_if(p->layers_.begin(),
+                          p->layers_.end(),
+                          [&](const types::LayerInfo& layer) {
+                             return layer.type_ == type &&
+                                    layer.description_ == description;
+                          });
 
    if (it != p->layers_.end())
    {
@@ -431,6 +442,40 @@ void LayerModel::SetLayerDisplayed(types::LayerType        type,
       // Notify observers
       Q_EMIT dataChanged(topLeft, bottomRight);
    }
+}
+
+bool LayerModel::SetLayerOpacity(types::LayerType        type,
+                                 types::LayerDescription description,
+                                 float                   opacity)
+{
+   if (!types::LayerSupportsOpacity(type))
+   {
+      return false;
+   }
+
+   auto it = std::find_if(p->layers_.begin(),
+                          p->layers_.end(),
+                          [&](const types::LayerInfo& layer) {
+                             return layer.type_ == type &&
+                                    layer.description_ == description;
+                          });
+
+   if (it == p->layers_.end())
+   {
+      return false;
+   }
+
+   const float clamped = types::ClampLayerOpacity(opacity);
+   if (it->opacity_ == clamped)
+   {
+      return false;
+   }
+
+   it->opacity_      = clamped;
+   const int   row   = std::distance(p->layers_.begin(), it);
+   QModelIndex index = createIndex(row, static_cast<int>(Column::Opacity));
+   Q_EMIT dataChanged(index, index);
+   return true;
 }
 
 void LayerModel::ResetLayers()
@@ -455,9 +500,7 @@ void LayerModel::ResetLayers()
    {
       if (it->type_ == types::LayerType::Placefile)
       {
-         newLayers.insert(
-            radarSiteIterator + 1,
-            {it->type_, it->description_, it->movable_, it->displayed_});
+         newLayers.insert(radarSiteIterator + 1, *it);
       }
    }
 
@@ -532,6 +575,13 @@ Qt::ItemFlags LayerModel::flags(const QModelIndex& index) const
       {
          flags |=
             Qt::ItemFlag::ItemIsUserCheckable | Qt::ItemFlag::ItemIsEditable;
+      }
+      break;
+
+   case static_cast<int>(Column::Opacity):
+      if (types::LayerSupportsOpacity(layer.type_))
+      {
+         flags |= Qt::ItemFlag::ItemIsEditable;
       }
       break;
 
@@ -640,6 +690,25 @@ QVariant LayerModel::data(const QModelIndex& index, int role) const
       }
       break;
 
+   case static_cast<int>(Column::Opacity):
+      if (role == Qt::ItemDataRole::DisplayRole ||
+          role == Qt::ItemDataRole::ToolTipRole)
+      {
+         if (!types::LayerSupportsOpacity(layer.type_))
+         {
+            return QObject::tr("Opaque");
+         }
+
+         return QStringLiteral("%1%").arg(
+            types::LayerOpacityToPercent(layer.opacity_));
+      }
+      else if (role == Qt::ItemDataRole::EditRole &&
+               types::LayerSupportsOpacity(layer.type_))
+      {
+         return types::LayerOpacityToPercent(layer.opacity_);
+      }
+      break;
+
    case static_cast<int>(Column::Description):
       if (role == Qt::ItemDataRole::DisplayRole ||
           role == Qt::ItemDataRole::ToolTipRole)
@@ -715,6 +784,9 @@ LayerModel::headerData(int section, Qt::Orientation orientation, int role) const
          case static_cast<int>(Column::Enabled):
             return tr("Enabled");
 
+         case static_cast<int>(Column::Opacity):
+            return tr("Opacity");
+
          case static_cast<int>(Column::Description):
             return tr("Description");
 
@@ -756,6 +828,9 @@ LayerModel::headerData(int section, Qt::Orientation orientation, int role) const
 
       case static_cast<int>(Column::DisplayMap9):
          return tr("Display on Map 9");
+
+      case static_cast<int>(Column::Opacity):
+         return tr("Layer opacity. Map style layers stay opaque.");
 
       default:
          break;
@@ -827,6 +902,25 @@ bool LayerModel::setData(const QModelIndex& index,
       }
       break;
 
+   case static_cast<int>(Column::Opacity):
+      if (role == Qt::ItemDataRole::EditRole &&
+          types::LayerSupportsOpacity(layer.type_))
+      {
+         bool ok             = false;
+         int  opacityPercent = value.toInt(&ok);
+         if (ok)
+         {
+            const float opacity =
+               types::LayerOpacityFromPercent(opacityPercent);
+            if (layer.opacity_ != opacity)
+            {
+               layer.opacity_ = opacity;
+               result         = true;
+            }
+         }
+      }
+      break;
+
    default:
       break;
    }
@@ -834,7 +928,10 @@ bool LayerModel::setData(const QModelIndex& index,
    if (result)
    {
       Q_EMIT dataChanged(index, index);
-      Q_EMIT LayerDisplayChanged(layer);
+      if (index.column() != static_cast<int>(Column::Opacity))
+      {
+         Q_EMIT LayerDisplayChanged(layer);
+      }
    }
 
    return result;

--- a/scwx-qt/source/scwx/qt/model/layer_model.cpp
+++ b/scwx-qt/source/scwx/qt/model/layer_model.cpp
@@ -392,12 +392,11 @@ LayerModel::GetLayerInfo(types::LayerType        type,
                          types::LayerDescription description) const
 {
    // Find the matching layer
-   auto it = std::find_if(p->layers_.begin(),
-                          p->layers_.end(),
-                          [&](const types::LayerInfo& layer) {
-                             return layer.type_ == type &&
-                                    layer.description_ == description;
-                          });
+   auto it = std::find_if(
+      p->layers_.begin(),
+      p->layers_.end(),
+      [&](const types::LayerInfo& layer)
+      { return layer.type_ == type && layer.description_ == description; });
    if (it != p->layers_.end())
    {
       // Return the layer info
@@ -417,12 +416,11 @@ void LayerModel::SetLayerDisplayed(types::LayerType        type,
                                    bool                    displayed)
 {
    // Find the matching layer
-   auto it = std::find_if(p->layers_.begin(),
-                          p->layers_.end(),
-                          [&](const types::LayerInfo& layer) {
-                             return layer.type_ == type &&
-                                    layer.description_ == description;
-                          });
+   auto it = std::find_if(
+      p->layers_.begin(),
+      p->layers_.end(),
+      [&](const types::LayerInfo& layer)
+      { return layer.type_ == type && layer.description_ == description; });
 
    if (it != p->layers_.end())
    {
@@ -453,12 +451,11 @@ bool LayerModel::SetLayerOpacity(types::LayerType        type,
       return false;
    }
 
-   auto it = std::find_if(p->layers_.begin(),
-                          p->layers_.end(),
-                          [&](const types::LayerInfo& layer) {
-                             return layer.type_ == type &&
-                                    layer.description_ == description;
-                          });
+   auto it = std::find_if(
+      p->layers_.begin(),
+      p->layers_.end(),
+      [&](const types::LayerInfo& layer)
+      { return layer.type_ == type && layer.description_ == description; });
 
    if (it == p->layers_.end())
    {
@@ -471,9 +468,10 @@ bool LayerModel::SetLayerOpacity(types::LayerType        type,
       return false;
    }
 
-   it->opacity_      = clamped;
-   const int   row   = std::distance(p->layers_.begin(), it);
-   QModelIndex index = createIndex(row, static_cast<int>(Column::Opacity));
+   it->opacity_  = clamped;
+   const int row = static_cast<int>(std::distance(p->layers_.begin(), it));
+   const QModelIndex index =
+      createIndex(row, static_cast<int>(Column::Opacity));
    Q_EMIT dataChanged(index, index);
    return true;
 }
@@ -906,8 +904,8 @@ bool LayerModel::setData(const QModelIndex& index,
       if (role == Qt::ItemDataRole::EditRole &&
           types::LayerSupportsOpacity(layer.type_))
       {
-         bool ok             = false;
-         int  opacityPercent = value.toInt(&ok);
+         bool      ok             = false;
+         const int opacityPercent = value.toInt(&ok);
          if (ok)
          {
             const float opacity =

--- a/scwx-qt/source/scwx/qt/model/layer_model.hpp
+++ b/scwx-qt/source/scwx/qt/model/layer_model.hpp
@@ -32,7 +32,8 @@ public:
       DisplayMap9 = 9,
       Type        = 10,
       Enabled     = 11,
-      Description = 12
+      Opacity     = 12,
+      Description = 13
    };
    using ColumnIterator =
       scwx::util::Iterator<Column, Column::Order, Column::Description>;
@@ -50,6 +51,9 @@ public:
    void                             SetLayerDisplayed(types::LayerType        type,
                                                       types::LayerDescription description,
                                                       bool                    displayed);
+   bool                             SetLayerOpacity(types::LayerType        type,
+                                                    types::LayerDescription description,
+                                                    float                   opacity);
 
    void ResetLayers();
 

--- a/scwx-qt/source/scwx/qt/types/layer_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/layer_types.cpp
@@ -1,5 +1,7 @@
 #include <scwx/qt/types/layer_types.hpp>
 
+#include <algorithm>
+#include <cmath>
 #include <unordered_map>
 
 #include <boost/algorithm/string.hpp>
@@ -39,6 +41,7 @@ static const std::string kTypeName_ {"type"};
 static const std::string kDescriptionName_ {"description"};
 static const std::string kMovableName_ {"movable"};
 static const std::string kDisplayedName_ {"displayed"};
+static const std::string kOpacityName_ {"opacity"};
 
 LayerType GetLayerType(const std::string& name)
 {
@@ -172,6 +175,29 @@ std::string GetLayerName(types::LayerType        type,
                       types::GetLayerDescriptionName(description));
 }
 
+bool LayerSupportsOpacity(LayerType type)
+{
+   return type != LayerType::Map && type != LayerType::Unknown;
+}
+
+float ClampLayerOpacity(float opacity)
+{
+   return std::clamp(opacity, 0.0f, 1.0f);
+}
+
+int LayerOpacityToPercent(float opacity)
+{
+   return std::clamp(
+      static_cast<int>(std::lround(ClampLayerOpacity(opacity) * 100.0f)),
+      0,
+      100);
+}
+
+float LayerOpacityFromPercent(int percent)
+{
+   return ClampLayerOpacity(static_cast<float>(percent) / 100.0f);
+}
+
 void tag_invoke(boost::json::value_from_tag,
                 boost::json::value& jv,
                 const LayerInfo&    record)
@@ -201,10 +227,15 @@ void tag_invoke(boost::json::value_from_tag,
       description = std::get<std::string>(record.description_);
    }
 
+   const float opacity = record.type_ == LayerType::Map ?
+                            1.0f :
+                            ClampLayerOpacity(record.opacity_);
+
    jv = {{kTypeName_, GetLayerTypeName(record.type_)},
          {kDescriptionName_, description},
          {kMovableName_, record.movable_},
-         {kDisplayedName_, boost::json::value_from(record.displayed_)}};
+         {kDisplayedName_, boost::json::value_from(record.displayed_)},
+         {kOpacityName_, opacity}};
 }
 
 LayerInfo tag_invoke(boost::json::value_to_tag<LayerInfo>,
@@ -242,11 +273,28 @@ LayerInfo tag_invoke(boost::json::value_to_tag<LayerInfo>,
       description = descriptionName;
    }
 
+   float opacity = 1.0f;
+   if (const auto* object = jv.if_object(); object != nullptr)
+   {
+      if (const auto* opacityValue = object->if_contains(kOpacityName_);
+          opacityValue != nullptr && opacityValue->is_number())
+      {
+         opacity = ClampLayerOpacity(
+            static_cast<float>(opacityValue->to_number<double>()));
+      }
+   }
+
+   if (!LayerSupportsOpacity(layerType))
+   {
+      opacity = 1.0f;
+   }
+
    return LayerInfo {
       .type_        = layerType,
       .description_ = description,
       .movable_     = jv.at(kMovableName_).as_bool(),
-      .displayed_   = [&jv]()
+      .displayed_ =
+         [&jv]()
       {
          std::array<bool, types::kMapCount_> displayed {};
          const auto& displayedArray = jv.at(kDisplayedName_).as_array();
@@ -274,7 +322,8 @@ LayerInfo tag_invoke(boost::json::value_to_tag<LayerInfo>,
          }
 
          return displayed;
-      }()};
+      }(),
+      .opacity_ = opacity};
 }
 
 } // namespace scwx::qt::types

--- a/scwx-qt/source/scwx/qt/types/layer_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/layer_types.cpp
@@ -172,7 +172,7 @@ std::string GetLayerName(types::LayerType        type,
 {
    return fmt::format("scwx.{}.{}",
                       types::GetLayerTypeName(type),
-                      types::GetLayerDescriptionName(description));
+                      types::GetLayerDescriptionName(std::move(description)));
 }
 
 bool LayerSupportsOpacity(LayerType type)
@@ -187,10 +187,13 @@ float ClampLayerOpacity(float opacity)
 
 int LayerOpacityToPercent(float opacity)
 {
+   static constexpr int kMinOpacity = 0;
+   static constexpr int kMaxOpacity = 100;
+
    return std::clamp(
       static_cast<int>(std::lround(ClampLayerOpacity(opacity) * 100.0f)),
-      0,
-      100);
+      kMinOpacity,
+      kMaxOpacity);
 }
 
 float LayerOpacityFromPercent(int percent)

--- a/scwx-qt/source/scwx/qt/types/layer_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/layer_types.hpp
@@ -65,7 +65,14 @@ struct LayerInfo
    bool                         movable_ {true};
    std::array<bool, kMapCount_> displayed_ {
       true, true, true, true, true, true, true, true, true};
+   // 0.0 (transparent) to 1.0 (opaque). Map style layers stay at 1.0.
+   float opacity_ {1.0f};
 };
+
+bool  LayerSupportsOpacity(LayerType type);
+float ClampLayerOpacity(float opacity);
+int   LayerOpacityToPercent(float opacity);
+float LayerOpacityFromPercent(int percent);
 
 using LayerVector = boost::container::stable_vector<LayerInfo>;
 

--- a/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
@@ -24,6 +24,10 @@ namespace scwx::qt::ui
 static const std::string logPrefix_ = "scwx::qt::ui::layer_dialog";
 static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 
+static constexpr int kMinOpacity_   = 0;
+static constexpr int kMaxOpacity_   = 100;
+static constexpr int kTickInterval_ = 25;
+
 class LayerDialogImpl
 {
 public:
@@ -79,14 +83,14 @@ LayerDialog::LayerDialog(QWidget* parent) :
    opacityLayout->setContentsMargins(0, 0, 0, 0);
    opacityLayout->addWidget(new QLabel(tr("Opacity"), opacityFrame));
    p->opacitySlider_ = new QSlider(Qt::Orientation::Horizontal, opacityFrame);
-   p->opacitySlider_->setRange(0, 100);
+   p->opacitySlider_->setRange(kMinOpacity_, kMaxOpacity_);
    p->opacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
-   p->opacitySlider_->setTickInterval(25);
+   p->opacitySlider_->setTickInterval(kTickInterval_);
    p->opacitySlider_->setToolTip(
       tr("Layer opacity. Map style layers stay opaque."));
    opacityLayout->addWidget(p->opacitySlider_);
    p->opacitySpinBox_ = new QFocusedSpinBox(opacityFrame);
-   p->opacitySpinBox_->setRange(0, 100);
+   p->opacitySpinBox_->setRange(kMinOpacity_, kMaxOpacity_);
    p->opacitySpinBox_->setSuffix(tr("%"));
    p->opacitySpinBox_->setKeyboardTracking(false);
    opacityLayout->addWidget(p->opacitySpinBox_);
@@ -94,7 +98,8 @@ LayerDialog::LayerDialog(QWidget* parent) :
 
    auto layerViewHeader = ui->layerTreeView->header();
 
-   layerViewHeader->setMinimumSectionSize(10);
+   static constexpr int kMinimumSectionSize = 10;
+   layerViewHeader->setMinimumSectionSize(kMinimumSectionSize);
 
    // Give small columns a fixed size
    for (auto column : model::LayerModel::ColumnIterator())
@@ -428,10 +433,10 @@ void LayerDialogImpl::UpdateOpacityControls()
    updatingOpacityControls_ = true;
 
    const auto selectedRows   = GetSelectedRows();
-   int        opacityPercent = 100;
+   int        opacityPercent = kMaxOpacity_;
    bool       anyEditable    = false;
 
-   for (int row : selectedRows)
+   for (const int row : selectedRows)
    {
       const QModelIndex typeIndex = layerModel_->index(
          row, static_cast<int>(model::LayerModel::Column::Type));
@@ -471,7 +476,7 @@ void LayerDialogImpl::SetSelectedLayersOpacityPercent(int percent)
    opacitySpinBox_->setValue(percent);
    updatingOpacityControls_ = false;
 
-   for (int row : GetSelectedRows())
+   for (const int row : GetSelectedRows())
    {
       const QModelIndex opacityIndex = layerModel_->index(
          row, static_cast<int>(model::LayerModel::Column::Opacity));

--- a/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
@@ -5,17 +5,14 @@
 #include <scwx/qt/settings/general_settings.hpp>
 #include <scwx/qt/types/layer_types.hpp>
 #include <scwx/qt/ui/layer_opacity_delegate.hpp>
-#include <scwx/qt/ui/widgets/focused_spin_box.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <boost/signals2/connection.hpp>
 
-#include <QFrame>
-#include <QHBoxLayout>
-#include <QLabel>
 #include <QPushButton>
 #include <QSlider>
 #include <QSortFilterProxyModel>
+#include <QSpinBox>
 #include <QWidget>
 
 namespace scwx::qt::ui
@@ -24,9 +21,7 @@ namespace scwx::qt::ui
 static const std::string logPrefix_ = "scwx::qt::ui::layer_dialog";
 static const auto        logger_    = scwx::util::Logger::Create(logPrefix_);
 
-static constexpr int kMinOpacity_   = 0;
-static constexpr int kMaxOpacity_   = 100;
-static constexpr int kTickInterval_ = 25;
+static constexpr int kMaxOpacity_ = 100;
 
 class LayerDialogImpl
 {
@@ -59,8 +54,6 @@ public:
    std::shared_ptr<model::LayerModel> layerModel_;
    QSortFilterProxyModel*             layerProxyModel_;
    LayerOpacityDelegate*              opacityDelegate_ {};
-   QSlider*                           opacitySlider_ {};
-   QFocusedSpinBox*                   opacitySpinBox_ {};
    bool                               updatingOpacityControls_ {false};
 };
 
@@ -77,24 +70,6 @@ LayerDialog::LayerDialog(QWidget* parent) :
    ui->layerTreeView->setItemDelegateForColumn(
       static_cast<int>(model::LayerModel::Column::Opacity),
       p->opacityDelegate_);
-
-   auto* opacityFrame  = new QFrame(this);
-   auto* opacityLayout = new QHBoxLayout(opacityFrame);
-   opacityLayout->setContentsMargins(0, 0, 0, 0);
-   opacityLayout->addWidget(new QLabel(tr("Opacity"), opacityFrame));
-   p->opacitySlider_ = new QSlider(Qt::Orientation::Horizontal, opacityFrame);
-   p->opacitySlider_->setRange(kMinOpacity_, kMaxOpacity_);
-   p->opacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
-   p->opacitySlider_->setTickInterval(kTickInterval_);
-   p->opacitySlider_->setToolTip(
-      tr("Layer opacity. Map style layers stay opaque."));
-   opacityLayout->addWidget(p->opacitySlider_);
-   p->opacitySpinBox_ = new QFocusedSpinBox(opacityFrame);
-   p->opacitySpinBox_->setRange(kMinOpacity_, kMaxOpacity_);
-   p->opacitySpinBox_->setSuffix(tr("%"));
-   p->opacitySpinBox_->setKeyboardTracking(false);
-   opacityLayout->addWidget(p->opacitySpinBox_);
-   ui->verticalLayout->insertWidget(1, opacityFrame);
 
    auto layerViewHeader = ui->layerTreeView->header();
 
@@ -181,12 +156,12 @@ void LayerDialogImpl::ConnectSignals()
                        UpdateOpacityControls();
                     });
 
-   QObject::connect(opacitySlider_,
+   QObject::connect(self_->ui->opacitySlider,
                     &QSlider::valueChanged,
                     self_,
                     [this](int value)
                     { SetSelectedLayersOpacityPercent(value); });
-   QObject::connect(opacitySpinBox_,
+   QObject::connect(self_->ui->opacitySpinBox,
                     &QSpinBox::valueChanged,
                     self_,
                     [this](int value)
@@ -456,10 +431,10 @@ void LayerDialogImpl::UpdateOpacityControls()
       break;
    }
 
-   opacitySlider_->setEnabled(anyEditable);
-   opacitySpinBox_->setEnabled(anyEditable);
-   opacitySlider_->setValue(opacityPercent);
-   opacitySpinBox_->setValue(opacityPercent);
+   self_->ui->opacitySlider->setEnabled(anyEditable);
+   self_->ui->opacitySpinBox->setEnabled(anyEditable);
+   self_->ui->opacitySlider->setValue(opacityPercent);
+   self_->ui->opacitySpinBox->setValue(opacityPercent);
 
    updatingOpacityControls_ = false;
 }
@@ -472,8 +447,8 @@ void LayerDialogImpl::SetSelectedLayersOpacityPercent(int percent)
    }
 
    updatingOpacityControls_ = true;
-   opacitySlider_->setValue(percent);
-   opacitySpinBox_->setValue(percent);
+   self_->ui->opacitySlider->setValue(percent);
+   self_->ui->opacitySpinBox->setValue(percent);
    updatingOpacityControls_ = false;
 
    for (const int row : GetSelectedRows())

--- a/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_dialog.cpp
@@ -3,12 +3,20 @@
 
 #include <scwx/qt/model/layer_model.hpp>
 #include <scwx/qt/settings/general_settings.hpp>
+#include <scwx/qt/types/layer_types.hpp>
+#include <scwx/qt/ui/layer_opacity_delegate.hpp>
+#include <scwx/qt/ui/widgets/focused_spin_box.hpp>
 #include <scwx/util/logger.hpp>
 
 #include <boost/signals2/connection.hpp>
 
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QPushButton>
+#include <QSlider>
 #include <QSortFilterProxyModel>
+#include <QWidget>
 
 namespace scwx::qt::ui
 {
@@ -34,6 +42,8 @@ public:
    void ConnectSignals();
    void UpdateMapDisplayColumns();
    void UpdateMoveButtonsEnabled();
+   void UpdateOpacityControls();
+   void SetSelectedLayersOpacityPercent(int percent);
 
    boost::signals2::scoped_connection gridWidthSettingsConnection_ {};
    boost::signals2::scoped_connection gridHeightSettingsConnection_ {};
@@ -44,6 +54,10 @@ public:
    LayerDialog*                       self_;
    std::shared_ptr<model::LayerModel> layerModel_;
    QSortFilterProxyModel*             layerProxyModel_;
+   LayerOpacityDelegate*              opacityDelegate_ {};
+   QSlider*                           opacitySlider_ {};
+   QFocusedSpinBox*                   opacitySpinBox_ {};
+   bool                               updatingOpacityControls_ {false};
 };
 
 LayerDialog::LayerDialog(QWidget* parent) :
@@ -54,6 +68,29 @@ LayerDialog::LayerDialog(QWidget* parent) :
    ui->setupUi(this);
 
    ui->layerTreeView->setModel(p->layerProxyModel_);
+
+   p->opacityDelegate_ = new LayerOpacityDelegate(ui->layerTreeView);
+   ui->layerTreeView->setItemDelegateForColumn(
+      static_cast<int>(model::LayerModel::Column::Opacity),
+      p->opacityDelegate_);
+
+   auto* opacityFrame  = new QFrame(this);
+   auto* opacityLayout = new QHBoxLayout(opacityFrame);
+   opacityLayout->setContentsMargins(0, 0, 0, 0);
+   opacityLayout->addWidget(new QLabel(tr("Opacity"), opacityFrame));
+   p->opacitySlider_ = new QSlider(Qt::Orientation::Horizontal, opacityFrame);
+   p->opacitySlider_->setRange(0, 100);
+   p->opacitySlider_->setTickPosition(QSlider::TickPosition::TicksBelow);
+   p->opacitySlider_->setTickInterval(25);
+   p->opacitySlider_->setToolTip(
+      tr("Layer opacity. Map style layers stay opaque."));
+   opacityLayout->addWidget(p->opacitySlider_);
+   p->opacitySpinBox_ = new QFocusedSpinBox(opacityFrame);
+   p->opacitySpinBox_->setRange(0, 100);
+   p->opacitySpinBox_->setSuffix(tr("%"));
+   p->opacitySpinBox_->setKeyboardTracking(false);
+   opacityLayout->addWidget(p->opacitySpinBox_);
+   ui->verticalLayout->insertWidget(1, opacityFrame);
 
    auto layerViewHeader = ui->layerTreeView->header();
 
@@ -79,6 +116,7 @@ LayerDialog::LayerDialog(QWidget* parent) :
    p->UpdateMapDisplayColumns();
 
    p->ConnectSignals();
+   p->UpdateOpacityControls();
 }
 
 LayerDialog::~LayerDialog()
@@ -117,7 +155,11 @@ void LayerDialogImpl::ConnectSignals()
       self_->ui->buttonBox->button(QDialogButtonBox::StandardButton::Reset),
       &QAbstractButton::clicked,
       self_,
-      [this]() { layerModel_->ResetLayers(); });
+      [this]()
+      {
+         layerModel_->ResetLayers();
+         UpdateOpacityControls();
+      });
 
    QObject::connect(self_->ui->layerFilter,
                     &QLineEdit::textChanged,
@@ -129,7 +171,40 @@ void LayerDialogImpl::ConnectSignals()
                     self_,
                     [this](const QItemSelection& /* selected */,
                            const QItemSelection& /* deselected */)
-                    { UpdateMoveButtonsEnabled(); });
+                    {
+                       UpdateMoveButtonsEnabled();
+                       UpdateOpacityControls();
+                    });
+
+   QObject::connect(opacitySlider_,
+                    &QSlider::valueChanged,
+                    self_,
+                    [this](int value)
+                    { SetSelectedLayersOpacityPercent(value); });
+   QObject::connect(opacitySpinBox_,
+                    &QSpinBox::valueChanged,
+                    self_,
+                    [this](int value)
+                    { SetSelectedLayersOpacityPercent(value); });
+
+   QObject::connect(
+      layerModel_.get(),
+      &QAbstractItemModel::dataChanged,
+      self_,
+      [this](const QModelIndex& topLeft, const QModelIndex& bottomRight)
+      {
+         const int opacityColumn =
+            static_cast<int>(model::LayerModel::Column::Opacity);
+         if (topLeft.column() <= opacityColumn &&
+             opacityColumn <= bottomRight.column())
+         {
+            UpdateOpacityControls();
+         }
+      });
+   QObject::connect(layerModel_.get(),
+                    &QAbstractItemModel::modelReset,
+                    self_,
+                    [this]() { UpdateOpacityControls(); });
 
    auto& generalSettings = settings::GeneralSettings::Instance();
    gridWidthSettingsConnection_ =
@@ -346,6 +421,67 @@ void LayerDialogImpl::UpdateMoveButtonsEnabled()
    self_->ui->moveUpButton->setEnabled(itemsMovableUp);
    self_->ui->moveDownButton->setEnabled(itemsMovableDown);
    self_->ui->moveBottomButton->setEnabled(itemsMovableDown);
+}
+
+void LayerDialogImpl::UpdateOpacityControls()
+{
+   updatingOpacityControls_ = true;
+
+   const auto selectedRows   = GetSelectedRows();
+   int        opacityPercent = 100;
+   bool       anyEditable    = false;
+
+   for (int row : selectedRows)
+   {
+      const QModelIndex typeIndex = layerModel_->index(
+         row, static_cast<int>(model::LayerModel::Column::Type));
+      const auto type =
+         types::GetLayerType(typeIndex.data(Qt::ItemDataRole::DisplayRole)
+                                .toString()
+                                .toStdString());
+      if (!types::LayerSupportsOpacity(type))
+      {
+         continue;
+      }
+
+      anyEditable                    = true;
+      const QModelIndex opacityIndex = layerModel_->index(
+         row, static_cast<int>(model::LayerModel::Column::Opacity));
+      opacityPercent = opacityIndex.data(Qt::ItemDataRole::EditRole).toInt();
+      break;
+   }
+
+   opacitySlider_->setEnabled(anyEditable);
+   opacitySpinBox_->setEnabled(anyEditable);
+   opacitySlider_->setValue(opacityPercent);
+   opacitySpinBox_->setValue(opacityPercent);
+
+   updatingOpacityControls_ = false;
+}
+
+void LayerDialogImpl::SetSelectedLayersOpacityPercent(int percent)
+{
+   if (updatingOpacityControls_)
+   {
+      return;
+   }
+
+   updatingOpacityControls_ = true;
+   opacitySlider_->setValue(percent);
+   opacitySpinBox_->setValue(percent);
+   updatingOpacityControls_ = false;
+
+   for (int row : GetSelectedRows())
+   {
+      const QModelIndex opacityIndex = layerModel_->index(
+         row, static_cast<int>(model::LayerModel::Column::Opacity));
+      if ((layerModel_->flags(opacityIndex) & Qt::ItemFlag::ItemIsEditable) ==
+          Qt::ItemFlag::ItemIsEditable)
+      {
+         layerModel_->setData(
+            opacityIndex, percent, Qt::ItemDataRole::EditRole);
+      }
+   }
 }
 
 } // namespace scwx::qt::ui

--- a/scwx-qt/source/scwx/qt/ui/layer_dialog.ui
+++ b/scwx-qt/source/scwx/qt/ui/layer_dialog.ui
@@ -143,6 +143,63 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="opacityFrame">
+     <layout class="QHBoxLayout" name="opacityLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="opacityLabel">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="opacitySlider">
+        <property name="toolTip">
+         <string>Layer opacity. Map style layers stay opaque.</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFocusedSpinBox" name="opacitySpinBox">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>%</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="frame_3">
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="leftMargin">
@@ -201,6 +258,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QFocusedSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>scwx/qt/ui/widgets/focused_spin_box.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../../../scwx-qt.qrc"/>
  </resources>

--- a/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.cpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.cpp
@@ -15,8 +15,11 @@ LayerOpacityDelegate::createEditor(QWidget* parent,
                                    const QStyleOptionViewItem& /* option */,
                                    const QModelIndex& /* index */) const
 {
+   static constexpr int kMinOpacity = 0;
+   static constexpr int kMaxOpacity = 100;
+
    auto* spinBox = new QFocusedSpinBox(parent);
-   spinBox->setRange(0, 100);
+   spinBox->setRange(kMinOpacity, kMaxOpacity);
    spinBox->setSuffix(tr("%"));
    spinBox->setKeyboardTracking(false);
    return spinBox;

--- a/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.cpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.cpp
@@ -1,0 +1,54 @@
+#include <scwx/qt/ui/layer_opacity_delegate.hpp>
+#include <scwx/qt/ui/widgets/focused_spin_box.hpp>
+
+namespace scwx::qt::ui
+{
+
+LayerOpacityDelegate::LayerOpacityDelegate(QObject* parent) :
+    QStyledItemDelegate(parent)
+{
+}
+LayerOpacityDelegate::~LayerOpacityDelegate() = default;
+
+QWidget*
+LayerOpacityDelegate::createEditor(QWidget* parent,
+                                   const QStyleOptionViewItem& /* option */,
+                                   const QModelIndex& /* index */) const
+{
+   auto* spinBox = new QFocusedSpinBox(parent);
+   spinBox->setRange(0, 100);
+   spinBox->setSuffix(tr("%"));
+   spinBox->setKeyboardTracking(false);
+   return spinBox;
+}
+
+void LayerOpacityDelegate::setEditorData(QWidget*           editor,
+                                         const QModelIndex& index) const
+{
+   auto* spinBox = qobject_cast<QFocusedSpinBox*>(editor);
+   if (spinBox != nullptr)
+   {
+      spinBox->setValue(index.data(Qt::ItemDataRole::EditRole).toInt());
+   }
+}
+
+void LayerOpacityDelegate::setModelData(QWidget*            editor,
+                                        QAbstractItemModel* model,
+                                        const QModelIndex&  index) const
+{
+   auto* spinBox = qobject_cast<QFocusedSpinBox*>(editor);
+   if (spinBox != nullptr)
+   {
+      model->setData(index, spinBox->value(), Qt::ItemDataRole::EditRole);
+   }
+}
+
+void LayerOpacityDelegate::updateEditorGeometry(
+   QWidget*                    editor,
+   const QStyleOptionViewItem& option,
+   const QModelIndex& /* index */) const
+{
+   editor->setGeometry(option.rect);
+}
+
+} // namespace scwx::qt::ui

--- a/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.hpp
+++ b/scwx-qt/source/scwx/qt/ui/layer_opacity_delegate.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+
+namespace scwx::qt::ui
+{
+
+class LayerOpacityDelegate : public QStyledItemDelegate
+{
+   Q_OBJECT
+   Q_DISABLE_COPY_MOVE(LayerOpacityDelegate)
+
+public:
+   explicit LayerOpacityDelegate(QObject* parent = nullptr);
+   ~LayerOpacityDelegate() override;
+
+   QWidget* createEditor(QWidget*                    parent,
+                         const QStyleOptionViewItem& option,
+                         const QModelIndex&          index) const override;
+   void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+   void setModelData(QWidget*            editor,
+                     QAbstractItemModel* model,
+                     const QModelIndex&  index) const override;
+   void updateEditorGeometry(QWidget*                    editor,
+                             const QStyleOptionViewItem& option,
+                             const QModelIndex&          index) const override;
+};
+
+} // namespace scwx::qt::ui

--- a/test/source/scwx/qt/gl/gl_context.test.cpp
+++ b/test/source/scwx/qt/gl/gl_context.test.cpp
@@ -1,7 +1,6 @@
 #include <scwx/qt/gl/gl_context.hpp>
 
 #include <cstddef>
-#include <cstring>
 
 #include <gtest/gtest.h>
 
@@ -16,7 +15,7 @@ TEST(LayerStateBlock, Std140Layout)
    EXPECT_EQ(offsetof(LayerStateBlock, opacity), 0u);
    EXPECT_EQ(alignof(LayerStateBlock), 16u);
 
-   LayerStateBlock block {};
+   const LayerStateBlock block {};
    EXPECT_FLOAT_EQ(block.opacity, 1.0f);
 }
 

--- a/test/source/scwx/qt/gl/gl_context.test.cpp
+++ b/test/source/scwx/qt/gl/gl_context.test.cpp
@@ -1,0 +1,23 @@
+#include <scwx/qt/gl/gl_context.hpp>
+
+#include <cstddef>
+#include <cstring>
+
+#include <gtest/gtest.h>
+
+namespace scwx::qt::gl
+{
+
+TEST(LayerStateBlock, Std140Layout)
+{
+   EXPECT_EQ(kLayerStateBindingPoint, 16u);
+   EXPECT_STREQ(kLayerStateBlockName, "LayerState");
+   EXPECT_EQ(sizeof(LayerStateBlock), 16u);
+   EXPECT_EQ(offsetof(LayerStateBlock, opacity), 0u);
+   EXPECT_EQ(alignof(LayerStateBlock), 16u);
+
+   LayerStateBlock block {};
+   EXPECT_FLOAT_EQ(block.opacity, 1.0f);
+}
+
+} // namespace scwx::qt::gl

--- a/test/source/scwx/qt/model/layer_model.test.cpp
+++ b/test/source/scwx/qt/model/layer_model.test.cpp
@@ -1,3 +1,4 @@
+#include <scwx/qt/main/application.hpp>
 #include <scwx/qt/model/layer_model.hpp>
 #include <scwx/qt/types/layer_types.hpp>
 
@@ -9,14 +10,22 @@ namespace scwx::qt::model
 class LayerModelOpacityTest : public ::testing::Test
 {
 protected:
-   void SetUp() override
+   static void SetUpTestSuite()
    {
+      // PlacefileManager waits on application initialization; without this
+      // the LayerModel destructor deadlocks joining that thread.
+      main::Application::FinishInitialization();
       model_ = LayerModel::Instance();
-      model_->ResetLayers();
    }
 
-   std::shared_ptr<LayerModel> model_ {};
+   static void TearDownTestSuite() { model_.reset(); }
+
+   void SetUp() override { model_->ResetLayers(); }
+
+   static std::shared_ptr<LayerModel> model_;
 };
+
+std::shared_ptr<LayerModel> LayerModelOpacityTest::model_ {};
 
 int FindRow(const std::shared_ptr<LayerModel>& model, types::LayerType type)
 {

--- a/test/source/scwx/qt/model/layer_model.test.cpp
+++ b/test/source/scwx/qt/model/layer_model.test.cpp
@@ -1,0 +1,93 @@
+#include <scwx/qt/model/layer_model.hpp>
+#include <scwx/qt/types/layer_types.hpp>
+
+#include <gtest/gtest.h>
+
+namespace scwx::qt::model
+{
+
+class LayerModelOpacityTest : public ::testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      model_ = LayerModel::Instance();
+      model_->ResetLayers();
+   }
+
+   std::shared_ptr<LayerModel> model_ {};
+};
+
+int FindRow(const std::shared_ptr<LayerModel>& model, types::LayerType type)
+{
+   for (int row = 0; row < model->rowCount(); ++row)
+   {
+      const QModelIndex typeIndex =
+         model->index(row, static_cast<int>(LayerModel::Column::Type));
+      if (types::GetLayerType(
+             typeIndex.data(Qt::DisplayRole).toString().toStdString()) == type)
+      {
+         return row;
+      }
+   }
+   return -1;
+}
+
+TEST_F(LayerModelOpacityTest, RadarOpacityIsEditable)
+{
+   const int radarRow = FindRow(model_, types::LayerType::Radar);
+   ASSERT_GE(radarRow, 0);
+
+   const QModelIndex opacityIndex =
+      model_->index(radarRow, static_cast<int>(LayerModel::Column::Opacity));
+
+   EXPECT_TRUE(model_->flags(opacityIndex) & Qt::ItemIsEditable);
+   EXPECT_EQ(opacityIndex.data(Qt::DisplayRole).toString(), "100%");
+   EXPECT_EQ(opacityIndex.data(Qt::EditRole).toInt(), 100);
+
+   EXPECT_TRUE(model_->setData(opacityIndex, 40, Qt::ItemDataRole::EditRole));
+   EXPECT_EQ(opacityIndex.data(Qt::EditRole).toInt(), 40);
+   EXPECT_EQ(opacityIndex.data(Qt::DisplayRole).toString(), "40%");
+
+   const types::LayerInfo info =
+      model_->GetLayerInfo(types::LayerType::Radar, std::monostate {});
+   EXPECT_FLOAT_EQ(info.opacity_, 0.4f);
+}
+
+TEST_F(LayerModelOpacityTest, MapStyleOpacityIsNotEditable)
+{
+   const int mapRow = FindRow(model_, types::LayerType::Map);
+   ASSERT_GE(mapRow, 0);
+
+   const QModelIndex opacityIndex =
+      model_->index(mapRow, static_cast<int>(LayerModel::Column::Opacity));
+
+   EXPECT_FALSE(model_->flags(opacityIndex) & Qt::ItemIsEditable);
+   EXPECT_EQ(opacityIndex.data(Qt::DisplayRole).toString(), "Opaque");
+   EXPECT_FALSE(model_->setData(opacityIndex, 25, Qt::ItemDataRole::EditRole));
+}
+
+TEST_F(LayerModelOpacityTest, SetLayerOpacityIgnoresMapLayers)
+{
+   EXPECT_FALSE(model_->SetLayerOpacity(
+      types::LayerType::Map, types::MapLayer::MapUnderlay, 0.2f));
+
+   EXPECT_TRUE(model_->SetLayerOpacity(
+      types::LayerType::Radar, std::monostate {}, 0.55f));
+   const types::LayerInfo info =
+      model_->GetLayerInfo(types::LayerType::Radar, std::monostate {});
+   EXPECT_FLOAT_EQ(info.opacity_, 0.55f);
+}
+
+TEST_F(LayerModelOpacityTest, ResetRestoresDefaultOpacity)
+{
+   ASSERT_TRUE(model_->SetLayerOpacity(
+      types::LayerType::Radar, std::monostate {}, 0.3f));
+   model_->ResetLayers();
+
+   const types::LayerInfo info =
+      model_->GetLayerInfo(types::LayerType::Radar, std::monostate {});
+   EXPECT_FLOAT_EQ(info.opacity_, 1.0f);
+}
+
+} // namespace scwx::qt::model

--- a/test/source/scwx/qt/types/layer_types.test.cpp
+++ b/test/source/scwx/qt/types/layer_types.test.cpp
@@ -41,7 +41,7 @@ TEST(LayerTypes, OpacityJsonRoundTrip)
                        .opacity_     = 0.6f};
 
    const boost::json::value json     = boost::json::value_from(original);
-   const LayerInfo          restored = boost::json::value_to<LayerInfo>(json);
+   const auto               restored = boost::json::value_to<LayerInfo>(json);
 
    EXPECT_EQ(restored.type_, LayerType::Radar);
    EXPECT_FLOAT_EQ(restored.opacity_, 0.6f);
@@ -57,7 +57,7 @@ TEST(LayerTypes, OpacityJsonDefaultsWhenMissing)
       {"movable", true},
       {"displayed", {true, true, true, true, true, true, true, true, true}}};
 
-   const LayerInfo restored = boost::json::value_to<LayerInfo>(json);
+   const auto restored = boost::json::value_to<LayerInfo>(json);
    EXPECT_EQ(restored.type_, LayerType::Radar);
    EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
 }
@@ -70,7 +70,7 @@ TEST(LayerTypes, MapStyleOpacityStaysOpaque)
                        .opacity_     = 0.25f};
 
    const boost::json::value json     = boost::json::value_from(mapLayer);
-   const LayerInfo          restored = boost::json::value_to<LayerInfo>(json);
+   const auto               restored = boost::json::value_to<LayerInfo>(json);
 
    EXPECT_EQ(restored.type_, LayerType::Map);
    EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
@@ -85,7 +85,7 @@ TEST(LayerTypes, OpacityJsonClampsOutOfRange)
                                     {"displayed", {true}},
                                     {"opacity", 2.5}};
 
-   const LayerInfo restored = boost::json::value_to<LayerInfo>(json);
+   const auto restored = boost::json::value_to<LayerInfo>(json);
    EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
 }
 

--- a/test/source/scwx/qt/types/layer_types.test.cpp
+++ b/test/source/scwx/qt/types/layer_types.test.cpp
@@ -1,0 +1,92 @@
+#include <scwx/qt/types/layer_types.hpp>
+
+#include <boost/json.hpp>
+#include <gtest/gtest.h>
+
+namespace scwx::qt::types
+{
+
+TEST(LayerTypes, LayerSupportsOpacity)
+{
+   EXPECT_TRUE(LayerSupportsOpacity(LayerType::Radar));
+   EXPECT_TRUE(LayerSupportsOpacity(LayerType::Alert));
+   EXPECT_TRUE(LayerSupportsOpacity(LayerType::Placefile));
+   EXPECT_TRUE(LayerSupportsOpacity(LayerType::Information));
+   EXPECT_TRUE(LayerSupportsOpacity(LayerType::Data));
+   EXPECT_FALSE(LayerSupportsOpacity(LayerType::Map));
+   EXPECT_FALSE(LayerSupportsOpacity(LayerType::Unknown));
+}
+
+TEST(LayerTypes, OpacityPercentConversion)
+{
+   EXPECT_EQ(LayerOpacityToPercent(1.0f), 100);
+   EXPECT_EQ(LayerOpacityToPercent(0.0f), 0);
+   EXPECT_EQ(LayerOpacityToPercent(0.5f), 50);
+   EXPECT_EQ(LayerOpacityToPercent(0.75f), 75);
+   EXPECT_EQ(LayerOpacityToPercent(1.5f), 100);
+   EXPECT_EQ(LayerOpacityToPercent(-0.2f), 0);
+
+   EXPECT_FLOAT_EQ(LayerOpacityFromPercent(100), 1.0f);
+   EXPECT_FLOAT_EQ(LayerOpacityFromPercent(0), 0.0f);
+   EXPECT_FLOAT_EQ(LayerOpacityFromPercent(50), 0.5f);
+   EXPECT_FLOAT_EQ(LayerOpacityFromPercent(150), 1.0f);
+   EXPECT_FLOAT_EQ(LayerOpacityFromPercent(-10), 0.0f);
+}
+
+TEST(LayerTypes, OpacityJsonRoundTrip)
+{
+   LayerInfo original {.type_        = LayerType::Radar,
+                       .description_ = std::monostate {},
+                       .movable_     = true,
+                       .opacity_     = 0.6f};
+
+   const boost::json::value json     = boost::json::value_from(original);
+   const LayerInfo          restored = boost::json::value_to<LayerInfo>(json);
+
+   EXPECT_EQ(restored.type_, LayerType::Radar);
+   EXPECT_FLOAT_EQ(restored.opacity_, 0.6f);
+   ASSERT_TRUE(json.is_object());
+   EXPECT_DOUBLE_EQ(json.as_object().at("opacity").to_number<double>(), 0.6);
+}
+
+TEST(LayerTypes, OpacityJsonDefaultsWhenMissing)
+{
+   const boost::json::value json = {
+      {"type", "Radar"},
+      {"description", ""},
+      {"movable", true},
+      {"displayed", {true, true, true, true, true, true, true, true, true}}};
+
+   const LayerInfo restored = boost::json::value_to<LayerInfo>(json);
+   EXPECT_EQ(restored.type_, LayerType::Radar);
+   EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
+}
+
+TEST(LayerTypes, MapStyleOpacityStaysOpaque)
+{
+   LayerInfo mapLayer {.type_        = LayerType::Map,
+                       .description_ = MapLayer::MapUnderlay,
+                       .movable_     = false,
+                       .opacity_     = 0.25f};
+
+   const boost::json::value json     = boost::json::value_from(mapLayer);
+   const LayerInfo          restored = boost::json::value_to<LayerInfo>(json);
+
+   EXPECT_EQ(restored.type_, LayerType::Map);
+   EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
+   EXPECT_DOUBLE_EQ(json.as_object().at("opacity").to_number<double>(), 1.0);
+}
+
+TEST(LayerTypes, OpacityJsonClampsOutOfRange)
+{
+   const boost::json::value json = {{"type", "Radar"},
+                                    {"description", ""},
+                                    {"movable", true},
+                                    {"displayed", {true}},
+                                    {"opacity", 2.5}};
+
+   const LayerInfo restored = boost::json::value_to<LayerInfo>(json);
+   EXPECT_FLOAT_EQ(restored.opacity_, 1.0f);
+}
+
+} // namespace scwx::qt::types

--- a/test/source/scwx/qt/types/layer_types.test.cpp
+++ b/test/source/scwx/qt/types/layer_types.test.cpp
@@ -46,7 +46,7 @@ TEST(LayerTypes, OpacityJsonRoundTrip)
    EXPECT_EQ(restored.type_, LayerType::Radar);
    EXPECT_FLOAT_EQ(restored.opacity_, 0.6f);
    ASSERT_TRUE(json.is_object());
-   EXPECT_DOUBLE_EQ(json.as_object().at("opacity").to_number<double>(), 0.6);
+   EXPECT_FLOAT_EQ(json.as_object().at("opacity").to_number<float>(), 0.6f);
 }
 
 TEST(LayerTypes, OpacityJsonDefaultsWhenMissing)

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -47,6 +47,7 @@ set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_annotation_layer.test.cpp
 set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp
                        source/scwx/qt/model/layer_model.test.cpp
                        source/scwx/qt/model/marker_model.test.cpp)
+set(SRC_QT_TYPES_TESTS source/scwx/qt/types/layer_types.test.cpp)
 set(SRC_QT_UI_TESTS source/scwx/qt/ui/threshold_value_utility.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp
@@ -55,8 +56,7 @@ set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
                       source/scwx/qt/util/geographic_lib.test.cpp
                       source/scwx/qt/util/network.test.cpp)
-set(SRC_TYPES_TESTS source/scwx/qt/types/layer_types.test.cpp
-                    source/scwx/types/ondas_types.test.cpp)
+set(SRC_TYPES_TESTS source/scwx/types/ondas_types.test.cpp)
 set(SRC_UTIL_TESTS source/scwx/util/float.test.cpp
                    source/scwx/util/rangebuf.test.cpp
                    source/scwx/util/streams.test.cpp
@@ -81,6 +81,7 @@ add_executable(wxtest ${SRC_MAIN}
                       ${SRC_QT_MANAGER_TESTS}
                       ${SRC_QT_MAP_TESTS}
                       ${SRC_QT_MODEL_TESTS}
+                      ${SRC_QT_TYPES_TESTS}
                       ${SRC_QT_UI_TESTS}
                       ${SRC_QT_SETTINGS_TESTS}
                       ${SRC_QT_UTIL_TESTS}
@@ -102,6 +103,7 @@ source_group("Source Files\\qt\\main"     FILES ${SRC_QT_MAIN_TESTS})
 source_group("Source Files\\qt\\manager"  FILES ${SRC_QT_MANAGER_TESTS})
 source_group("Source Files\\qt\\map"      FILES ${SRC_QT_MAP_TESTS})
 source_group("Source Files\\qt\\model"    FILES ${SRC_QT_MODEL_TESTS})
+source_group("Source Files\\qt\\types"    FILES ${SRC_QT_TYPES_TESTS})
 source_group("Source Files\\qt\\ui"       FILES ${SRC_QT_UI_TESTS})
 source_group("Source Files\\qt\\settings" FILES ${SRC_QT_SETTINGS_TESTS})
 source_group("Source Files\\qt\\util"     FILES ${SRC_QT_UTIL_TESTS})

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -44,6 +44,7 @@ set(SRC_QT_MAP_TESTS source/scwx/qt/map/map_annotation_layer.test.cpp
                      source/scwx/qt/map/map_annotation_model.test.cpp
                      source/scwx/qt/map/map_provider.test.cpp)
 set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp
+                       source/scwx/qt/model/layer_model.test.cpp
                        source/scwx/qt/model/marker_model.test.cpp)
 set(SRC_QT_UI_TESTS source/scwx/qt/ui/threshold_value_utility.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
@@ -53,7 +54,8 @@ set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
                       source/scwx/qt/util/geographic_lib.test.cpp
                       source/scwx/qt/util/network.test.cpp)
-set(SRC_TYPES_TESTS source/scwx/types/ondas_types.test.cpp)
+set(SRC_TYPES_TESTS source/scwx/qt/types/layer_types.test.cpp
+                    source/scwx/types/ondas_types.test.cpp)
 set(SRC_UTIL_TESTS source/scwx/util/float.test.cpp
                    source/scwx/util/rangebuf.test.cpp
                    source/scwx/util/streams.test.cpp

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -33,6 +33,7 @@ set(SRC_PROVIDER_TESTS source/scwx/provider/aws_level2_data_provider.test.cpp
                        source/scwx/provider/warnings_provider.test.cpp)
 set(SRC_QT_CONFIG_TESTS source/scwx/qt/config/county_database.test.cpp
                         source/scwx/qt/config/radar_site.test.cpp)
+set(SRC_QT_GL_TESTS source/scwx/qt/gl/gl_context.test.cpp)
 set(SRC_QT_MAIN_TESTS source/scwx/qt/main/application_paths.test.cpp
                       source/scwx/qt/main/program_options.test.cpp
                       source/scwx/qt/main/theme.test.cpp)
@@ -75,6 +76,7 @@ add_executable(wxtest ${SRC_MAIN}
                       ${SRC_NETWORK_TESTS}
                       ${SRC_PROVIDER_TESTS}
                       ${SRC_QT_CONFIG_TESTS}
+                      ${SRC_QT_GL_TESTS}
                       ${SRC_QT_MAIN_TESTS}
                       ${SRC_QT_MANAGER_TESTS}
                       ${SRC_QT_MAP_TESTS}
@@ -95,6 +97,7 @@ source_group("Source Files\\gr"           FILES ${SRC_GR_TESTS})
 source_group("Source Files\\network"      FILES ${SRC_NETWORK_TESTS})
 source_group("Source Files\\provider"     FILES ${SRC_PROVIDER_TESTS})
 source_group("Source Files\\qt\\config"   FILES ${SRC_QT_CONFIG_TESTS})
+source_group("Source Files\\qt\\gl"       FILES ${SRC_QT_GL_TESTS})
 source_group("Source Files\\qt\\main"     FILES ${SRC_QT_MAIN_TESTS})
 source_group("Source Files\\qt\\manager"  FILES ${SRC_QT_MANAGER_TESTS})
 source_group("Source Files\\qt\\map"      FILES ${SRC_QT_MAP_TESTS})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SCWX-168 / #168.

Radar products (BR, BV, CC, and the rest) can now be faded on the fly so satellite imagery and streets show through. Overlay layers in Layer Manager get the same control; MapLibre map styles stay fully opaque.

## What changed
- Each overlay layer stores opacity (0–100%) in `layers.json`. Map Underlay and Map Symbology are locked at 100%.
- **Radar Toolbox → Map Settings** has a Radar Opacity slider and percent field for live radar fading.
- **Layer Manager** adds an Opacity column plus a slider/spin box for the selected overlay layer(s).
- Fragment shaders multiply output alpha by the current layer opacity so radar, alerts, placefiles, markers, overlay products, and the color table respect the setting. Radar range uses MapLibre `line-opacity`.

## Testing
Unit tests (`LayerTypes.*` and `LayerModelOpacityTest.*`) all passed:

```
100% tests passed, 0 tests failed out of 10
```

Manual GUI check on KLSX reflectivity over a satellite style: Radar Opacity 100% → 40% → 15% → 100%, streets visible through faded radar. Layer Manager shows an Opacity column, with map style layers labeled **Opaque**.

[Radar opacity at 100%](https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fradar_opacity_100.webp)
[Radar opacity at 40% with streets visible through radar](https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fradar_opacity_40.webp)
[Radar opacity at 15%](https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fradar_opacity_15.webp)
[Layer Manager Opacity column and slider](https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flayer_manager_opacity.webp)

[radar_opacity_slider_and_layer_manager.mp4](https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fradar_opacity_slider_and_layer_manager.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SCWX-168](https://linear.app/dpaulat/issue/SCWX-168/radar-data-needs-opacity-control)

<div><a href="https://cursor.com/agents/bc-936c3a2a-e985-4ee3-a031-42376327a385?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936c3a2a-e985-4ee3-a031-42376327a385&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

