### PR TITLE
Add ARL/MSL option for radar beam height tooltip

### DIFF
--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -176,19 +176,20 @@ void RadarProductLayer::Initialize(
               }
            });
 
+   auto updateRadarBeamHeightReference = [this](auto&&...)
+   {
+      p->radarBeamHeightReference_ = types::GetRadarBeamHeightReferenceFromName(
+         settings::UnitSettings::Instance()
+            .radar_beam_height_reference()
+            .GetValue());
+   };
+
    p->radarBeamHeightReferenceConnection_ =
       settings::UnitSettings::Instance()
          .radar_beam_height_reference()
          .changed_signal()
-         .connect(
-            [this](auto&&...)
-            {
-               p->radarBeamHeightReference_ =
-                  types::GetRadarBeamHeightReferenceFromName(
-                     settings::UnitSettings::Instance()
-                        .radar_beam_height_reference()
-                        .GetValue());
-            });
+         .connect(updateRadarBeamHeightReference);
+   updateRadarBeamHeightReference();
 }
 
 void RadarProductLayer::UpdateSweep(

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -453,11 +453,23 @@ bool RadarProductLayer::RunMousePicking(
       std::optional<float> elevation = radarProductView->elevation();
       if (elevation.has_value())
       {
-         const auto altitudeMeters =
-            util::GeographicLib::GetRadarBeamAltititude(
-               distanceMeters,
-               units::angle::degrees<double>(*elevation),
-               mapContext->radar_site()->altitude());
+         const units::length::meters<double> radarAltitude =
+            mapContext->radar_site()->altitude();
+         auto altitudeMeters = util::GeographicLib::GetRadarBeamAltititude(
+            distanceMeters,
+            units::angle::degrees<double>(*elevation),
+            radarAltitude);
+
+         const types::RadarBeamHeightReference heightReference =
+            types::GetRadarBeamHeightReferenceFromName(
+               settings::UnitSettings::Instance()
+                  .radar_beam_height_reference()
+                  .GetValue());
+         if (heightReference ==
+             types::RadarBeamHeightReference::AboveRadarLevel)
+         {
+            altitudeMeters -= radarAltitude;
+         }
 
          const std::string heightUnitName =
             settings::UnitSettings::Instance().echo_tops_units().GetValue();
@@ -466,13 +478,19 @@ bool RadarProductLayer::RunMousePicking(
          const double heightScale = types::GetEchoTopsUnitsScale(heightUnits);
          const std::string heightAbbrev =
             types::GetEchoTopsUnitsAbbreviation(heightUnits);
+         const std::string heightReferenceAbbrev =
+            types::GetRadarBeamHeightReferenceAbbreviation(heightReference);
 
          const double altitude = altitudeMeters.value() *
                                  scwx::common::kKilometersPerMeter *
                                  heightScale;
 
-         distanceHeightStr = fmt::format(
-            "{}\n{:.2f} {}", distanceHeightStr, altitude, heightAbbrev);
+         distanceHeightStr =
+            fmt::format("{}\n{:.2f} {} {}",
+                        distanceHeightStr,
+                        altitude,
+                        heightAbbrev,
+                        heightReferenceAbbrev);
       }
 
       std::optional<std::uint16_t> binLevel =

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -485,12 +485,11 @@ bool RadarProductLayer::RunMousePicking(
                                  scwx::common::kKilometersPerMeter *
                                  heightScale;
 
-         distanceHeightStr =
-            fmt::format("{}\n{:.2f} {} {}",
-                        distanceHeightStr,
-                        altitude,
-                        heightAbbrev,
-                        heightReferenceAbbrev);
+         distanceHeightStr = fmt::format("{}\n{:.2f} {} {}",
+                                         distanceHeightStr,
+                                         altitude,
+                                         heightAbbrev,
+                                         heightReferenceAbbrev);
       }
 
       std::optional<std::uint16_t> binLevel =

--- a/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
+++ b/scwx-qt/source/scwx/qt/map/radar_product_layer.cpp
@@ -65,13 +65,20 @@ public:
 
    types::RadarProductLoadStatus latchedLoadStatus_ {
       types::RadarProductLoadStatus::ProductNotAvailable};
+
+   types::RadarBeamHeightReference radarBeamHeightReference_ {
+      types::RadarBeamHeightReference::Unknown};
+   boost::signals2::scoped_connection radarBeamHeightReferenceConnection_;
 };
 
 RadarProductLayer::RadarProductLayer(std::shared_ptr<gl::GlContext> glContext) :
     GenericLayer(std::move(glContext)), p(std::make_unique<Impl>())
 {
 }
-RadarProductLayer::~RadarProductLayer() = default;
+RadarProductLayer::~RadarProductLayer()
+{
+   p->radarBeamHeightReferenceConnection_.disconnect();
+};
 
 void RadarProductLayer::Initialize(
    const std::shared_ptr<MapContext>& mapContext)
@@ -168,6 +175,20 @@ void RadarProductLayer::Initialize(
                  }
               }
            });
