### PR TITLE
Add File > Save NEXRAD Product export

### DIFF
--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -71,6 +71,7 @@
 #include <QActionGroup>
 #include <QDesktopServices>
 #include <QDialog>
+#include <QDir>
 #include <QFileDialog>
 #include <QGuiApplication>
 #include <QJsonArray>
@@ -810,6 +811,82 @@ void MainWindow::on_actionOpenTextEvent_triggered()
               logger_->info("Selected: {}", file.toStdString());
               p->textEventManager_->LoadFile(file.toStdString());
            });
+
+   dialog->open();
+}
+
+void MainWindow::on_actionSaveNexrad_triggered()
+{
+   map::MapWidget* currentMap = p->activeMap_;
+   if (currentMap == nullptr)
+   {
+      return;
+   }
+
+   auto radarSite = currentMap->GetRadarSite();
+   if (radarSite == nullptr)
+   {
+      QMessageBox::warning(this,
+                           tr("Save NEXRAD Product"),
+                           tr("No radar site is selected."));
+      return;
+   }
+
+   auto manager = manager::RadarProductManager::Instance(radarSite->id());
+   auto record  = manager->GetRadarProductRecord(
+      currentMap->GetRadarProductGroup(),
+      currentMap->GetRadarProductName(),
+      currentMap->GetSelectedTime());
+
+   auto nexradFile = (record != nullptr) ? record->nexrad_file() : nullptr;
+   if (nexradFile == nullptr || !nexradFile->has_file_data())
+   {
+      QMessageBox::warning(
+         this,
+         tr("Save NEXRAD Product"),
+         tr("The currently displayed radar product is not available as a "
+            "complete NEXRAD file. This can happen while a live Level 2 volume "
+            "is still being received. Select a completed historical volume, "
+            "then try again."));
+      return;
+   }
+
+   static const std::string nexradFilter = "NEXRAD Products (*)";
+
+   QFileDialog* dialog = new QFileDialog(this);
+
+   dialog->setAcceptMode(QFileDialog::AcceptSave);
+   dialog->setFileMode(QFileDialog::AnyFile);
+   dialog->setNameFilter(tr(nexradFilter.c_str()));
+   dialog->setAttribute(Qt::WA_DeleteOnClose);
+   dialog->selectFile(QString::fromStdString(record->suggested_filename()));
+
+   // Make sure the parent window properly repaints on close
+   connect(dialog,
+           &QFileDialog::finished,
+           this,
+           static_cast<void (MainWindow::*)()>(&MainWindow::update),
+           Qt::QueuedConnection);
+
+   connect(
+      dialog,
+      &QFileDialog::fileSelected,
+      this,
+      [this, nexradFile](const QString& file)
+      {
+         const std::string filename =
+            QDir::toNativeSeparators(file).toStdString();
+         logger_->info("Saving NEXRAD product: {}", filename);
+
+         if (!nexradFile->SaveFile(filename))
+         {
+            QMessageBox::critical(
+               this,
+               tr("Save NEXRAD Product"),
+               tr("Unable to save NEXRAD product to %1.")
+                  .arg(QDir::toNativeSeparators(file)));
+         }
+      });
 
    dialog->open();
 }

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -852,7 +852,7 @@ void MainWindow::on_actionSaveNexrad_triggered()
 
    static const std::string nexradFilter = "NEXRAD Products (*)";
 
-   QFileDialog* dialog = new QFileDialog(this);
+   auto dialog = new QFileDialog(this);
 
    dialog->setAcceptMode(QFileDialog::AcceptSave);
    dialog->setFileMode(QFileDialog::AnyFile);

--- a/scwx-qt/source/scwx/qt/main/main_window.cpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.cpp
@@ -826,17 +826,16 @@ void MainWindow::on_actionSaveNexrad_triggered()
    auto radarSite = currentMap->GetRadarSite();
    if (radarSite == nullptr)
    {
-      QMessageBox::warning(this,
-                           tr("Save NEXRAD Product"),
-                           tr("No radar site is selected."));
+      QMessageBox::warning(
+         this, tr("Save NEXRAD Product"), tr("No radar site is selected."));
       return;
    }
 
    auto manager = manager::RadarProductManager::Instance(radarSite->id());
-   auto record  = manager->GetRadarProductRecord(
-      currentMap->GetRadarProductGroup(),
-      currentMap->GetRadarProductName(),
-      currentMap->GetSelectedTime());
+   auto record =
+      manager->GetRadarProductRecord(currentMap->GetRadarProductGroup(),
+                                     currentMap->GetRadarProductName(),
+                                     currentMap->GetSelectedTime());
 
    auto nexradFile = (record != nullptr) ? record->nexrad_file() : nullptr;
    if (nexradFile == nullptr || !nexradFile->has_file_data())
@@ -868,25 +867,24 @@ void MainWindow::on_actionSaveNexrad_triggered()
            static_cast<void (MainWindow::*)()>(&MainWindow::update),
            Qt::QueuedConnection);
 
