### PR TITLE
Add #include <cstring> for std::memcpy to ZipStreamWriter

### DIFF
--- a/wxdata/source/scwx/zip/zip_stream_writer.cpp
+++ b/wxdata/source/scwx/zip/zip_stream_writer.cpp
@@ -2,6 +2,7 @@
 #include <scwx/util/logger.hpp>
 
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 
 #include <zip.h>


### PR DESCRIPTION
Eliminates reliance on transitive include. Some dependency versions may not automatically include <cstring>, breaking compilation on some systems (i.e., NixOS).