+
+   p->radarBeamHeightReferenceConnection_ =
+      settings::UnitSettings::Instance()
+         .radar_beam_height_reference()
+         .changed_signal()
+         .connect(
+            [this](auto&&...)
+            {
+               p->radarBeamHeightReference_ =
+                  types::GetRadarBeamHeightReferenceFromName(
+                     settings::UnitSettings::Instance()
+                        .radar_beam_height_reference()
+                        .GetValue());
+            });
 }
 
 void RadarProductLayer::UpdateSweep(
@@ -461,10 +482,7 @@ bool RadarProductLayer::RunMousePicking(
             radarAltitude);
 
          const types::RadarBeamHeightReference heightReference =
-            types::GetRadarBeamHeightReferenceFromName(
-               settings::UnitSettings::Instance()
-                  .radar_beam_height_reference()
-                  .GetValue());
+            p->radarBeamHeightReference_;
          if (heightReference ==
              types::RadarBeamHeightReference::AboveRadarLevel)
          {

--- a/scwx-qt/source/scwx/qt/settings/settings_definitions.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_definitions.hpp
@@ -3,7 +3,7 @@
 #define SCWX_SETTINGS_ENUM_VALIDATOR(Type, Iterator, ToName)                   \
    [](const std::string& value)                                                \
    {                                                                           \
-      for (Type enumValue : Iterator)                                          \
+      for (const Type enumValue : Iterator)                                    \
       {                                                                        \
          /* If the value is equal to a lower case name */                      \
          std::string enumName = ToName(enumValue);                             \

--- a/scwx-qt/source/scwx/qt/settings/settings_definitions.hpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_definitions.hpp
@@ -3,7 +3,7 @@
 #define SCWX_SETTINGS_ENUM_VALIDATOR(Type, Iterator, ToName)                   \
    [](const std::string& value)                                                \
    {                                                                           \
-      for (const Type enumValue : Iterator)                                    \
+      for (const Type enumValue : (Iterator))                                  \
       {                                                                        \
          /* If the value is equal to a lower case name */                      \
          std::string enumName = ToName(enumValue);                             \

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -24,12 +24,16 @@ public:
          types::GetSpeedUnitsName(types::SpeedUnits::Knots);
       std::string defaultDistanceUnitsValue =
          types::GetDistanceUnitsName(types::DistanceUnits::Miles);
+      std::string defaultRadarBeamHeightReferenceValue =
+         types::GetRadarBeamHeightReferenceName(
+            types::RadarBeamHeightReference::AboveRadarLevel);
 
       boost::to_lower(defaultAccumulationUnitsValue);
       boost::to_lower(defaultEchoTopsUnitsValue);
       boost::to_lower(defaultOtherUnitsValue);
       boost::to_lower(defaultSpeedUnitsValue);
       boost::to_lower(defaultDistanceUnitsValue);
+      boost::to_lower(defaultRadarBeamHeightReferenceValue);
 
       // SetDefault, SetMinimum and SetMaximum are descriptive
       // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
@@ -38,6 +42,8 @@ public:
       otherUnits_.SetDefault(defaultOtherUnitsValue);
       speedUnits_.SetDefault(defaultSpeedUnitsValue);
       distanceUnits_.SetDefault(defaultDistanceUnitsValue);
+      radarBeamHeightReference_.SetDefault(
+         defaultRadarBeamHeightReferenceValue);
       // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
       accumulationUnits_.SetValidator(
@@ -60,6 +66,10 @@ public:
          SCWX_SETTINGS_ENUM_VALIDATOR(types::DistanceUnits,
                                       types::DistanceUnitsIterator(),
                                       types::GetDistanceUnitsName));
+      radarBeamHeightReference_.SetValidator(SCWX_SETTINGS_ENUM_VALIDATOR(
+         types::RadarBeamHeightReference,
+         types::RadarBeamHeightReferenceIterator(),
+         types::GetRadarBeamHeightReferenceName));
    }
 
    ~Impl()                       = default;
@@ -73,6 +83,8 @@ public:
    SettingsVariable<std::string> otherUnits_ {"other_units"};
    SettingsVariable<std::string> speedUnits_ {"speed_units"};
    SettingsVariable<std::string> distanceUnits_ {"distance_units"};
+   SettingsVariable<std::string> radarBeamHeightReference_ {
+      "radar_beam_height_reference"};
 };
 
 UnitSettings::UnitSettings() :
@@ -82,7 +94,8 @@ UnitSettings::UnitSettings() :
                       &p->echoTopsUnits_,
                       &p->otherUnits_,
                       &p->speedUnits_,
-                      &p->distanceUnits_});
+                      &p->distanceUnits_,
+                      &p->radarBeamHeightReference_});
    SetDefaults();
 }
 UnitSettings::~UnitSettings() = default;
@@ -115,6 +128,11 @@ SettingsVariable<std::string>& UnitSettings::distance_units() const
    return p->distanceUnits_;
 }
 
+SettingsVariable<std::string>& UnitSettings::radar_beam_height_reference() const
+{
+   return p->radarBeamHeightReference_;
+}
+
 UnitSettings& UnitSettings::Instance()
 {
    static UnitSettings generalSettings_;
@@ -127,7 +145,9 @@ bool operator==(const UnitSettings& lhs, const UnitSettings& rhs)
            lhs.p->echoTopsUnits_ == rhs.p->echoTopsUnits_ &&
            lhs.p->otherUnits_ == rhs.p->otherUnits_ &&
            lhs.p->speedUnits_ == rhs.p->speedUnits_ &&
-           lhs.p->distanceUnits_ == rhs.p->distanceUnits_);
+           lhs.p->distanceUnits_ == rhs.p->distanceUnits_ &&
+           lhs.p->radarBeamHeightReference_ ==
+              rhs.p->radarBeamHeightReference_);
 }
 
 } // namespace scwx::qt::settings

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -26,7 +26,7 @@ public:
          types::GetDistanceUnitsName(types::DistanceUnits::Miles);
       std::string defaultRadarBeamHeightReferenceValue =
          types::GetRadarBeamHeightReferenceName(
-            types::RadarBeamHeightReference::AboveRadarLevel);
+            types::RadarBeamHeightReference::MeanSeaLevel);
 
       boost::to_lower(defaultAccumulationUnitsValue);
       boost::to_lower(defaultEchoTopsUnitsValue);

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.cpp
@@ -66,10 +66,10 @@ public:
          SCWX_SETTINGS_ENUM_VALIDATOR(types::DistanceUnits,
                                       types::DistanceUnitsIterator(),
                                       types::GetDistanceUnitsName));