-   connect(
-      dialog,
-      &QFileDialog::fileSelected,
-      this,
-      [this, nexradFile](const QString& file)
-      {
-         const std::string filename =
-            QDir::toNativeSeparators(file).toStdString();
-         logger_->info("Saving NEXRAD product: {}", filename);
+   connect(dialog,
+           &QFileDialog::fileSelected,
+           this,
+           [this, nexradFile](const QString& file)
+           {
+              const std::string filename =
+                 QDir::toNativeSeparators(file).toStdString();
+              logger_->info("Saving NEXRAD product: {}", filename);
 
-         if (!nexradFile->SaveFile(filename))
-         {
-            QMessageBox::critical(
-               this,
-               tr("Save NEXRAD Product"),
-               tr("Unable to save NEXRAD product to %1.")
-                  .arg(QDir::toNativeSeparators(file)));
-         }
-      });
+              if (!nexradFile->SaveFile(filename))
+              {
+                 QMessageBox::critical(
+                    this,
+                    tr("Save NEXRAD Product"),
+                    tr("Unable to save NEXRAD product to %1.")
+                       .arg(QDir::toNativeSeparators(file)));
+              }
+           });
 
    dialog->open();
 }

--- a/scwx-qt/source/scwx/qt/main/main_window.hpp
+++ b/scwx-qt/source/scwx/qt/main/main_window.hpp
@@ -37,6 +37,7 @@ signals:
 private slots:
    void on_actionOpenNexrad_triggered();
    void on_actionOpenTextEvent_triggered();
+   void on_actionSaveNexrad_triggered();
    void on_actionScreenCaptureCopy_triggered();
    void on_actionScreenCaptureSaveImage_triggered();
    void on_actionImport_triggered();

--- a/scwx-qt/source/scwx/qt/main/main_window.ui
+++ b/scwx-qt/source/scwx/qt/main/main_window.ui
@@ -61,6 +61,7 @@
      <addaction name="actionScreenCaptureSaveImage"/>
     </widget>
     <addaction name="menu_Open"/>
+    <addaction name="actionSaveNexrad"/>
     <addaction name="separator"/>
     <addaction name="menuScreenCapture"/>
     <addaction name="separator"/>
@@ -425,6 +426,14 @@
   <action name="actionOpenTextEvent">
    <property name="text">
     <string>Text &amp;Event Product...</string>
