### PR TITLE
Launch Windows updates via the NSIS installer instead of msiexec

### DIFF
--- a/scwx-qt/source/scwx/qt/manager/update_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/update_manager.cpp
@@ -229,7 +229,9 @@ void UpdateManager::RemoveTemporaryReleases()
 
    for (auto& file : it)
    {
-      if (file.is_regular_file() && file.path().string().ends_with(".msi") &&
+      if (file.is_regular_file() &&
+          (file.path().string().ends_with(".msi") ||
+           file.path().string().ends_with(".exe")) &&
           file.path().stem().string().starts_with("supercell-wx-"))
       {
          logger_->info("Removing temporary installer: {}",

--- a/scwx-qt/source/scwx/qt/ui/update_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/update_dialog.cpp
@@ -9,7 +9,6 @@
 
 #include <QDesktopServices>
 #include <QFontDatabase>
-#include <QProcess>
 
 namespace scwx::qt::ui
 {
@@ -89,9 +88,9 @@ void UpdateDialog::Impl::HandleAsset(const types::gh::ReleaseAsset& asset)
 #if defined(_WIN32)
 
 #   if defined(_M_AMD64)
-   static const std::string assetSuffix = "-x64.msi";
+   static const std::string assetSuffix = "-x64.exe";
 #   else
-   static const std::string assetSuffix = "-arm64.msi";
+   static const std::string assetSuffix = "-arm64.exe";
 #   endif
 
    if (asset.name_.ends_with(assetSuffix))
@@ -154,28 +153,26 @@ void UpdateDialog::on_installUpdateButton_clicked()
               });
 
       // Connect dialog signals
-      connect(
-         downloadDialog,
-         &QDialog::accepted,
-         this,
-         [=, this]()
-         {
-            std::filesystem::path installerPackage =
-               request->destination_path();
-            installerPackage.make_preferred();
+      connect(downloadDialog,
+              &QDialog::accepted,
+              this,
+              [=, this]()
+              {
+                 std::filesystem::path installerPackage =
+                    request->destination_path();
+                 installerPackage.make_preferred();
 
-            logger_->info("Launching application installer: {}",
-                          installerPackage.string());
+                 logger_->info("Launching application installer: {}",
+                               installerPackage.string());
 
-            if (!QProcess::startDetached(
-                   "msiexec.exe",
-                   {"/i", QString::fromStdString(installerPackage.string())}))
-            {
-               logger_->error("Failed to launch installer");
-            }
+                 if (!QDesktopServices::openUrl(QUrl::fromLocalFile(
+                        QString::fromStdString(installerPackage.string()))))
+                 {
+                    logger_->error("Failed to launch installer");
+                 }
 
-            ui->installUpdateButton->setEnabled(true);
-         });
+                 ui->installUpdateButton->setEnabled(true);
+              });
       connect(downloadDialog,
               &QDialog::rejected,
               this,

--- a/scwx-qt/source/scwx/qt/ui/update_dialog.cpp
+++ b/scwx-qt/source/scwx/qt/ui/update_dialog.cpp
@@ -156,7 +156,7 @@ void UpdateDialog::on_installUpdateButton_clicked()
       connect(downloadDialog,
               &QDialog::accepted,
               this,
-              [=, this]()
+              [request, this]()
               {
                  std::filesystem::path installerPackage =
                     request->destination_path();


### PR DESCRIPTION
Open the downloaded .exe through the shell so UAC elevation works, and clean up temporary .exe installers as well as .msi files.