-      radarBeamHeightReference_.SetValidator(SCWX_SETTINGS_ENUM_VALIDATOR(
-         types::RadarBeamHeightReference,
-         types::RadarBeamHeightReferenceIterator(),
-         types::GetRadarBeamHeightReferenceName));
+      radarBeamHeightReference_.SetValidator(
+         SCWX_SETTINGS_ENUM_VALIDATOR(types::RadarBeamHeightReference,
+                                      types::RadarBeamHeightReferenceIterator(),
+                                      types::GetRadarBeamHeightReferenceName));
    }
 
    ~Impl()                       = default;

--- a/scwx-qt/source/scwx/qt/settings/unit_settings.hpp
+++ b/scwx-qt/source/scwx/qt/settings/unit_settings.hpp
@@ -26,6 +26,8 @@ public:
    [[nodiscard]] SettingsVariable<std::string>& other_units() const;
    [[nodiscard]] SettingsVariable<std::string>& speed_units() const;
    [[nodiscard]] SettingsVariable<std::string>& distance_units() const;
+   [[nodiscard]] SettingsVariable<std::string>&
+   radar_beam_height_reference() const;
 
    static UnitSettings& Instance();
 

--- a/scwx-qt/source/scwx/qt/types/unit_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.cpp
@@ -6,11 +6,7 @@
 #include <boost/algorithm/string.hpp>
 #include <units/velocity.h>
 