+   </property>
+  </action>
+  <action name="actionSaveNexrad">
+   <property name="text">
+    <string>&amp;Save NEXRAD Product...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionAlerts">

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -881,9 +881,8 @@ RadarProductManager::GetRadarProductRecord(
    const std::string&                    product,
    std::chrono::system_clock::time_point time)
 {
-   auto lookupRecord =
-      [](RadarProductRecordMap&                records,
-         std::chrono::system_clock::time_point queryTime)
+   auto lookupRecord = [](RadarProductRecordMap&                records,
+                          std::chrono::system_clock::time_point queryTime)
       -> std::shared_ptr<types::RadarProductRecord>
    {
       if (records.empty())

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -906,14 +906,14 @@ RadarProductManager::GetRadarProductRecord(
 
    if (group == common::RadarProductGroup::Level2)
    {
-      std::shared_lock lock {p->level2ProductRecordMutex_};
+      const std::shared_lock lock {p->level2ProductRecordMutex_};
       return lookupRecord(p->level2ProductRecords_, time);
    }
 
    if (group == common::RadarProductGroup::Level3)
    {
-      std::shared_lock lock {p->level3ProductRecordMutex_};
-      auto             it = p->level3ProductRecordsMap_.find(product);
+      const std::shared_lock lock {p->level3ProductRecordMutex_};
+      auto                   it = p->level3ProductRecordsMap_.find(product);
       if (it != p->level3ProductRecordsMap_.cend())
       {
          return lookupRecord(it->second, time);

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.cpp
@@ -875,6 +875,55 @@ void RadarProductManager::LoadFile(
    }
 }
 
+std::shared_ptr<types::RadarProductRecord>
+RadarProductManager::GetRadarProductRecord(
+   common::RadarProductGroup             group,
+   const std::string&                    product,
+   std::chrono::system_clock::time_point time)
+{
+   auto lookupRecord =
+      [](RadarProductRecordMap&                records,
+         std::chrono::system_clock::time_point queryTime)
+      -> std::shared_ptr<types::RadarProductRecord>
+   {
+      if (records.empty())
+      {
+         return nullptr;
+      }
+
+      if (queryTime == std::chrono::system_clock::time_point {})
+      {
+         return records.rbegin()->second.lock();
+      }
+
+      auto it = scwx::util::GetBoundedElementIterator(records, queryTime);
+      if (it == records.cend())
+      {
+         return nullptr;
+      }
+
+      return it->second.lock();
+   };
+
+   if (group == common::RadarProductGroup::Level2)
+   {
+      std::shared_lock lock {p->level2ProductRecordMutex_};
+      return lookupRecord(p->level2ProductRecords_, time);
+   }
+
+   if (group == common::RadarProductGroup::Level3)
+   {
+      std::shared_lock lock {p->level3ProductRecordMutex_};
+      auto             it = p->level3ProductRecordsMap_.find(product);
+      if (it != p->level3ProductRecordsMap_.cend())
+      {
+         return lookupRecord(it->second, time);
+      }
+   }
+
+   return nullptr;
+}
+
 void RadarProductManagerImpl::LoadNexradFileAsync(
    CreateNexradFileFunction                           load,
    const std::shared_ptr<request::NexradFileRequest>& request,

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
@@ -140,10 +140,10 @@ public:
     *
     * @return Cached radar product record, or nullptr if none is loaded
     */
-   std::shared_ptr<types::RadarProductRecord> GetRadarProductRecord(
-      common::RadarProductGroup             group,
-      const std::string&                    product = {},
-      std::chrono::system_clock::time_point time    = {});
+   std::shared_ptr<types::RadarProductRecord>
+   GetRadarProductRecord(common::RadarProductGroup             group,
+                         const std::string&                    product = {},
+                         std::chrono::system_clock::time_point time    = {});
 
    common::Level3ProductCategoryMap GetAvailableLevel3Categories();
    std::vector<std::string>         GetLevel3Products();

--- a/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
+++ b/scwx-qt/source/scwx/qt/manager/radar_product_manager.hpp
@@ -128,6 +128,23 @@ public:
       const std::string&                                 filename,
       const std::shared_ptr<request::NexradFileRequest>& request = nullptr);
 
+   /**
+    * @brief Gets a previously loaded radar product record from the cache.
+    *
+    * Does not trigger a network load. Records assembled from live Level 2
+    * chunks may be absent, or may lack original Archive II file bytes.
+    *
+    * @param [in] group Radar product group
+    * @param [in] product Radar product name (Level 3)
+    * @param [in] time Radar product time. Default is the latest cached record.
+    *
+    * @return Cached radar product record, or nullptr if none is loaded
+    */
+   std::shared_ptr<types::RadarProductRecord> GetRadarProductRecord(
+      common::RadarProductGroup             group,
+      const std::string&                    product = {},
+      std::chrono::system_clock::time_point time    = {});
+
    common::Level3ProductCategoryMap GetAvailableLevel3Categories();
    std::vector<std::string>         GetLevel3Products();
 

--- a/scwx-qt/source/scwx/qt/types/radar_product_record.cpp
+++ b/scwx-qt/source/scwx/qt/types/radar_product_record.cpp
@@ -3,6 +3,9 @@
 #include <scwx/common/sites.hpp>
 #include <scwx/util/time.hpp>
 
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
 namespace scwx
 {
 namespace qt
@@ -136,6 +139,43 @@ std::chrono::system_clock::time_point RadarProductRecord::time() const
 void RadarProductRecord::set_time(std::chrono::system_clock::time_point time)
 {
    p->time_ = time;
+}
+
+std::string RadarProductRecord::suggested_filename() const
+{
+   std::string name {};
+
+   if (p->nexradFile_ != nullptr)
+   {
+      name = p->nexradFile_->filename();
+   }
+
+   if (name.empty())
+   {
+      const auto recordTime =
+         std::chrono::time_point_cast<std::chrono::seconds>(p->time_);
+
+      if (p->radarProductGroup_ == common::RadarProductGroup::Level2)
+      {
+         name = fmt::format(
+            "{0}{1:%Y%m%d}_{1:%H%M%S}", p->radarId_, recordTime);
+      }
+      else
+      {
+         name = fmt::format("{0}_{1}_{2:%Y_%m_%d_%H_%M_%S}",
+                            p->siteId_,
+                            p->radarProduct_,
+                            recordTime);
+      }
+   }
+
+   if (p->nexradFile_ != nullptr && p->nexradFile_->is_gzip_compressed() &&
+       !name.ends_with(".gz") && !name.ends_with(".GZ"))
+   {
+      name += ".gz";
+   }
+
+   return name;
 }
 
 std::shared_ptr<RadarProductRecord>

--- a/scwx-qt/source/scwx/qt/types/radar_product_record.cpp
+++ b/scwx-qt/source/scwx/qt/types/radar_product_record.cpp
@@ -157,8 +157,8 @@ std::string RadarProductRecord::suggested_filename() const
 
       if (p->radarProductGroup_ == common::RadarProductGroup::Level2)
       {
-         name = fmt::format(
-            "{0}{1:%Y%m%d}_{1:%H%M%S}", p->radarId_, recordTime);
+         name =
+            fmt::format("{0}{1:%Y%m%d}_{1:%H%M%S}", p->radarId_, recordTime);
       }
       else
       {

--- a/scwx-qt/source/scwx/qt/types/radar_product_record.hpp
+++ b/scwx-qt/source/scwx/qt/types/radar_product_record.hpp
@@ -38,6 +38,14 @@ public:
    std::string                           site_id() const;
    std::chrono::system_clock::time_point time() const;
 
+   /**
+    * @brief Filename suitable for saving the original NEXRAD product.
+    *
+    * Uses the source object name when available, otherwise a name derived from
+    * the radar site, product, and time. Gzip payloads receive a .gz suffix.
+    */
+   [[nodiscard]] std::string suggested_filename() const;
+
    void set_time(std::chrono::system_clock::time_point time);
 
    static std::shared_ptr<RadarProductRecord>

--- a/test/source/scwx/provider/aws_level2_data_provider.test.cpp
+++ b/test/source/scwx/provider/aws_level2_data_provider.test.cpp
@@ -42,6 +42,9 @@ TEST(AwsLevel2DataProvider, LoadObjectByKey)
    auto file = provider.LoadObjectByKey(key);
 
    EXPECT_NE(file, nullptr);
+   ASSERT_NE(file, nullptr);
+   EXPECT_EQ(file->filename(), "KLSX20220421_160055_V06");
+   EXPECT_TRUE(file->has_file_data());
 }
 
 TEST(AwsLevel2DataProvider, Prune)

--- a/test/source/scwx/provider/aws_level3_data_provider.test.cpp
+++ b/test/source/scwx/provider/aws_level3_data_provider.test.cpp
@@ -42,6 +42,9 @@ TEST(AwsLevel3DataProvider, LoadObjectByKey)
    auto file = provider.LoadObjectByKey(key);
 
    EXPECT_NE(file, nullptr);
+   ASSERT_NE(file, nullptr);
+   EXPECT_EQ(file->filename(), "LSX_N0Q_2021_05_27_17_57_17");
+   EXPECT_TRUE(file->has_file_data());
 }
 
 TEST(AwsLevel3DataProvider, Refresh)

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -1,8 +1,10 @@
 #include <scwx/qt/manager/radar_product_manager.hpp>
 #include <scwx/qt/manager/provider_manager.hpp>
 #include <scwx/qt/config/radar_site.hpp>
+#include <scwx/qt/types/radar_product_record.hpp>
 #include <scwx/qt/util/geographic_lib.hpp>
 #include <scwx/common/constants.hpp>
+#include <scwx/wsr88d/nexrad_file_factory.hpp>
 
 #include <array>
 #include <cstdint>
@@ -129,6 +131,34 @@ TEST(ProviderManager, NameFormatting)
    EXPECT_EQ(level2ProviderManager.name(), "KLSX, L2");
    EXPECT_EQ(level3ProviderManager.name(), "KLSX, L3, N0B");
    EXPECT_EQ(level2ChunksProviderManager.name(), "KLSX, L2");
+}
+
+TEST(RadarProductRecord, SuggestedFilenameFromSource)
+{
+   config::RadarSite::Initialize();
+
+   const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
+                                "/nexrad/level2/Level2_KLSX_20210527_1757.ar2v";
+   auto file = wsr88d::NexradFileFactory::Create(filename);
+   ASSERT_NE(file, nullptr);
+
+   auto record = types::RadarProductRecord::Create(file);
+   ASSERT_NE(record, nullptr);
+   EXPECT_EQ(record->suggested_filename(), "Level2_KLSX_20210527_1757.ar2v");
+}
+
+TEST(RadarProductRecord, SuggestedFilenameGzip)
+{
+   config::RadarSite::Initialize();
+
+   const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
+                                "/nexrad/level2/KLSX20130206_175044_V06.gz";
+   auto file = wsr88d::NexradFileFactory::Create(filename);
+   ASSERT_NE(file, nullptr);
+
+   auto record = types::RadarProductRecord::Create(file);
+   ASSERT_NE(record, nullptr);
+   EXPECT_EQ(record->suggested_filename(), "KLSX20130206_175044_V06.gz");
 }
 
 } // namespace scwx::qt::manager

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -139,7 +139,7 @@ TEST(RadarProductRecord, SuggestedFilenameFromSource)
 
    const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
                                 "/nexrad/level2/Level2_KLSX_20210527_1757.ar2v";
-   auto file = wsr88d::NexradFileFactory::Create(filename);
+   auto              file     = wsr88d::NexradFileFactory::Create(filename);
    ASSERT_NE(file, nullptr);
 
    auto record = types::RadarProductRecord::Create(file);
@@ -153,7 +153,7 @@ TEST(RadarProductRecord, SuggestedFilenameGzip)
 
    const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
                                 "/nexrad/level2/KLSX20130206_175044_V06.gz";
-   auto file = wsr88d::NexradFileFactory::Create(filename);
+   auto              file     = wsr88d::NexradFileFactory::Create(filename);
    ASSERT_NE(file, nullptr);
 
    auto record = types::RadarProductRecord::Create(file);

--- a/test/source/scwx/qt/manager/radar_product_manager.test.cpp
+++ b/test/source/scwx/qt/manager/radar_product_manager.test.cpp
@@ -139,7 +139,7 @@ TEST(RadarProductRecord, SuggestedFilenameFromSource)
 
    const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
                                 "/nexrad/level2/Level2_KLSX_20210527_1757.ar2v";
-   auto              file     = wsr88d::NexradFileFactory::Create(filename);
+   auto file = wsr88d::NexradFileFactory::Create(filename);
    ASSERT_NE(file, nullptr);
 
    auto record = types::RadarProductRecord::Create(file);
@@ -153,7 +153,7 @@ TEST(RadarProductRecord, SuggestedFilenameGzip)
 
    const std::string filename = std::string(SCWX_TEST_DATA_DIR) +
                                 "/nexrad/level2/KLSX20130206_175044_V06.gz";
-   auto              file     = wsr88d::NexradFileFactory::Create(filename);
+   auto file = wsr88d::NexradFileFactory::Create(filename);
    ASSERT_NE(file, nullptr);
 
    auto record = types::RadarProductRecord::Create(file);

--- a/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
+++ b/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
@@ -19,7 +19,8 @@ static const std::string logPrefix_ = "scwx::wsr88d::nexrad_file_factory.test";
 static std::string ReadAllBytes(const std::string& filename)
 {
    std::ifstream is(filename, std::ios_base::in | std::ios_base::binary);
-   return {std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>()};
+   return {std::istreambuf_iterator<char>(is),
+           std::istreambuf_iterator<char>()};
 }
 
 TEST(NexradFileFactory, Level2V06)

--- a/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
+++ b/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
@@ -78,7 +78,7 @@ TEST_P(NexradFileSaveTest, SaveRoundTrip)
 {
    const std::string filename = std::string(SCWX_TEST_DATA_DIR) + GetParam();
 
-   std::shared_ptr<NexradFile> file = NexradFileFactory::Create(filename);
+   const std::shared_ptr<NexradFile> file = NexradFileFactory::Create(filename);
    ASSERT_NE(file, nullptr);
    ASSERT_TRUE(file->has_file_data());
 
@@ -101,8 +101,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(NexradFile, SaveFileWithoutData)
 {
-   Ar2vFile   file;
-   const auto tempPath =
+   const Ar2vFile file;
+   const auto     tempPath =
       std::filesystem::temp_directory_path() / "scwx_nexrad_export_missing";
 
    EXPECT_FALSE(file.has_file_data());

--- a/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
+++ b/test/source/scwx/wsr88d/nexrad_file_factory.test.cpp
@@ -2,6 +2,11 @@
 #include <scwx/wsr88d/ar2v_file.hpp>
 #include <scwx/wsr88d/level3_file.hpp>
 
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace scwx
@@ -10,6 +15,12 @@ namespace wsr88d
 {
 
 static const std::string logPrefix_ = "scwx::wsr88d::nexrad_file_factory.test";
+
+static std::string ReadAllBytes(const std::string& filename)
+{
+   std::ifstream is(filename, std::ios_base::in | std::ios_base::binary);
+   return {std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>()};
+}
 
 TEST(NexradFileFactory, Level2V06)
 {
@@ -22,6 +33,9 @@ TEST(NexradFileFactory, Level2V06)
 
    EXPECT_NE(file, nullptr);
    EXPECT_NE(level2File, nullptr);
+   EXPECT_EQ(file->filename(), "Level2_KLSX_20210527_1757.ar2v");
+   EXPECT_TRUE(file->has_file_data());
+   EXPECT_FALSE(file->is_gzip_compressed());
 }
 
 TEST(NexradFileFactory, Level2V06Gzip)
@@ -35,6 +49,9 @@ TEST(NexradFileFactory, Level2V06Gzip)
 
    EXPECT_NE(file, nullptr);
    EXPECT_NE(level2File, nullptr);
+   EXPECT_EQ(file->filename(), "KLSX20130206_175044_V06.gz");
+   EXPECT_TRUE(file->has_file_data());
+   EXPECT_TRUE(file->is_gzip_compressed());
 }
 
 TEST(NexradFileFactory, Level3)
@@ -48,6 +65,47 @@ TEST(NexradFileFactory, Level3)
 
    EXPECT_NE(file, nullptr);
    EXPECT_NE(level3File, nullptr);
+   EXPECT_EQ(file->filename(), "KLSX_SDUS23_N2QLSX_202112110250");
+   EXPECT_TRUE(file->has_file_data());
+}
+
+class NexradFileSaveTest : public testing::TestWithParam<std::string>
+{
+};
+
+TEST_P(NexradFileSaveTest, SaveRoundTrip)
+{
+   const std::string filename = std::string(SCWX_TEST_DATA_DIR) + GetParam();
+
+   std::shared_ptr<NexradFile> file = NexradFileFactory::Create(filename);
+   ASSERT_NE(file, nullptr);
+   ASSERT_TRUE(file->has_file_data());
+
+   const auto tempPath = std::filesystem::temp_directory_path() /
+                         ("scwx_nexrad_export_test_" + file->filename());
+   std::filesystem::remove(tempPath);
+
+   ASSERT_TRUE(file->SaveFile(tempPath.string()));
+   EXPECT_EQ(ReadAllBytes(filename), ReadAllBytes(tempPath.string()));
+
+   std::filesystem::remove(tempPath);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+   NexradFileFactory,
+   NexradFileSaveTest,
+   testing::Values("/nexrad/level2/Level2_KLSX_20210527_1757.ar2v",
+                   "/nexrad/level2/KLSX20130206_175044_V06.gz",
+                   "/nexrad/level3/KLSX_SDUS23_N2QLSX_202112110250"));
+
+TEST(NexradFile, SaveFileWithoutData)
+{
+   Ar2vFile   file;
+   const auto tempPath =
+      std::filesystem::temp_directory_path() / "scwx_nexrad_export_missing";
+
+   EXPECT_FALSE(file.has_file_data());
+   EXPECT_FALSE(file.SaveFile(tempPath.string()));
 }
 
 } // namespace wsr88d

--- a/wxdata/include/scwx/wsr88d/nexrad_file.hpp
+++ b/wxdata/include/scwx/wsr88d/nexrad_file.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <iosfwd>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace scwx
 {
@@ -20,6 +23,35 @@ public:
 
    virtual bool LoadFile(const std::string& filename) = 0;
    virtual bool LoadData(std::istream& is)            = 0;
+
+   /**
+    * @brief Original file bytes captured when the product was loaded.
+    *
+    * Gzip-compressed products retain the compressed payload so other
+    * applications receive the same data that was downloaded.
+    */
+   [[nodiscard]] const std::vector<std::uint8_t>& file_data() const;
+
+   /**
+    * @brief Source filename (basename) associated with the original payload.
+    */
+   [[nodiscard]] const std::string& filename() const;
+
+   [[nodiscard]] bool has_file_data() const;
+   [[nodiscard]] bool is_gzip_compressed() const;
+
+   void set_file_data(std::vector<std::uint8_t> data);
+   void set_filename(std::string filename);
+   void set_filename_from_path(const std::string& path);
+
+   /**
+    * @brief Writes the original file bytes to disk.
+    *
+    * @param [in] filename Destination path
+    *
+    * @return Whether the file was written successfully
+    */
+   [[nodiscard]] bool SaveFile(const std::string& filename) const;
 
 protected:
    explicit NexradFile();

--- a/wxdata/include/scwx/wsr88d/nexrad_file_factory.hpp
+++ b/wxdata/include/scwx/wsr88d/nexrad_file_factory.hpp
@@ -18,7 +18,8 @@ public:
    NexradFileFactory& operator=(NexradFileFactory&&) noexcept = delete;
 
    static std::shared_ptr<NexradFile> Create(const std::string& filename);
-   static std::shared_ptr<NexradFile> Create(std::istream& is);
+   static std::shared_ptr<NexradFile>
+   Create(std::istream& is, const std::string& sourcePath = {});
 };
 
 } // namespace wsr88d

--- a/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/aws_nexrad_data_provider.cpp
@@ -341,7 +341,7 @@ AwsNexradDataProvider::LoadObjectByKey(const std::string& key)
    if (outcome.IsSuccess())
    {
       auto& body = outcome.GetResultWithOwnership().GetBody();
-      nexradFile = wsr88d::NexradFileFactory::Create(body);
+      nexradFile = wsr88d::NexradFileFactory::Create(body, key);
    }
    else if (p->running_)
    {

--- a/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
+++ b/wxdata/source/scwx/provider/http_nexrad_data_provider.cpp
@@ -212,7 +212,7 @@ HttpNexradDataProvider::LoadObjectByKey(const std::string& key)
    }
    ss.seekg(0, std::ios::beg);
 
-   return wsr88d::NexradFileFactory::Create(ss);
+   return wsr88d::NexradFileFactory::Create(ss, key);
 }
 
 std::shared_ptr<wsr88d::NexradFile> HttpNexradDataProvider::LoadObjectByTime(

--- a/wxdata/source/scwx/wsr88d/nexrad_file.cpp
+++ b/wxdata/source/scwx/wsr88d/nexrad_file.cpp
@@ -28,19 +28,13 @@ NexradFile::NexradFile(NexradFile&&) noexcept            = default;
 NexradFile& NexradFile::operator=(NexradFile&&) noexcept = default;
 
 const std::vector<std::uint8_t>& NexradFile::file_data() const
-{
-   return p->fileData_;
-}
+{ return p->fileData_; }
 
 const std::string& NexradFile::filename() const
-{
-   return p->filename_;
-}
+{ return p->filename_; }
 
 bool NexradFile::has_file_data() const
-{
-   return !p->fileData_.empty();
-}
+{ return !p->fileData_.empty(); }
 
 bool NexradFile::is_gzip_compressed() const
 {
@@ -52,20 +46,15 @@ bool NexradFile::is_gzip_compressed() const
 }
 
 void NexradFile::set_file_data(std::vector<std::uint8_t> data)
-{
-   p->fileData_ = std::move(data);
-}
+{ p->fileData_ = std::move(data); }
 
 void NexradFile::set_filename(std::string filename)
-{
-   p->filename_ = std::move(filename);
-}
+{ p->filename_ = std::move(filename); }
 
 void NexradFile::set_filename_from_path(const std::string& path)
 {
    const std::size_t pos = path.find_last_of("/\\");
-   p->filename_ =
-      (pos == std::string::npos) ? path : path.substr(pos + 1);
+   p->filename_ = (pos == std::string::npos) ? path : path.substr(pos + 1);
 }
 
 bool NexradFile::SaveFile(const std::string& filename) const

--- a/wxdata/source/scwx/wsr88d/nexrad_file.cpp
+++ b/wxdata/source/scwx/wsr88d/nexrad_file.cpp
@@ -1,15 +1,24 @@
 #include <scwx/wsr88d/nexrad_file.hpp>
+#include <scwx/util/logger.hpp>
+
+#include <fstream>
 
 namespace scwx
 {
 namespace wsr88d
 {
 
+static const std::string logPrefix_ = "scwx::wsr88d::nexrad_file";
+static const auto        logger_    = util::Logger::Create(logPrefix_);
+
 class NexradFileImpl
 {
 public:
    explicit NexradFileImpl() {}
    ~NexradFileImpl() = default;
+
+   std::vector<std::uint8_t> fileData_ {};
+   std::string               filename_ {};
 };
 
 NexradFile::NexradFile() : p(std::make_unique<NexradFileImpl>()) {}
@@ -17,6 +26,79 @@ NexradFile::~NexradFile() = default;
 
 NexradFile::NexradFile(NexradFile&&) noexcept            = default;
 NexradFile& NexradFile::operator=(NexradFile&&) noexcept = default;
+
+const std::vector<std::uint8_t>& NexradFile::file_data() const
+{
+   return p->fileData_;
+}
+
+const std::string& NexradFile::filename() const
+{
+   return p->filename_;
+}
+
+bool NexradFile::has_file_data() const
+{
+   return !p->fileData_.empty();
+}
+
+bool NexradFile::is_gzip_compressed() const
+{
+   static constexpr std::uint8_t kGzipMagic0 = 0x1f;
+   static constexpr std::uint8_t kGzipMagic1 = 0x8b;
+
+   return p->fileData_.size() >= 2 && p->fileData_[0] == kGzipMagic0 &&
+          p->fileData_[1] == kGzipMagic1;
+}
+
+void NexradFile::set_file_data(std::vector<std::uint8_t> data)
+{
+   p->fileData_ = std::move(data);
+}
+
+void NexradFile::set_filename(std::string filename)
+{
+   p->filename_ = std::move(filename);
+}
+
+void NexradFile::set_filename_from_path(const std::string& path)
+{
+   const std::size_t pos = path.find_last_of("/\\");
+   p->filename_ =
+      (pos == std::string::npos) ? path : path.substr(pos + 1);
+}
+
+bool NexradFile::SaveFile(const std::string& filename) const
+{
+   if (p->fileData_.empty())
+   {
+      logger_->warn(
+         "Cannot save NEXRAD file, original data is not available: {}",
+         filename);
+      return false;
+   }
+
+   std::ofstream ofs(filename,
+                     std::ios_base::out | std::ios_base::binary |
+                        std::ios_base::trunc);
+   if (!ofs.is_open() || !ofs.good())
+   {
+      logger_->error("Could not open file for writing: {}", filename);
+      return false;
+   }
+
+   ofs.write(reinterpret_cast<const char*>(p->fileData_.data()),
+             static_cast<std::streamsize>(p->fileData_.size()));
+
+   if (!ofs.good())
+   {
+      logger_->error("Could not write NEXRAD file: {}", filename);
+      return false;
+   }
+
+   logger_->info("Saved NEXRAD file: {}", filename);
+   return true;
+}
 
 } // namespace wsr88d
 } // namespace scwx

--- a/wxdata/source/scwx/wsr88d/nexrad_file.cpp
+++ b/wxdata/source/scwx/wsr88d/nexrad_file.cpp
@@ -28,13 +28,19 @@ NexradFile::NexradFile(NexradFile&&) noexcept            = default;
 NexradFile& NexradFile::operator=(NexradFile&&) noexcept = default;
 
 const std::vector<std::uint8_t>& NexradFile::file_data() const
-{ return p->fileData_; }
+{
+   return p->fileData_;
+}
 
 const std::string& NexradFile::filename() const
-{ return p->filename_; }
+{
+   return p->filename_;
+}
 
 bool NexradFile::has_file_data() const
-{ return !p->fileData_.empty(); }
+{
+   return !p->fileData_.empty();
+}
 
 bool NexradFile::is_gzip_compressed() const
 {
@@ -46,10 +52,14 @@ bool NexradFile::is_gzip_compressed() const
 }
 
 void NexradFile::set_file_data(std::vector<std::uint8_t> data)
-{ p->fileData_ = std::move(data); }
+{
+   p->fileData_ = std::move(data);
+}
 
 void NexradFile::set_filename(std::string filename)
-{ p->filename_ = std::move(filename); }
+{
+   p->filename_ = std::move(filename);
+}
 
 void NexradFile::set_filename_from_path(const std::string& path)
 {

--- a/wxdata/source/scwx/wsr88d/nexrad_file_factory.cpp
+++ b/wxdata/source/scwx/wsr88d/nexrad_file_factory.cpp
@@ -3,8 +3,10 @@
 #include <scwx/wsr88d/level3_file.hpp>
 #include <scwx/util/logger.hpp>
 
+#include <array>
 #include <fstream>
 #include <sstream>
+#include <vector>
 
 #if defined(_MSC_VER)
 #   pragma warning(push)
@@ -37,6 +39,26 @@ namespace wsr88d
 static const std::string logPrefix_ = "scwx::wsr88d::nexrad_file_factory";
 static const auto        logger_    = util::Logger::Create(logPrefix_);
 
+static std::vector<std::uint8_t> ReadStream(std::istream& is)
+{
+   std::vector<std::uint8_t> data {};
+   std::array<char, 4096>    buffer {};
+
+   while (is)
+   {
+      is.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+      const auto count = is.gcount();
+      if (count > 0)
+      {
+         const auto* begin =
+            reinterpret_cast<const std::uint8_t*>(buffer.data());
+         data.insert(data.end(), begin, begin + count);
+      }
+   }
+
+   return data;
+}
+
 std::shared_ptr<NexradFile>
 NexradFileFactory::Create(const std::string& filename)
 {
@@ -54,33 +76,46 @@ NexradFileFactory::Create(const std::string& filename)
 
    if (fileValid)
    {
-      nexradFile = Create(f);
+      nexradFile = Create(f, filename);
    }
 
    return nexradFile;
 }
 
-std::shared_ptr<NexradFile> NexradFileFactory::Create(std::istream& is)
+std::shared_ptr<NexradFile>
+NexradFileFactory::Create(std::istream& is, const std::string& sourcePath)
 {
    std::shared_ptr<NexradFile> message = nullptr;
 
-   std::istream*     pis      = &is;
-   std::streampos    pisBegin = is.tellg();
+   std::vector<std::uint8_t> originalData = ReadStream(is);
+   if (originalData.size() < 8)
+   {
+      logger_->warn("Error reading file");
+      return nullptr;
+   }
+
+   std::istringstream originalStream(
+      std::string(reinterpret_cast<const char*>(originalData.data()),
+                  originalData.size()),
+      std::ios_base::in | std::ios_base::binary);
+
+   std::istream*     pis      = &originalStream;
+   std::streampos    pisBegin = originalStream.tellg();
    std::stringstream ss;
    std::string       buffer;
    bool              dataValid;
 
    buffer.resize(8);
 
-   is.read(buffer.data(), 8);
-   dataValid = is.good();
-   is.seekg(pisBegin, std::ios_base::beg);
+   originalStream.read(buffer.data(), 8);
+   dataValid = originalStream.good();
+   originalStream.seekg(pisBegin, std::ios_base::beg);
 
    if (dataValid && buffer.starts_with("\x1f\x8b"))
    {
       boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
       in.push(boost::iostreams::gzip_decompressor());
-      in.push(is);
+      in.push(originalStream);
 
       try
       {
@@ -131,6 +166,15 @@ std::shared_ptr<NexradFile> NexradFileFactory::Create(std::istream& is)
       if (!dataValid)
       {
          message = nullptr;
+      }
+   }
+
+   if (message != nullptr)
+   {
+      message->set_file_data(std::move(originalData));
+      if (!sourcePath.empty())
+      {
+         message->set_filename_from_path(sourcePath);
       }
    }
 

--- a/wxdata/source/scwx/wsr88d/nexrad_file_factory.cpp
+++ b/wxdata/source/scwx/wsr88d/nexrad_file_factory.cpp
@@ -3,9 +3,12 @@
 #include <scwx/wsr88d/level3_file.hpp>
 #include <scwx/util/logger.hpp>
 
-#include <array>
+#include <cstddef>
+#include <cstring>
 #include <fstream>
+#include <iterator>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #if defined(_MSC_VER)
@@ -39,23 +42,17 @@ namespace wsr88d
 static const std::string logPrefix_ = "scwx::wsr88d::nexrad_file_factory";
 static const auto        logger_    = util::Logger::Create(logPrefix_);
 
+static constexpr std::size_t kFileHeaderSize = 8;
+
 static std::vector<std::uint8_t> ReadStream(std::istream& is)
 {
-   std::vector<std::uint8_t> data {};
-   std::array<char, 4096>    buffer {};
-
-   while (is)
+   using CharIterator = std::istreambuf_iterator<char>;
+   const std::vector<char>   raw {CharIterator {is}, CharIterator {}};
+   std::vector<std::uint8_t> data(raw.size());
+   if (!raw.empty())
    {
-      is.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-      const auto count = is.gcount();
-      if (count > 0)
-      {
-         const auto* begin =
-            reinterpret_cast<const std::uint8_t*>(buffer.data());
-         data.insert(data.end(), begin, begin + count);
-      }
+      std::memcpy(data.data(), raw.data(), raw.size());
    }
-
    return data;
 }
 
@@ -88,7 +85,7 @@ NexradFileFactory::Create(std::istream& is, const std::string& sourcePath)
    std::shared_ptr<NexradFile> message = nullptr;
 
    std::vector<std::uint8_t> originalData = ReadStream(is);
-   if (originalData.size() < 8)
+   if (originalData.size() < kFileHeaderSize)
    {
       logger_->warn("Error reading file");
       return nullptr;
@@ -105,9 +102,10 @@ NexradFileFactory::Create(std::istream& is, const std::string& sourcePath)
    std::string       buffer;
    bool              dataValid;
 
-   buffer.resize(8);
+   buffer.resize(kFileHeaderSize);
 
-   originalStream.read(buffer.data(), 8);
+   originalStream.read(buffer.data(),
+                       static_cast<std::streamsize>(kFileHeaderSize));
    dataValid = originalStream.good();
    originalStream.seekg(pisBegin, std::ios_base::beg);
 
@@ -124,7 +122,7 @@ NexradFileFactory::Create(std::istream& is, const std::string& sourcePath)
          pis      = &ss;
          pisBegin = ss.tellg();
 
-         ss.read(buffer.data(), 8);
+         ss.read(buffer.data(), static_cast<std::streamsize>(kFileHeaderSize));
          dataValid = ss.good();
          ss.seekg(pisBegin, std::ios_base::beg);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves SCWX-176.

Users can now save the currently displayed Level 2 or Level 3 product to disk from **File > Save NEXRAD Product...** (Ctrl+Shift+S). The original downloaded payload is written as-is, including gzip-compressed Archive II files, so other applications can load the same volume that was viewed in the historical timeline.

Live Level 2 data assembled from chunks does not have a complete Archive II file; in that case the action explains that a completed historical volume should be selected first.

## Changes
- Capture original NEXRAD bytes (and source object name) when loading from disk or a data provider
- `NexradFile::SaveFile()` writes that payload back to disk
- File menu action with a default filename matching the AWS object name when available

## Testing
- Round-trip unit tests for uncompressed Level 2, gzip Level 2, and Level 3 (`NexradFileFactory` + `NexradFileSaveTest`)
- Save without captured payload is rejected
- Provider tests assert the source object name is preserved (network; run in CI)
- Follow-up commit addresses clang-format-21 (`git clang-format`) and clang-tidy-18 review comments from CI
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SCWX-176](https://linear.app/dpaulat/issue/SCWX-176/is-there-a-way-to-export-the-level-2-files-that-i-load-in-supercellwx)

<div><a href="https://cursor.com/agents/bc-4f75fe07-9ea9-4acd-976e-f90a7d00cf3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f75fe07-9ea9-4acd-976e-f90a7d00cf3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