-namespace scwx
-{
-namespace qt
-{
-namespace types
+namespace scwx::qt::types
 {
 
 static const std::unordered_map<AccumulationUnits, std::string>
@@ -112,13 +108,13 @@ static const std::unordered_map<DistanceUnits, double> distanceUnitsScale_ {
 static const std::unordered_map<RadarBeamHeightReference, std::string>
    radarBeamHeightReferenceAbbreviation_ {
       {RadarBeamHeightReference::AboveRadarLevel, "ARL"},
-      {RadarBeamHeightReference::AboveMeanSeaLevel, "AMSL"},
+      {RadarBeamHeightReference::MeanSeaLevel, "MSL"},
       {RadarBeamHeightReference::Unknown, ""}};
 
 static const std::unordered_map<RadarBeamHeightReference, std::string>
    radarBeamHeightReferenceName_ {
       {RadarBeamHeightReference::AboveRadarLevel, "Above Radar Level"},
-      {RadarBeamHeightReference::AboveMeanSeaLevel, "Above Mean Sea Level"},
+      {RadarBeamHeightReference::MeanSeaLevel, "Mean Sea Level"},
       {RadarBeamHeightReference::Unknown, "?"}};
 
 SCWX_GET_ENUM(AccumulationUnits,
@@ -209,6 +205,4 @@ GetRadarBeamHeightReferenceName(RadarBeamHeightReference reference)
    return radarBeamHeightReferenceName_.at(reference);
 }
 
-} // namespace types
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::types

--- a/scwx-qt/source/scwx/qt/types/unit_types.cpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.cpp
@@ -109,6 +109,18 @@ static const std::unordered_map<DistanceUnits, double> distanceUnitsScale_ {
    {DistanceUnits::User, 1.0f},
    {DistanceUnits::Unknown, 1.0f}};
 
+static const std::unordered_map<RadarBeamHeightReference, std::string>
+   radarBeamHeightReferenceAbbreviation_ {
+      {RadarBeamHeightReference::AboveRadarLevel, "ARL"},
+      {RadarBeamHeightReference::AboveMeanSeaLevel, "AMSL"},
+      {RadarBeamHeightReference::Unknown, ""}};
+
+static const std::unordered_map<RadarBeamHeightReference, std::string>
+   radarBeamHeightReferenceName_ {
+      {RadarBeamHeightReference::AboveRadarLevel, "Above Radar Level"},
+      {RadarBeamHeightReference::AboveMeanSeaLevel, "Above Mean Sea Level"},
+      {RadarBeamHeightReference::Unknown, "?"}};
+
 SCWX_GET_ENUM(AccumulationUnits,
               GetAccumulationUnitsFromName,
               accumulationUnitsName_)
@@ -116,6 +128,9 @@ SCWX_GET_ENUM(EchoTopsUnits, GetEchoTopsUnitsFromName, echoTopsUnitsName_)
 SCWX_GET_ENUM(OtherUnits, GetOtherUnitsFromName, otherUnitsName_)
 SCWX_GET_ENUM(SpeedUnits, GetSpeedUnitsFromName, speedUnitsName_)
 SCWX_GET_ENUM(DistanceUnits, GetDistanceUnitsFromName, distanceUnitsName_)
+SCWX_GET_ENUM(RadarBeamHeightReference,
+              GetRadarBeamHeightReferenceFromName,
+              radarBeamHeightReferenceName_)
 
 const std::string& GetAccumulationUnitsAbbreviation(AccumulationUnits units)
 {
@@ -180,6 +195,18 @@ const std::string& GetDistanceUnitsName(DistanceUnits units)
 double GetDistanceUnitsScale(DistanceUnits units)
 {
    return distanceUnitsScale_.at(units);
+}
+
+const std::string&
+GetRadarBeamHeightReferenceAbbreviation(RadarBeamHeightReference reference)
+{
+   return radarBeamHeightReferenceAbbreviation_.at(reference);
+}
+
+const std::string&
+GetRadarBeamHeightReferenceName(RadarBeamHeightReference reference)
+{
+   return radarBeamHeightReferenceName_.at(reference);
 }
 
 } // namespace types

--- a/scwx-qt/source/scwx/qt/types/unit_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.hpp
@@ -2,48 +2,44 @@
 
 #include <scwx/util/iterator.hpp>
 
+#include <cstdint>
 #include <string>
 
-namespace scwx
-{
-namespace qt
-{
-namespace types
+namespace scwx::qt::types
 {
 
-enum class AccumulationUnits
+enum class AccumulationUnits : std::uint8_t
 {
    Inches,
    Millimeters,
    User,
    Unknown
 };
-typedef scwx::util::Iterator<AccumulationUnits,
-                             AccumulationUnits::Inches,
-                             AccumulationUnits::User>
-   AccumulationUnitsIterator;
+using AccumulationUnitsIterator =
+   scwx::util::Iterator<AccumulationUnits,
+                        AccumulationUnits::Inches,
+                        AccumulationUnits::User>;
 
-enum class EchoTopsUnits
+enum class EchoTopsUnits : std::uint8_t
 {
    Kilofeet,
    Kilometers,
    User,
    Unknown
 };
-typedef scwx::util::
-   Iterator<EchoTopsUnits, EchoTopsUnits::Kilofeet, EchoTopsUnits::User>
-      EchoTopsUnitsIterator;
+using EchoTopsUnitsIterator = scwx::util::
+   Iterator<EchoTopsUnits, EchoTopsUnits::Kilofeet, EchoTopsUnits::User>;
 
-enum class OtherUnits
+enum class OtherUnits : std::uint8_t
 {
    Default,
    User,
    Unknown
 };
-typedef scwx::util::Iterator<OtherUnits, OtherUnits::Default, OtherUnits::User>
-   OtherUnitsIterator;
+using OtherUnitsIterator =
+   scwx::util::Iterator<OtherUnits, OtherUnits::Default, OtherUnits::User>;
 
-enum class SpeedUnits
+enum class SpeedUnits : std::uint8_t
 {
    KilometersPerHour,
    Knots,
@@ -52,31 +48,29 @@ enum class SpeedUnits
    User,
    Unknown
 };
-typedef scwx::util::
-   Iterator<SpeedUnits, SpeedUnits::KilometersPerHour, SpeedUnits::User>
-      SpeedUnitsIterator;
+using SpeedUnitsIterator = scwx::util::
+   Iterator<SpeedUnits, SpeedUnits::KilometersPerHour, SpeedUnits::User>;
 
-enum class DistanceUnits
+enum class DistanceUnits : std::uint8_t
 {
    Kilometers,
    Miles,
    User,
    Unknown
 };
-typedef scwx::util::
-   Iterator<DistanceUnits, DistanceUnits::Kilometers, DistanceUnits::User>
-      DistanceUnitsIterator;
+using DistanceUnitsIterator = scwx::util::
+   Iterator<DistanceUnits, DistanceUnits::Kilometers, DistanceUnits::User>;
 
-enum class RadarBeamHeightReference
+enum class RadarBeamHeightReference : std::uint8_t
 {
    AboveRadarLevel,
-   AboveMeanSeaLevel,
+   MeanSeaLevel,
    Unknown
 };
-typedef scwx::util::Iterator<RadarBeamHeightReference,
-                             RadarBeamHeightReference::AboveRadarLevel,
-                             RadarBeamHeightReference::AboveMeanSeaLevel>
-   RadarBeamHeightReferenceIterator;
+using RadarBeamHeightReferenceIterator =
+   scwx::util::Iterator<RadarBeamHeightReference,
+                        RadarBeamHeightReference::AboveRadarLevel,
+                        RadarBeamHeightReference::MeanSeaLevel>;
 
 const std::string& GetAccumulationUnitsAbbreviation(AccumulationUnits units);
 const std::string& GetAccumulationUnitsName(AccumulationUnits units);
@@ -108,6 +102,4 @@ GetRadarBeamHeightReferenceName(RadarBeamHeightReference reference);
 RadarBeamHeightReference
 GetRadarBeamHeightReferenceFromName(const std::string& name);
 
-} // namespace types
-} // namespace qt
-} // namespace scwx
+} // namespace scwx::qt::types

--- a/scwx-qt/source/scwx/qt/types/unit_types.hpp
+++ b/scwx-qt/source/scwx/qt/types/unit_types.hpp
@@ -67,6 +67,17 @@ typedef scwx::util::
    Iterator<DistanceUnits, DistanceUnits::Kilometers, DistanceUnits::User>
       DistanceUnitsIterator;
 
+enum class RadarBeamHeightReference
+{
+   AboveRadarLevel,
+   AboveMeanSeaLevel,
+   Unknown
+};
+typedef scwx::util::Iterator<RadarBeamHeightReference,
+                             RadarBeamHeightReference::AboveRadarLevel,
+                             RadarBeamHeightReference::AboveMeanSeaLevel>
+   RadarBeamHeightReferenceIterator;
+
 const std::string& GetAccumulationUnitsAbbreviation(AccumulationUnits units);
 const std::string& GetAccumulationUnitsName(AccumulationUnits units);
 AccumulationUnits  GetAccumulationUnitsFromName(const std::string& name);
@@ -89,6 +100,13 @@ const std::string& GetDistanceUnitsAbbreviation(DistanceUnits units);
 const std::string& GetDistanceUnitsName(DistanceUnits units);
 DistanceUnits      GetDistanceUnitsFromName(const std::string& name);
 double             GetDistanceUnitsScale(DistanceUnits units);
+
+const std::string&
+GetRadarBeamHeightReferenceAbbreviation(RadarBeamHeightReference reference);
+const std::string&
+GetRadarBeamHeightReferenceName(RadarBeamHeightReference reference);
+RadarBeamHeightReference
+GetRadarBeamHeightReferenceFromName(const std::string& name);
 
 } // namespace types
 } // namespace qt

--- a/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
@@ -92,24 +92,6 @@ public:
                               types::GetEchoTopsUnitsName);
       AddRow(echoTopsUnits_, "Echo Tops", echoTopsComboBox);
 
-      auto* radarBeamHeightComboBox = new QFocusedComboBox(self);
-      radarBeamHeightComboBox->setSizePolicy(QSizePolicy::Expanding,
-                                             QSizePolicy::Preferred);
-      radarBeamHeightComboBox->setFocusPolicy(Qt::StrongFocus);
-      radarBeamHeightComboBox->setToolTip(QObject::tr(
-         "Reference for radar beam height in the Shift+hover tooltip. "
-         "Above Radar Level (ARL) is the height above the radar antenna. "
-         "Above Mean Sea Level (AMSL) includes the radar site elevation."));
-      radarBeamHeightReference_.SetSettingsVariable(
-         unitSettings.radar_beam_height_reference());
-      SCWX_SETTINGS_COMBO_BOX(radarBeamHeightReference_,
-                              radarBeamHeightComboBox,
-                              types::RadarBeamHeightReferenceIterator(),
-                              types::GetRadarBeamHeightReferenceName);
-      AddRow(radarBeamHeightReference_,
-             "Radar Beam Height",
-             radarBeamHeightComboBox);
-
       auto* speedComboBox = new QFocusedComboBox(self);
       speedComboBox->setSizePolicy(QSizePolicy::Expanding,
                                    QSizePolicy::Preferred);
@@ -143,6 +125,24 @@ public:
                               types::GetOtherUnitsName);
       AddRow(otherUnits_, "Other", otherComboBox);
 
+      auto* radarBeamHeightComboBox = new QFocusedComboBox(self);
+      radarBeamHeightComboBox->setSizePolicy(QSizePolicy::Expanding,
+                                             QSizePolicy::Preferred);
+      radarBeamHeightComboBox->setFocusPolicy(Qt::StrongFocus);
+      radarBeamHeightComboBox->setToolTip(QObject::tr(
+         "Reference for radar beam height in the Shift+hover tooltip. "
+         "Above Radar Level (ARL) is the height above the radar antenna. "
+         "Mean Sea Level (MSL) includes the radar site elevation."));
+      radarBeamHeightReference_.SetSettingsVariable(
+         unitSettings.radar_beam_height_reference());
+      SCWX_SETTINGS_COMBO_BOX(radarBeamHeightReference_,
+                              radarBeamHeightComboBox,
+                              types::RadarBeamHeightReferenceIterator(),
+                              types::GetRadarBeamHeightReferenceName);
+      AddRow(radarBeamHeightReference_,
+             "Radar Beam Height",
+             radarBeamHeightComboBox);
+
       auto* spacer =
          new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
       gridLayout_->addItem(spacer, row, 0);
@@ -162,11 +162,11 @@ public:
    QGridLayout* gridLayout_ {};
 
    settings::SettingsInterface<std::string> accumulationUnits_ {};
-   settings::SettingsInterface<std::string> echoTopsUnits_ {};
-   settings::SettingsInterface<std::string> radarBeamHeightReference_ {};
-   settings::SettingsInterface<std::string> otherUnits_ {};
-   settings::SettingsInterface<std::string> speedUnits_ {};
    settings::SettingsInterface<std::string> distanceUnits_ {};
+   settings::SettingsInterface<std::string> echoTopsUnits_ {};
+   settings::SettingsInterface<std::string> otherUnits_ {};
+   settings::SettingsInterface<std::string> radarBeamHeightReference_ {};
+   settings::SettingsInterface<std::string> speedUnits_ {};
 };
 
 UnitSettingsWidget::UnitSettingsWidget(QWidget* parent) :

--- a/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
+++ b/scwx-qt/source/scwx/qt/ui/settings/unit_settings_widget.cpp
@@ -92,6 +92,24 @@ public:
                               types::GetEchoTopsUnitsName);
       AddRow(echoTopsUnits_, "Echo Tops", echoTopsComboBox);
 
+      auto* radarBeamHeightComboBox = new QFocusedComboBox(self);
+      radarBeamHeightComboBox->setSizePolicy(QSizePolicy::Expanding,
+                                             QSizePolicy::Preferred);
+      radarBeamHeightComboBox->setFocusPolicy(Qt::StrongFocus);
+      radarBeamHeightComboBox->setToolTip(QObject::tr(
+         "Reference for radar beam height in the Shift+hover tooltip. "
+         "Above Radar Level (ARL) is the height above the radar antenna. "
+         "Above Mean Sea Level (AMSL) includes the radar site elevation."));
+      radarBeamHeightReference_.SetSettingsVariable(
+         unitSettings.radar_beam_height_reference());
+      SCWX_SETTINGS_COMBO_BOX(radarBeamHeightReference_,
+                              radarBeamHeightComboBox,
+                              types::RadarBeamHeightReferenceIterator(),
+                              types::GetRadarBeamHeightReferenceName);
+      AddRow(radarBeamHeightReference_,
+             "Radar Beam Height",
+             radarBeamHeightComboBox);
+
       auto* speedComboBox = new QFocusedComboBox(self);
       speedComboBox->setSizePolicy(QSizePolicy::Expanding,
                                    QSizePolicy::Preferred);
@@ -145,6 +163,7 @@ public:
 
    settings::SettingsInterface<std::string> accumulationUnits_ {};
    settings::SettingsInterface<std::string> echoTopsUnits_ {};
+   settings::SettingsInterface<std::string> radarBeamHeightReference_ {};
    settings::SettingsInterface<std::string> otherUnits_ {};
    settings::SettingsInterface<std::string> speedUnits_ {};
    settings::SettingsInterface<std::string> distanceUnits_ {};

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
@@ -122,13 +122,15 @@ bool AreaInRangeOfPoint(const std::vector<common::Coordinate>& area,
                         const units::length::meters<double>    distance);
 
 /**
- * Get the altitude of the radar beam at a given distance, elevation and height
+ * Get the altitude of the radar beam at a given range, elevation and radar
+ * site height. The returned value is above mean sea level (AMSL). Subtract
+ * the radar site height from the result for above radar level (ARL).
  *
- * @param [in] range The range to the radar site
- * @param [in] elevation The elevation of the radar site
- * @param [in] height The height of the radar site
+ * @param [in] range The range from the radar site
+ * @param [in] elevation The elevation angle of the radar beam
+ * @param [in] height The height of the radar site above mean sea level
  *
- * @return The altitude of the radar at that range
+ * @return The beam altitude above mean sea level at that range
  */
 units::length::meters<double>
 GetRadarBeamAltititude(units::length::meters<double> range,

--- a/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
+++ b/scwx-qt/source/scwx/qt/util/geographic_lib.hpp
@@ -123,7 +123,7 @@ bool AreaInRangeOfPoint(const std::vector<common::Coordinate>& area,
 
 /**
  * Get the altitude of the radar beam at a given range, elevation and radar
- * site height. The returned value is above mean sea level (AMSL). Subtract
+ * site height. The returned value is above mean sea level (MSL). Subtract
  * the radar site height from the result for above radar level (ARL).
  *
  * @param [in] range The range from the radar site

--- a/test/source/scwx/qt/settings/unit_settings.test.cpp
+++ b/test/source/scwx/qt/settings/unit_settings.test.cpp
@@ -1,0 +1,46 @@
+#include <scwx/qt/settings/unit_settings.hpp>
+#include <scwx/qt/types/unit_types.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <gtest/gtest.h>
+
+namespace scwx::qt::settings
+{
+
+TEST(UnitSettingsTest, RadarBeamHeightReferenceDefaultsToArl)
+{
+   const UnitSettings settings;
+
+   EXPECT_EQ(settings.radar_beam_height_reference().GetValue(),
+             "above radar level");
+   EXPECT_EQ(types::GetRadarBeamHeightReferenceFromName(
+                settings.radar_beam_height_reference().GetValue()),
+             types::RadarBeamHeightReference::AboveRadarLevel);
+}
+
+TEST(UnitSettingsTest, RadarBeamHeightReferenceParticipatesInEquality)
+{
+   const UnitSettings lhs;
+   const UnitSettings rhs;
+
+   EXPECT_TRUE(lhs == rhs);
+
+   std::string amslName = types::GetRadarBeamHeightReferenceName(
+      types::RadarBeamHeightReference::AboveMeanSeaLevel);
+   boost::to_lower(amslName);
+
+   EXPECT_TRUE(lhs.radar_beam_height_reference().SetValue(amslName));
+   EXPECT_FALSE(lhs == rhs);
+}
+
+TEST(UnitSettingsTest, RadarBeamHeightReferenceAbbreviations)
+{
+   EXPECT_EQ(types::GetRadarBeamHeightReferenceAbbreviation(
+                types::RadarBeamHeightReference::AboveRadarLevel),
+             "ARL");
+   EXPECT_EQ(types::GetRadarBeamHeightReferenceAbbreviation(
+                types::RadarBeamHeightReference::AboveMeanSeaLevel),
+             "AMSL");
+}
+
+} // namespace scwx::qt::settings

--- a/test/source/scwx/qt/settings/unit_settings.test.cpp
+++ b/test/source/scwx/qt/settings/unit_settings.test.cpp
@@ -7,15 +7,15 @@
 namespace scwx::qt::settings
 {
 
-TEST(UnitSettingsTest, RadarBeamHeightReferenceDefaultsToArl)
+TEST(UnitSettingsTest, RadarBeamHeightReferenceDefaultsToMsl)
 {
    const UnitSettings settings;
 
    EXPECT_EQ(settings.radar_beam_height_reference().GetValue(),
-             "above radar level");
+             "mean sea level");
    EXPECT_EQ(types::GetRadarBeamHeightReferenceFromName(
                 settings.radar_beam_height_reference().GetValue()),
-             types::RadarBeamHeightReference::AboveRadarLevel);
+             types::RadarBeamHeightReference::MeanSeaLevel);
 }
 
 TEST(UnitSettingsTest, RadarBeamHeightReferenceParticipatesInEquality)
@@ -25,11 +25,11 @@ TEST(UnitSettingsTest, RadarBeamHeightReferenceParticipatesInEquality)
 
    EXPECT_TRUE(lhs == rhs);
 
-   std::string amslName = types::GetRadarBeamHeightReferenceName(
-      types::RadarBeamHeightReference::AboveMeanSeaLevel);
-   boost::to_lower(amslName);
+   std::string arlName = types::GetRadarBeamHeightReferenceName(
+      types::RadarBeamHeightReference::AboveRadarLevel);
+   boost::to_lower(arlName);
 
-   EXPECT_TRUE(lhs.radar_beam_height_reference().SetValue(amslName));
+   EXPECT_TRUE(lhs.radar_beam_height_reference().SetValue(arlName));
    EXPECT_FALSE(lhs == rhs);
 }
 
@@ -39,8 +39,8 @@ TEST(UnitSettingsTest, RadarBeamHeightReferenceAbbreviations)
                 types::RadarBeamHeightReference::AboveRadarLevel),
              "ARL");
    EXPECT_EQ(types::GetRadarBeamHeightReferenceAbbreviation(
-                types::RadarBeamHeightReference::AboveMeanSeaLevel),
-             "AMSL");
+                types::RadarBeamHeightReference::MeanSeaLevel),
+             "MSL");
 }
 
 } // namespace scwx::qt::settings

--- a/test/source/scwx/qt/util/geographic_lib.test.cpp
+++ b/test/source/scwx/qt/util/geographic_lib.test.cpp
@@ -64,5 +64,53 @@ TEST(geographic_lib, area_in_range_far)
    EXPECT_EQ(value, true);
 }
 
+TEST(geographic_lib, radar_beam_altitude_at_radar)
+{
+   const units::length::meters<double> radarHeight {914.4}; // 3000 ft
+   const auto                          altitude =
+      scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
+         units::length::meters<double> {0.0},
+         units::angle::degrees<double> {0.5},
+         radarHeight);
+
+   EXPECT_NEAR(altitude.value(), radarHeight.value(), 0.01);
+}
+
+TEST(geographic_lib, radar_beam_altitude_arl_near_radar)
+{
+   const units::length::meters<double> radarHeight {3048.0}; // ~10000 ft
+   const units::length::meters<double> range {1000.0};
+   const auto                          altitudeAmsl =
+      scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
+         range, units::angle::degrees<double> {0.5}, radarHeight);
+   const auto altitudeArl = altitudeAmsl - radarHeight;
+
+   // Close to the radar, ARL should be much smaller than AMSL
+   EXPECT_LT(altitudeArl.value(), 50.0);
+   EXPECT_GT(altitudeArl.value(), 0.0);
+   EXPECT_NEAR(altitudeAmsl.value(),
+               radarHeight.value() + altitudeArl.value(),
+               0.01);
+}
+
+TEST(geographic_lib, radar_beam_altitude_amsl_includes_site_height)
+{
+   const units::length::meters<double> lowSite {100.0};
+   const units::length::meters<double> highSite {3000.0};
+   const units::length::meters<double> range {5000.0};
+   const units::angle::degrees<double> elevation {0.5};
+
+   const auto lowAltitude =
+      scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
+         range, elevation, lowSite);
+   const auto highAltitude =
+      scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
+         range, elevation, highSite);
+
+   EXPECT_NEAR(highAltitude.value() - lowAltitude.value(),
+               highSite.value() - lowSite.value(),
+               1.0);
+}
+
 } // namespace util
 } // namespace scwx

--- a/test/source/scwx/qt/util/geographic_lib.test.cpp
+++ b/test/source/scwx/qt/util/geographic_lib.test.cpp
@@ -67,11 +67,10 @@ TEST(geographic_lib, area_in_range_far)
 TEST(geographic_lib, radar_beam_altitude_at_radar)
 {
    const units::length::meters<double> radarHeight {914.4}; // 3000 ft
-   const auto                          altitude =
-      scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
-         units::length::meters<double> {0.0},
-         units::angle::degrees<double> {0.5},
-         radarHeight);
+   const auto altitude = scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
+      units::length::meters<double> {0.0},
+      units::angle::degrees<double> {0.5},
+      radarHeight);
 
    EXPECT_NEAR(altitude.value(), radarHeight.value(), 0.01);
 }
@@ -88,9 +87,8 @@ TEST(geographic_lib, radar_beam_altitude_arl_near_radar)
    // Close to the radar, ARL should be much smaller than AMSL
    EXPECT_LT(altitudeArl.value(), 50.0);
    EXPECT_GT(altitudeArl.value(), 0.0);
-   EXPECT_NEAR(altitudeAmsl.value(),
-               radarHeight.value() + altitudeArl.value(),
-               0.01);
+   EXPECT_NEAR(
+      altitudeAmsl.value(), radarHeight.value() + altitudeArl.value(), 0.01);
 }
 
 TEST(geographic_lib, radar_beam_altitude_amsl_includes_site_height)

--- a/test/source/scwx/qt/util/geographic_lib.test.cpp
+++ b/test/source/scwx/qt/util/geographic_lib.test.cpp
@@ -4,9 +4,7 @@
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 
-namespace scwx
-{
-namespace util
+namespace scwx::util
 {
 
 std::vector<common::Coordinate> area = {
@@ -79,19 +77,19 @@ TEST(geographic_lib, radar_beam_altitude_arl_near_radar)
 {
    const units::length::meters<double> radarHeight {3048.0}; // ~10000 ft
    const units::length::meters<double> range {1000.0};
-   const auto                          altitudeAmsl =
+   const auto                          altitudeMsl =
       scwx::qt::util::GeographicLib::GetRadarBeamAltititude(
          range, units::angle::degrees<double> {0.5}, radarHeight);
-   const auto altitudeArl = altitudeAmsl - radarHeight;
+   const auto altitudeArl = altitudeMsl - radarHeight;
 
-   // Close to the radar, ARL should be much smaller than AMSL
+   // Close to the radar, ARL should be much smaller than MSL
    EXPECT_LT(altitudeArl.value(), 50.0);
    EXPECT_GT(altitudeArl.value(), 0.0);
    EXPECT_NEAR(
-      altitudeAmsl.value(), radarHeight.value() + altitudeArl.value(), 0.01);
+      altitudeMsl.value(), radarHeight.value() + altitudeArl.value(), 0.01);
 }
 
-TEST(geographic_lib, radar_beam_altitude_amsl_includes_site_height)
+TEST(geographic_lib, radar_beam_altitude_msl_includes_site_height)
 {
    const units::length::meters<double> lowSite {100.0};
    const units::length::meters<double> highSite {3000.0};
@@ -110,5 +108,4 @@ TEST(geographic_lib, radar_beam_altitude_amsl_includes_site_height)
                1.0);
 }
 
-} // namespace util
-} // namespace scwx
+} // namespace scwx::util

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -47,7 +47,8 @@ set(SRC_QT_MODEL_TESTS source/scwx/qt/model/imgui_context_model.test.cpp
 set(SRC_QT_UI_TESTS source/scwx/qt/ui/threshold_value_utility.test.cpp)
 set(SRC_QT_SETTINGS_TESTS source/scwx/qt/settings/settings_container.test.cpp
                           source/scwx/qt/settings/settings_variable.test.cpp
-                          source/scwx/qt/settings/ui_settings.test.cpp)
+                          source/scwx/qt/settings/ui_settings.test.cpp
+                          source/scwx/qt/settings/unit_settings.test.cpp)
 set(SRC_QT_UTIL_TESTS source/scwx/qt/util/q_file_input_stream.test.cpp
                       source/scwx/qt/util/geographic_lib.test.cpp
                       source/scwx/qt/util/network.test.cpp)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SCWX-505.

The Shift+hover radar tooltip previously always showed beam height above mean sea level (MSL). That includes the radar site elevation, so a sample near the radar (especially a high-elevation site like KGJX) could read several thousand feet even though the beam is still close to the antenna.

True above-ground-level (AGL) would need a terrain map. This change follows the issue discussion and ~~matches GR3~~: default to ~~**above radar level (ARL)**~~ MSL, keep ~~AMSL~~ **above radar level (ARL)** as an option, and label which reference is shown.

## Changes
- New Units setting **Radar Beam Height**: Above Radar Level ~~(default)~~ or Mean Sea Level (default)
- Tooltip now shows the height with an `ARL` or `MSL` suffix
- ARL is MSL minus radar site elevation (the 4/3-earth beam calculation is unchanged)
- Tests for ARL vs MSL near the radar and for the new setting default
- `test/data` submodule updated (branch `cursor/radar-beam-height-arl-ab93` on [supercell-wx-test-data](https://github.com/dpaulat/supercell-wx-test-data/tree/cursor/radar-beam-height-arl-ab93)) so settings fixtures include the new key

## How to verify
1. Hold Shift and hover near a radar site — height should include site elevation and be labeled `AMSL`
2. Settings → Units → Radar Beam Height → Above Radar Level — the same sample should be small and labeled `ARL` (not thousands of feet from site elevation)

## Walkthrough
On KLSX at 6.25 mi / 0.5°: **0.30 kft ARL** vs **0.91 kft AMSL** (the difference is site elevation).

[beam_height_arl_vs_amsl_tooltip.mp4](https://cursor.com/agents/bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbeam_height_arl_vs_amsl_tooltip.mp4)

[ARL tooltip near radar](https://cursor.com/agents/bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftooltip_arl_near_radar_closeup.png)
[AMSL tooltip near radar](https://cursor.com/agents/bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftooltip_amsl_near_radar_closeup.png)
[Units setting dropdown](https://cursor.com/agents/bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_units_dropdown.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SCWX-505](https://linear.app/dpaulat/issue/SCWX-505/radar-range-beam-height-tooltip)

<div><a href="https://cursor.com/agents/bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4f45a33-8d8b-4870-8d94-ebd01089ab93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

