### PR TITLE
August 2026 Compiler Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,26 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: windows_vs2022_x64
-            os: windows-2022
-            build_type: Release
-            env_cc: ''
-            env_cxx: ''
-            compiler: msvc
-            cppflags: ''
-            ldflags: ''
-            vs_arch: x64
-            vs_version: 2022
-            qt_version: 6.11.1
-            qt_arch_aqt: win64_msvc2022_64
-            qt_arch_dir: msvc2022_64
-            qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
-            qt_tools: ''
-            conan_package_manager: ''
-            conan_build_profile: scwx-windows_vs2022_x64
-            conan_host_profile: scwx-windows_vs2022_x64
-            appimage_arch: ''
-            artifact_suffix: windows-vs2022-x64
           - name: windows_vs2026_x64
             os: windows-2025-vs2026
             build_type: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
             appimage_arch: aarch64
             artifact_suffix: linux-gcc-13-arm64
             compiler_packages: g++-13
-          - name: macos_clang-22_x64
+          - name: macos_clang-20_x64
             os: macos-15-intel
             build_type: Release
             env_cc: clang
@@ -281,11 +281,11 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_build_profile: scwx-macos_clang-22
-            conan_host_profile: scwx-macos_clang-22
+            conan_build_profile: scwx-macos_clang-20
+            conan_host_profile: scwx-macos_clang-20
             appimage_arch: ''
             artifact_suffix: macos-x64
-          - name: macos_clang-22_arm64
+          - name: macos_clang-20_arm64
             os: macos-14
             build_type: Release
             env_cc: clang
@@ -297,8 +297,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_build_profile: scwx-macos_clang-22_armv8
-            conan_host_profile: scwx-macos_clang-22_armv8
+            conan_build_profile: scwx-macos_clang-20_armv8
+            conan_host_profile: scwx-macos_clang-20_armv8
             appimage_arch: ''
             artifact_suffix: macos-arm64
     name: ${{ matrix.name }}
@@ -379,8 +379,8 @@ jobs:
       if: ${{ startsWith(matrix.os, 'macos') }}
       shell: bash
       run: |
-        brew install llvm@22
-        LLVM_PATH=$(brew --prefix llvm@22)
+        brew install llvm@20
+        LLVM_PATH=$(brew --prefix llvm@20)
         echo "CC=${LLVM_PATH}/bin/clang" >> $GITHUB_ENV
         echo "CXX=${LLVM_PATH}/bin/clang++" >> $GITHUB_ENV
         echo "CPPFLAGS=-I${LLVM_PATH}/include" >> $GITHUB_ENV
@@ -443,13 +443,19 @@ jobs:
       shell: pwsh
       run: |
         cd build
-        cmake ../source/ `
-          -G Ninja `
-          -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
-          -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES="${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake" `
-          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/supercell-wx" `
-          -DCONAN_HOST_PROFILE="${{ matrix.conan_host_profile }}" `
-          -DCONAN_BUILD_PROFILE="${{ matrix.conan_build_profile }}"
+        $cmakeArgs = @(
+          '../source/',
+          '-G', 'Ninja',
+          "-DCMAKE_BUILD_TYPE=${{ matrix.build_type }}",
+          "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${{ github.workspace }}/source/external/cmake-conan/conan_provider.cmake",
+          "-DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/supercell-wx",
+          "-DCONAN_HOST_PROFILE=${{ matrix.conan_host_profile }}",
+          "-DCONAN_BUILD_PROFILE=${{ matrix.conan_build_profile }}"
+        )
+        if ('${{ matrix.os }}' -like 'macos*') {
+          $cmakeArgs += '-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0'
+        }
+        cmake @cmakeArgs
         ninja supercell-wx
 
     - name: Build Supercell Wx (Test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
             appimage_arch: aarch64
             artifact_suffix: linux-gcc-13-arm64
             compiler_packages: g++-13
-          - name: macos_clang-18_x64
+          - name: macos_clang-22_x64
             os: macos-15-intel
             build_type: Release
             env_cc: clang
@@ -281,11 +281,11 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_build_profile: scwx-macos_clang-18
-            conan_host_profile: scwx-macos_clang-18
+            conan_build_profile: scwx-macos_clang-22
+            conan_host_profile: scwx-macos_clang-22
             appimage_arch: ''
             artifact_suffix: macos-x64
-          - name: macos_clang-18_arm64
+          - name: macos_clang-22_arm64
             os: macos-14
             build_type: Release
             env_cc: clang
@@ -297,8 +297,8 @@ jobs:
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: ''
-            conan_build_profile: scwx-macos_clang-18_armv8
-            conan_host_profile: scwx-macos_clang-18_armv8
+            conan_build_profile: scwx-macos_clang-22_armv8
+            conan_host_profile: scwx-macos_clang-22_armv8
             appimage_arch: ''
             artifact_suffix: macos-arm64
     name: ${{ matrix.name }}
@@ -379,8 +379,8 @@ jobs:
       if: ${{ startsWith(matrix.os, 'macos') }}
       shell: bash
       run: |
-        brew install llvm@18
-        LLVM_PATH=$(brew --prefix llvm@18)
+        brew install llvm@22
+        LLVM_PATH=$(brew --prefix llvm@22)
         echo "CC=${LLVM_PATH}/bin/clang" >> $GITHUB_ENV
         echo "CXX=${LLVM_PATH}/bin/clang++" >> $GITHUB_ENV
         echo "CPPFLAGS=-I${LLVM_PATH}/include" >> $GITHUB_ENV

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -16,18 +16,18 @@ jobs:
       matrix:
         include:
           - name: linux_clang-tidy_x64
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             build_type: Release
-            env_cc: clang-18
-            env_cxx: clang++-18
+            env_cc: clang-21
+            env_cxx: clang++-21
             qt_version: 6.11.1
             qt_arch_aqt: linux_gcc_64
             qt_modules: qtimageformats qtmultimedia qtpositioning qtserialport
             qt_tools: ''
             conan_package_manager: --conf tools.system.package_manager:mode=install --conf tools.system.package_manager:sudo=True
-            conan_profile: scwx-linux_clang-18
-            compiler_packages: clang-18 clang-tidy-18
-            clang_tidy_binary: clang-tidy-18
+            conan_profile: scwx-linux_clang-21
+            compiler_packages: clang-21 clang-tidy-21
+            clang_tidy_binary: clang-tidy-21
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(PROJECT_NAME supercell-wx)
 
 include(tools/scwx_config.cmake)
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "13.3" CACHE STRING "Minimum macOS deployment target")
 
 scwx_python_setup()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(PROJECT_NAME supercell-wx)
 
 include(tools/scwx_config.cmake)
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "13.3" CACHE STRING "Minimum macOS deployment target")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum macOS deployment target")
 
 scwx_python_setup()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -545,7 +545,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_PREFIX_PATH": "$env{HOME}/Qt/6.11.1/macos",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
       },
       "condition": {
         "type": "equals",
@@ -557,9 +557,6 @@
       "name": "macos-clang18-x64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/usr/local/opt/llvm@18/bin/clang",
         "CXX": "/usr/local/opt/llvm@18/bin/clang++",
@@ -572,9 +569,6 @@
       "name": "macos-clang19-x64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/usr/local/opt/llvm@19/bin/clang",
         "CXX": "/usr/local/opt/llvm@19/bin/clang++",
@@ -587,9 +581,6 @@
       "name": "macos-clang20-x64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/usr/local/opt/llvm@20/bin/clang",
         "CXX": "/usr/local/opt/llvm@20/bin/clang++",
@@ -602,6 +593,9 @@
       "name": "macos-clang21-x64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/usr/local/opt/llvm@21/bin/clang",
         "CXX": "/usr/local/opt/llvm@21/bin/clang++",
@@ -614,6 +608,9 @@
       "name": "macos-clang22-x64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/usr/local/opt/llvm@22/bin/clang",
         "CXX": "/usr/local/opt/llvm@22/bin/clang++",
@@ -626,6 +623,9 @@
       "name": "macos-clang23-x64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/usr/local/opt/llvm@23/bin/clang",
         "CXX": "/usr/local/opt/llvm@23/bin/clang++",
@@ -638,9 +638,6 @@
       "name": "macos-clang18-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@18/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@18/bin/clang++",
@@ -653,9 +650,6 @@
       "name": "macos-clang19-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@19/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@19/bin/clang++",
@@ -668,9 +662,6 @@
       "name": "macos-clang20-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@20/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@20/bin/clang++",
@@ -683,6 +674,9 @@
       "name": "macos-clang21-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@21/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@21/bin/clang++",
@@ -695,6 +689,9 @@
       "name": "macos-clang22-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@22/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@22/bin/clang++",
@@ -707,6 +704,9 @@
       "name": "macos-clang23-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
+      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@23/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@23/bin/clang++",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -553,13 +553,8 @@
       }
     },
     {
-      "name": "macos-clang18-base",
-      "inherits": "macos-base",
-      "hidden": true
-    },
-    {
       "name": "macos-clang18-x64-base",
-      "inherits": "macos-clang18-base",
+      "inherits": "macos-base",
       "hidden": true,
       "environment": {
         "CC": "/usr/local/opt/llvm@18/bin/clang",
@@ -570,8 +565,32 @@
       }
     },
     {
+      "name": "macos-clang22-x64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/usr/local/opt/llvm@22/bin/clang",
+        "CXX": "/usr/local/opt/llvm@22/bin/clang++",
+        "PATH": "/usr/local/opt/llvm@22/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/usr/local/opt/llvm@22/include",
+        "LDFLAGS": "-L/usr/local/opt/llvm@22/lib -L/usr/local/opt/llvm@22/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang23-x64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/usr/local/opt/llvm@23/bin/clang",
+        "CXX": "/usr/local/opt/llvm@23/bin/clang++",
+        "PATH": "/usr/local/opt/llvm@23/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/usr/local/opt/llvm@23/include",
+        "LDFLAGS": "-L/usr/local/opt/llvm@23/lib -L/usr/local/opt/llvm@23/lib/c++"
+      }
+    },
+    {
       "name": "macos-clang18-arm64-base",
-      "inherits": "macos-clang18-base",
+      "inherits": "macos-base",
       "hidden": true,
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@18/bin/clang",
@@ -579,6 +598,30 @@
         "PATH": "/opt/homebrew/opt/llvm@18/bin:$penv{PATH}",
         "CPPFLAGS": "-I/opt/homebrew/opt/llvm@18/include",
         "LDFLAGS": "-L/opt/homebrew/opt/llvm@18/lib -L/opt/homebrew/opt/llvm@18/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang22-arm64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/opt/homebrew/opt/llvm@22/bin/clang",
+        "CXX": "/opt/homebrew/opt/llvm@22/bin/clang++",
+        "PATH": "/opt/homebrew/opt/llvm@22/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/opt/homebrew/opt/llvm@22/include",
+        "LDFLAGS": "-L/opt/homebrew/opt/llvm@22/lib -L/opt/homebrew/opt/llvm@22/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang23-arm64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/opt/homebrew/opt/llvm@23/bin/clang",
+        "CXX": "/opt/homebrew/opt/llvm@23/bin/clang++",
+        "PATH": "/opt/homebrew/opt/llvm@23/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/opt/homebrew/opt/llvm@23/include",
+        "LDFLAGS": "-L/opt/homebrew/opt/llvm@23/lib -L/opt/homebrew/opt/llvm@23/lib/c++"
       }
     },
     {
@@ -602,6 +645,46 @@
       }
     },
     {
+      "name": "macos-clang22-x64-debug",
+      "inherits": "macos-clang22-x64-base",
+      "displayName": "macOS Clang 22 x64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-22-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-22-debug"
+      }
+    },
+    {
+      "name": "macos-clang22-x64-release",
+      "inherits": "macos-clang22-x64-base",
+      "displayName": "macOS Clang 22 x64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-22",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-22"
+      }
+    },
+    {
+      "name": "macos-clang23-x64-debug",
+      "inherits": "macos-clang23-x64-base",
+      "displayName": "macOS Clang 23 x64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-23-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-23-debug"
+      }
+    },
+    {
+      "name": "macos-clang23-x64-release",
+      "inherits": "macos-clang23-x64-base",
+      "displayName": "macOS Clang 23 x64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-23",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-23"
+      }
+    },
+    {
       "name": "macos-clang18-arm64-debug",
       "inherits": "macos-clang18-arm64-base",
       "displayName": "macOS Clang 18 Arm64 Debug",
@@ -619,6 +702,46 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CONAN_HOST_PROFILE": "scwx-macos_clang-18_armv8",
         "CONAN_BUILD_PROFILE": "scwx-macos_clang-18_armv8"
+      }
+    },
+    {
+      "name": "macos-clang22-arm64-debug",
+      "inherits": "macos-clang22-arm64-base",
+      "displayName": "macOS Clang 22 Arm64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-22_armv8-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-22_armv8-debug"
+      }
+    },
+    {
+      "name": "macos-clang22-arm64-release",
+      "inherits": "macos-clang22-arm64-base",
+      "displayName": "macOS Clang 22 Arm64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-22_armv8",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-22_armv8"
+      }
+    },
+    {
+      "name": "macos-clang23-arm64-debug",
+      "inherits": "macos-clang23-arm64-base",
+      "displayName": "macOS Clang 23 Arm64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-23_armv8-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-23_armv8-debug"
+      }
+    },
+    {
+      "name": "macos-clang23-arm64-release",
+      "inherits": "macos-clang23-arm64-base",
+      "displayName": "macOS Clang 23 Arm64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-23_armv8",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-23_armv8"
       }
     }
   ],
@@ -708,6 +831,30 @@
       "configuration": "Release"
     },
     {
+      "name": "macos-clang22-x64-debug",
+      "configurePreset": "macos-clang22-x64-debug",
+      "displayName": "macOS Clang 22 x64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang22-x64-release",
+      "configurePreset": "macos-clang22-x64-release",
+      "displayName": "macOS Clang 22 x64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang23-x64-debug",
+      "configurePreset": "macos-clang23-x64-debug",
+      "displayName": "macOS Clang 23 x64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang23-x64-release",
+      "configurePreset": "macos-clang23-x64-release",
+      "displayName": "macOS Clang 23 x64 Release",
+      "configuration": "Release"
+    },
+    {
       "name": "macos-clang18-arm64-debug",
       "configurePreset": "macos-clang18-arm64-debug",
       "displayName": "macOS Clang 18 Arm64 Debug",
@@ -717,6 +864,30 @@
       "name": "macos-clang18-arm64-release",
       "configurePreset": "macos-clang18-arm64-release",
       "displayName": "macOS Clang 18 Arm64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang22-arm64-debug",
+      "configurePreset": "macos-clang22-arm64-debug",
+      "displayName": "macOS Clang 22 Arm64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang22-arm64-release",
+      "configurePreset": "macos-clang22-arm64-release",
+      "displayName": "macOS Clang 22 Arm64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang23-arm64-debug",
+      "configurePreset": "macos-clang23-arm64-debug",
+      "displayName": "macOS Clang 23 Arm64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang23-arm64-release",
+      "configurePreset": "macos-clang23-arm64-release",
+      "displayName": "macOS Clang 23 Arm64 Release",
       "configuration": "Release"
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -544,7 +544,8 @@
       "inherits": "base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_PREFIX_PATH": "$env{HOME}/Qt/6.11.1/macos"
+        "CMAKE_PREFIX_PATH": "$env{HOME}/Qt/6.11.1/macos",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.3"
       },
       "condition": {
         "type": "equals",
@@ -556,12 +557,57 @@
       "name": "macos-clang18-x64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
       "environment": {
         "CC": "/usr/local/opt/llvm@18/bin/clang",
         "CXX": "/usr/local/opt/llvm@18/bin/clang++",
         "PATH": "/usr/local/opt/llvm@18/bin:$penv{PATH}",
         "CPPFLAGS": "-I/usr/local/opt/llvm@18/include",
         "LDFLAGS": "-L/usr/local/opt/llvm@18/lib -L/usr/local/opt/llvm@18/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang19-x64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "environment": {
+        "CC": "/usr/local/opt/llvm@19/bin/clang",
+        "CXX": "/usr/local/opt/llvm@19/bin/clang++",
+        "PATH": "/usr/local/opt/llvm@19/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/usr/local/opt/llvm@19/include",
+        "LDFLAGS": "-L/usr/local/opt/llvm@19/lib -L/usr/local/opt/llvm@19/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang20-x64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "environment": {
+        "CC": "/usr/local/opt/llvm@20/bin/clang",
+        "CXX": "/usr/local/opt/llvm@20/bin/clang++",
+        "PATH": "/usr/local/opt/llvm@20/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/usr/local/opt/llvm@20/include",
+        "LDFLAGS": "-L/usr/local/opt/llvm@20/lib -L/usr/local/opt/llvm@20/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang21-x64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/usr/local/opt/llvm@21/bin/clang",
+        "CXX": "/usr/local/opt/llvm@21/bin/clang++",
+        "PATH": "/usr/local/opt/llvm@21/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/usr/local/opt/llvm@21/include",
+        "LDFLAGS": "-L/usr/local/opt/llvm@21/lib -L/usr/local/opt/llvm@21/lib/c++"
       }
     },
     {
@@ -592,12 +638,57 @@
       "name": "macos-clang18-arm64-base",
       "inherits": "macos-base",
       "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
       "environment": {
         "CC": "/opt/homebrew/opt/llvm@18/bin/clang",
         "CXX": "/opt/homebrew/opt/llvm@18/bin/clang++",
         "PATH": "/opt/homebrew/opt/llvm@18/bin:$penv{PATH}",
         "CPPFLAGS": "-I/opt/homebrew/opt/llvm@18/include",
         "LDFLAGS": "-L/opt/homebrew/opt/llvm@18/lib -L/opt/homebrew/opt/llvm@18/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang19-arm64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "environment": {
+        "CC": "/opt/homebrew/opt/llvm@19/bin/clang",
+        "CXX": "/opt/homebrew/opt/llvm@19/bin/clang++",
+        "PATH": "/opt/homebrew/opt/llvm@19/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/opt/homebrew/opt/llvm@19/include",
+        "LDFLAGS": "-L/opt/homebrew/opt/llvm@19/lib -L/opt/homebrew/opt/llvm@19/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang20-arm64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "environment": {
+        "CC": "/opt/homebrew/opt/llvm@20/bin/clang",
+        "CXX": "/opt/homebrew/opt/llvm@20/bin/clang++",
+        "PATH": "/opt/homebrew/opt/llvm@20/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/opt/homebrew/opt/llvm@20/include",
+        "LDFLAGS": "-L/opt/homebrew/opt/llvm@20/lib -L/opt/homebrew/opt/llvm@20/lib/c++"
+      }
+    },
+    {
+      "name": "macos-clang21-arm64-base",
+      "inherits": "macos-base",
+      "hidden": true,
+      "environment": {
+        "CC": "/opt/homebrew/opt/llvm@21/bin/clang",
+        "CXX": "/opt/homebrew/opt/llvm@21/bin/clang++",
+        "PATH": "/opt/homebrew/opt/llvm@21/bin:$penv{PATH}",
+        "CPPFLAGS": "-I/opt/homebrew/opt/llvm@21/include",
+        "LDFLAGS": "-L/opt/homebrew/opt/llvm@21/lib -L/opt/homebrew/opt/llvm@21/lib/c++"
       }
     },
     {
@@ -642,6 +733,66 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CONAN_HOST_PROFILE": "scwx-macos_clang-18",
         "CONAN_BUILD_PROFILE": "scwx-macos_clang-18"
+      }
+    },
+    {
+      "name": "macos-clang19-x64-debug",
+      "inherits": "macos-clang19-x64-base",
+      "displayName": "macOS Clang 19 x64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-19-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-19-debug"
+      }
+    },
+    {
+      "name": "macos-clang19-x64-release",
+      "inherits": "macos-clang19-x64-base",
+      "displayName": "macOS Clang 19 x64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-19",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-19"
+      }
+    },
+    {
+      "name": "macos-clang20-x64-debug",
+      "inherits": "macos-clang20-x64-base",
+      "displayName": "macOS Clang 20 x64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-20-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-20-debug"
+      }
+    },
+    {
+      "name": "macos-clang20-x64-release",
+      "inherits": "macos-clang20-x64-base",
+      "displayName": "macOS Clang 20 x64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-20",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-20"
+      }
+    },
+    {
+      "name": "macos-clang21-x64-debug",
+      "inherits": "macos-clang21-x64-base",
+      "displayName": "macOS Clang 21 x64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-21-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-21-debug"
+      }
+    },
+    {
+      "name": "macos-clang21-x64-release",
+      "inherits": "macos-clang21-x64-base",
+      "displayName": "macOS Clang 21 x64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-21",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-21"
       }
     },
     {
@@ -702,6 +853,66 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CONAN_HOST_PROFILE": "scwx-macos_clang-18_armv8",
         "CONAN_BUILD_PROFILE": "scwx-macos_clang-18_armv8"
+      }
+    },
+    {
+      "name": "macos-clang19-arm64-debug",
+      "inherits": "macos-clang19-arm64-base",
+      "displayName": "macOS Clang 19 Arm64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-19_armv8-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-19_armv8-debug"
+      }
+    },
+    {
+      "name": "macos-clang19-arm64-release",
+      "inherits": "macos-clang19-arm64-base",
+      "displayName": "macOS Clang 19 Arm64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-19_armv8",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-19_armv8"
+      }
+    },
+    {
+      "name": "macos-clang20-arm64-debug",
+      "inherits": "macos-clang20-arm64-base",
+      "displayName": "macOS Clang 20 Arm64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-20_armv8-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-20_armv8-debug"
+      }
+    },
+    {
+      "name": "macos-clang20-arm64-release",
+      "inherits": "macos-clang20-arm64-base",
+      "displayName": "macOS Clang 20 Arm64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-20_armv8",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-20_armv8"
+      }
+    },
+    {
+      "name": "macos-clang21-arm64-debug",
+      "inherits": "macos-clang21-arm64-base",
+      "displayName": "macOS Clang 21 Arm64 Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-21_armv8-debug",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-21_armv8-debug"
+      }
+    },
+    {
+      "name": "macos-clang21-arm64-release",
+      "inherits": "macos-clang21-arm64-base",
+      "displayName": "macOS Clang 21 Arm64 Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CONAN_HOST_PROFILE": "scwx-macos_clang-21_armv8",
+        "CONAN_BUILD_PROFILE": "scwx-macos_clang-21_armv8"
       }
     },
     {
@@ -831,6 +1042,42 @@
       "configuration": "Release"
     },
     {
+      "name": "macos-clang19-x64-debug",
+      "configurePreset": "macos-clang19-x64-debug",
+      "displayName": "macOS Clang 19 x64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang19-x64-release",
+      "configurePreset": "macos-clang19-x64-release",
+      "displayName": "macOS Clang 19 x64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang20-x64-debug",
+      "configurePreset": "macos-clang20-x64-debug",
+      "displayName": "macOS Clang 20 x64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang20-x64-release",
+      "configurePreset": "macos-clang20-x64-release",
+      "displayName": "macOS Clang 20 x64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang21-x64-debug",
+      "configurePreset": "macos-clang21-x64-debug",
+      "displayName": "macOS Clang 21 x64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang21-x64-release",
+      "configurePreset": "macos-clang21-x64-release",
+      "displayName": "macOS Clang 21 x64 Release",
+      "configuration": "Release"
+    },
+    {
       "name": "macos-clang22-x64-debug",
       "configurePreset": "macos-clang22-x64-debug",
       "displayName": "macOS Clang 22 x64 Debug",
@@ -864,6 +1111,42 @@
       "name": "macos-clang18-arm64-release",
       "configurePreset": "macos-clang18-arm64-release",
       "displayName": "macOS Clang 18 Arm64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang19-arm64-debug",
+      "configurePreset": "macos-clang19-arm64-debug",
+      "displayName": "macOS Clang 19 Arm64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang19-arm64-release",
+      "configurePreset": "macos-clang19-arm64-release",
+      "displayName": "macOS Clang 19 Arm64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang20-arm64-debug",
+      "configurePreset": "macos-clang20-arm64-debug",
+      "displayName": "macOS Clang 20 Arm64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang20-arm64-release",
+      "configurePreset": "macos-clang20-arm64-release",
+      "displayName": "macOS Clang 20 Arm64 Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "macos-clang21-arm64-debug",
+      "configurePreset": "macos-clang21-arm64-debug",
+      "displayName": "macOS Clang 21 Arm64 Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "macos-clang21-arm64-release",
+      "configurePreset": "macos-clang21-arm64-release",
+      "displayName": "macOS Clang 21 Arm64 Release",
       "configuration": "Release"
     },
     {

--- a/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/marker_manager.cpp
@@ -198,22 +198,23 @@ void MarkerManager::Impl::ApplyMarkerSettings(
          idToIndex_.reserve(markerArray.size());
          for (auto& markerEntry : markerArray)
          {
-            try
-            {
-               auto record = boost::json::value_to<MarkerRecord>(markerEntry);
+            auto record = boost::json::try_value_to<MarkerRecord>(markerEntry);
 
+            if (!record.has_error())
+            {
                const types::MarkerId id    = NewId();
                const size_t          index = markerRecords_.size();
-               record.markerInfo_.id       = id;
+               record->markerInfo_.id      = id;
                markerRecords_.emplace_back(
-                  std::make_shared<MarkerRecord>(record.markerInfo_));
+                  std::make_shared<MarkerRecord>(record->markerInfo_));
                idToIndex_.emplace(id, index);
 
-               self_->add_icon(record.markerInfo_.iconName, true);
+               self_->add_icon(record->markerInfo_.iconName, true);
             }
-            catch (const std::exception& ex)
+            else
             {
-               logger_->warn("Invalid location marker entry: {}", ex.what());
+               logger_->warn("Invalid location marker entry: {}",
+                             record.error().message());
             }
          }
 

--- a/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
@@ -37,6 +37,8 @@ static const std::string kThresholdedName_ = "thresholded";
 static const std::string kTitleName_       = "title";
 static const std::string kNameName_        = "name";
 
+namespace
+{
 // JSON settings DTO. PlacefileRecord is not copyable/movable (mutex, atomic,
 // ASIO types), so try_value_to cannot wrap it in boost::system::result.
 struct PlacefileSettingsEntry
@@ -52,11 +54,12 @@ tag_invoke(boost::json::value_to_tag<PlacefileSettingsEntry>,
            const boost::json::value& jv)
 {
    return PlacefileSettingsEntry {
-      boost::json::value_to<std::string>(jv.at(kNameName_)),
-      boost::json::value_to<std::string>(jv.at(kTitleName_)),
-      jv.at(kEnabledName_).as_bool(),
-      jv.at(kThresholdedName_).as_bool()};
+      .name        = boost::json::value_to<std::string>(jv.at(kNameName_)),
+      .title       = boost::json::value_to<std::string>(jv.at(kTitleName_)),
+      .enabled     = jv.at(kEnabledName_).as_bool(),
+      .thresholded = jv.at(kThresholdedName_).as_bool()};
 }
+} // namespace
 
 class PlacefileManager::Impl
 {

--- a/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/placefile_manager.cpp
@@ -37,6 +37,27 @@ static const std::string kThresholdedName_ = "thresholded";
 static const std::string kTitleName_       = "title";
 static const std::string kNameName_        = "name";
 
+// JSON settings DTO. PlacefileRecord is not copyable/movable (mutex, atomic,
+// ASIO types), so try_value_to cannot wrap it in boost::system::result.
+struct PlacefileSettingsEntry
+{
+   std::string name {};
+   std::string title {};
+   bool        enabled {false};
+   bool        thresholded {false};
+};
+
+PlacefileSettingsEntry
+tag_invoke(boost::json::value_to_tag<PlacefileSettingsEntry>,
+           const boost::json::value& jv)
+{
+   return PlacefileSettingsEntry {
+      boost::json::value_to<std::string>(jv.at(kNameName_)),
+      boost::json::value_to<std::string>(jv.at(kTitleName_)),
+      jv.at(kEnabledName_).as_bool(),
+      jv.at(kThresholdedName_).as_bool()};
+}
+
 class PlacefileManager::Impl
 {
 public:
@@ -118,18 +139,6 @@ public:
             {kThresholdedName_, record->thresholded_},
             {kTitleName_, record->title_},
             {kNameName_, record->name_}};
-   }
-
-   friend PlacefileRecord tag_invoke(boost::json::value_to_tag<PlacefileRecord>,
-                                     const boost::json::value& jv)
-   {
-      return PlacefileRecord {
-         nullptr,
-         boost::json::value_to<std::string>(jv.at(kNameName_)),
-         nullptr,
-         boost::json::value_to<std::string>(jv.at(kTitleName_)),
-         jv.at(kEnabledName_).as_bool(),
-         jv.at(kThresholdedName_).as_bool()};
    }
 
    Impl* p;
@@ -408,23 +417,24 @@ void PlacefileManager::Impl::ApplyPlacefileSettings(
       auto& placefileArray = placefileJson.as_array();
       for (auto& placefileEntry : placefileArray)
       {
-         try
-         {
-            // Convert placefile entry to a record
-            PlacefileRecord record =
-               boost::json::value_to<PlacefileRecord>(placefileEntry);
+         // Convert placefile entry to settings fields
+         auto record =
+            boost::json::try_value_to<PlacefileSettingsEntry>(placefileEntry);
 
-            if (!record.name_.empty())
+         if (!record.has_error())
+         {
+            if (!record->name.empty())
             {
-               self_->AddUrl(record.name_,
-                             record.title_,
-                             record.enabled_,
-                             record.thresholded_);
+               self_->AddUrl(record->name,
+                             record->title,
+                             record->enabled,
+                             record->thresholded);
             }
          }
-         catch (const std::exception& ex)
+         else
          {
-            logger_->warn("Invalid placefile entry: {}", ex.what());
+            logger_->warn("Invalid placefile entry: {}",
+                          record.error().message());
          }
       }
    }

--- a/scwx-qt/source/scwx/qt/manager/update_manager.cpp
+++ b/scwx-qt/source/scwx/qt/manager/update_manager.cpp
@@ -169,17 +169,19 @@ size_t UpdateManager::Impl::AddReleases(const boost::json::value& json)
 {
    // Parse releases
    std::vector<types::gh::Release> newReleases {};
-   try
+
+   auto converted =
+      boost::json::try_value_to<std::vector<types::gh::Release>>(json);
+   if (!converted.has_error())
    {
-      newReleases =
-         boost::json::value_to<std::vector<types::gh::Release>>(json);
+      newReleases = std::move(*converted);
    }
-   catch (const std::exception& ex)
+   else
    {
-      logger_->warn("Error parsing JSON: {}", ex.what());
+      logger_->warn("Error parsing JSON: {}", converted.error().message());
    }
 
-   size_t newReleaseCount = newReleases.size();
+   const size_t newReleaseCount = newReleases.size();
 
    // Add releases to the current list
    releases_.insert(releases_.end(), newReleases.begin(), newReleases.end());

--- a/scwx-qt/source/scwx/qt/model/layer_model.cpp
+++ b/scwx-qt/source/scwx/qt/model/layer_model.cpp
@@ -231,15 +231,17 @@ void LayerModel::Impl::ApplyLayerSettings(const boost::json::value& layerJson)
       auto& layerArray = layerJson.as_array();
       for (auto& layerEntry : layerArray)
       {
-         try
+         // Convert layer entry to a LayerInfo record, and add to new layers
+         auto converted =
+            boost::json::try_value_to<types::LayerInfo>(layerEntry);
+         if (!converted.has_error())
          {
-            // Convert layer entry to a LayerInfo record, and add to new layers
-            newLayers.emplace_back(
-               boost::json::value_to<types::LayerInfo>(layerEntry));
+            newLayers.emplace_back(std::move(*converted));
          }
-         catch (const std::exception& ex)
+         else
          {
-            logger_->warn("Invalid layer entry: {}", ex.what());
+            logger_->warn("Invalid layer entry: {}",
+                          converted.error().message());
          }
       }
 

--- a/scwx-qt/source/scwx/qt/settings/settings_variable.cpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_variable.cpp
@@ -384,13 +384,34 @@ bool SettingsVariable<T>::ReadValue(const boost::json::object& json)
    {
       try
       {
-         validated = SetValueOrDefault(boost::json::value_to<T>(*jv));
+         // value_to() throws with_throw_location<system_error>, which Clang 20
+         // + libc++ does not catch as std::exception.
+         const auto converted = boost::json::try_value_to<T>(*jv);
+         if (converted.has_error())
+         {
+            logger_->warn("{} is invalid ({}), setting to default: {}",
+                          name(),
+                          converted.error().message(),
+                          FormatParameter<T>(p->default_));
+            p->value_ = p->default_;
+         }
+         else
+         {
+            validated = SetValueOrDefault(*converted);
+         }
       }
       catch (const std::exception& ex)
       {
          logger_->warn("{} is invalid ({}), setting to default: {}",
                        name(),
                        ex.what(),
+                       FormatParameter<T>(p->default_));
+         p->value_ = p->default_;
+      }
+      catch (...)
+      {
+         logger_->warn("{} is invalid, setting to default: {}",
+                       name(),
                        FormatParameter<T>(p->default_));
          p->value_ = p->default_;
       }

--- a/scwx-qt/source/scwx/qt/settings/settings_variable.cpp
+++ b/scwx-qt/source/scwx/qt/settings/settings_variable.cpp
@@ -382,38 +382,18 @@ bool SettingsVariable<T>::ReadValue(const boost::json::object& json)
 
    if (jv != nullptr)
    {
-      try
-      {
-         // value_to() throws with_throw_location<system_error>, which Clang 20
-         // + libc++ does not catch as std::exception.
-         const auto converted = boost::json::try_value_to<T>(*jv);
-         if (converted.has_error())
-         {
-            logger_->warn("{} is invalid ({}), setting to default: {}",
-                          name(),
-                          converted.error().message(),
-                          FormatParameter<T>(p->default_));
-            p->value_ = p->default_;
-         }
-         else
-         {
-            validated = SetValueOrDefault(*converted);
-         }
-      }
-      catch (const std::exception& ex)
+      const auto converted = boost::json::try_value_to<T>(*jv);
+      if (converted.has_error())
       {
          logger_->warn("{} is invalid ({}), setting to default: {}",
                        name(),
-                       ex.what(),
+                       converted.error().message(),
                        FormatParameter<T>(p->default_));
          p->value_ = p->default_;
       }
-      catch (...)
+      else
       {
-         logger_->warn("{} is invalid, setting to default: {}",
-                       name(),
-                       FormatParameter<T>(p->default_));
-         p->value_ = p->default_;
+         validated = SetValueOrDefault(*converted);
       }
    }
    else

--- a/test/source/scwx/qt/manager/settings_manager.test.cpp
+++ b/test/source/scwx/qt/manager/settings_manager.test.cpp
@@ -22,18 +22,27 @@ static const std::string TEMP_SETTINGS_FILE =
 class SettingsManagerTest : public testing::Test
 {
    virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
+   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
 
 class DefaultSettingsTest : public testing::TestWithParam<std::string>
 {
    virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
+   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
 
 class BadSettingsTest :
     public testing::TestWithParam<std::pair<std::string, std::string>>
 {
    virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
+   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
+
+static void CopyToTempSettings(const std::string& sourceFile, const std::string& tempSettingsFile)
+{
+   std::filesystem::remove(tempSettingsFile);
+   std::filesystem::copy_file(sourceFile, tempSettingsFile);
+}
 
 static void VerifyDefaults()
 {
@@ -108,7 +117,9 @@ TEST_F(SettingsManagerTest, CreateJson)
 {
    scwx::qt::config::RadarSite::Initialize();
 
-   std::string filename {TEMP_SETTINGS_FILE};
+   const std::string filename {TEMP_SETTINGS_FILE};
+
+   std::filesystem::remove(filename);
 
    // Verify file doesn't exist prior to test start
    EXPECT_EQ(std::filesystem::exists(filename), false);
@@ -126,7 +137,7 @@ TEST_F(SettingsManagerTest, CreateJson)
 
 TEST_F(SettingsManagerTest, SettingsKeax)
 {
-   std::string filename(std::string(SCWX_TEST_DATA_DIR) +
+   const std::string filename(std::string(SCWX_TEST_DATA_DIR) +
                         "/json/settings/settings-keax.json");
 
    SettingsManager::Instance().ReadSettings(filename);
@@ -143,11 +154,11 @@ TEST_F(SettingsManagerTest, SettingsKeax)
 
 TEST_P(DefaultSettingsTest, DefaultSettings)
 {
-   std::string sourceFile(std::string(SCWX_TEST_DATA_DIR) + "/json/settings/" +
+   const std::string sourceFile(std::string(SCWX_TEST_DATA_DIR) + "/json/settings/" +
                           GetParam());
-   std::string filename {TEMP_SETTINGS_FILE};
+   const std::string filename {TEMP_SETTINGS_FILE};
 
-   std::filesystem::copy_file(sourceFile, filename);
+   CopyToTempSettings(sourceFile, filename);
 
    SettingsManager::Instance().ReadSettings(filename);
 
@@ -175,7 +186,7 @@ TEST_P(BadSettingsTest, BadSettings)
                                 "/json/settings/" + badFilename);
    const std::string filename {TEMP_SETTINGS_FILE};
 
-   std::filesystem::copy_file(sourceFile, filename);
+   CopyToTempSettings(sourceFile, filename);
 
    SettingsManager::Instance().ReadSettings(filename);
 

--- a/test/source/scwx/qt/manager/settings_manager.test.cpp
+++ b/test/source/scwx/qt/manager/settings_manager.test.cpp
@@ -21,24 +21,25 @@ static const std::string TEMP_SETTINGS_FILE =
 
 class SettingsManagerTest : public testing::Test
 {
-   virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
-   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
+   void SetUp() override { scwx::qt::config::RadarSite::Initialize(); }
+   void TearDown() override { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
 
 class DefaultSettingsTest : public testing::TestWithParam<std::string>
 {
-   virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
-   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
+   void SetUp() override { scwx::qt::config::RadarSite::Initialize(); }
+   void TearDown() override { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
 
 class BadSettingsTest :
     public testing::TestWithParam<std::pair<std::string, std::string>>
 {
-   virtual void SetUp() { scwx::qt::config::RadarSite::Initialize(); }
-   virtual void TearDown() { std::filesystem::remove(TEMP_SETTINGS_FILE); }
+   void SetUp() override { scwx::qt::config::RadarSite::Initialize(); }
+   void TearDown() override { std::filesystem::remove(TEMP_SETTINGS_FILE); }
 };
 
-static void CopyToTempSettings(const std::string& sourceFile, const std::string& tempSettingsFile)
+static void CopyToTempSettings(const std::string& sourceFile,
+                               const std::string& tempSettingsFile)
 {
    std::filesystem::remove(tempSettingsFile);
    std::filesystem::copy_file(sourceFile, tempSettingsFile);
@@ -138,7 +139,7 @@ TEST_F(SettingsManagerTest, CreateJson)
 TEST_F(SettingsManagerTest, SettingsKeax)
 {
    const std::string filename(std::string(SCWX_TEST_DATA_DIR) +
-                        "/json/settings/settings-keax.json");
+                              "/json/settings/settings-keax.json");
 
    SettingsManager::Instance().ReadSettings(filename);
 
@@ -154,8 +155,8 @@ TEST_F(SettingsManagerTest, SettingsKeax)
 
 TEST_P(DefaultSettingsTest, DefaultSettings)
 {
-   const std::string sourceFile(std::string(SCWX_TEST_DATA_DIR) + "/json/settings/" +
-                          GetParam());
+   const std::string sourceFile(std::string(SCWX_TEST_DATA_DIR) +
+                                "/json/settings/" + GetParam());
    const std::string filename {TEMP_SETTINGS_FILE};
 
    CopyToTempSettings(sourceFile, filename);

--- a/test/source/scwx/qt/settings/settings_variable.test.cpp
+++ b/test/source/scwx/qt/settings/settings_variable.test.cpp
@@ -1,5 +1,6 @@
 #include <scwx/qt/settings/settings_variable.hpp>
 
+#include <boost/json.hpp>
 #include <gtest/gtest.h>
 
 namespace scwx
@@ -20,6 +21,26 @@ TEST(SettingsVariableTest, Boolean)
    EXPECT_EQ(boolVariable.SetValue(true), true);
    EXPECT_EQ(boolVariable.GetValue(), true);
    EXPECT_EQ(boolVariable.SetValueOrDefault(false), true);
+   EXPECT_EQ(boolVariable.GetValue(), false);
+}
+
+TEST(SettingsVariableTest, ReadValueInvalidTypeUsesDefault)
+{
+   SettingsVariable<bool> boolVariable {"bool"};
+   boolVariable.SetDefault(true);
+   boolVariable.SetValue(false);
+
+   const boost::json::object stringValue {{"bool", ""}};
+   EXPECT_FALSE(boolVariable.ReadValue(stringValue));
+   EXPECT_EQ(boolVariable.GetValue(), true);
+
+   boolVariable.SetValue(false);
+   const boost::json::object integerValue {{"bool", 0}};
+   EXPECT_FALSE(boolVariable.ReadValue(integerValue));
+   EXPECT_EQ(boolVariable.GetValue(), true);
+
+   const boost::json::object validValue {{"bool", false}};
+   EXPECT_TRUE(boolVariable.ReadValue(validValue));
    EXPECT_EQ(boolVariable.GetValue(), false);
 }
 

--- a/tools/conan/profiles/scwx-linux_clang-23
+++ b/tools/conan/profiles/scwx-linux_clang-23
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libstdc++11
+compiler.version=23
+os=Linux

--- a/tools/conan/profiles/scwx-linux_clang-23_armv8
+++ b/tools/conan/profiles/scwx-linux_clang-23_armv8
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libstdc++11
+compiler.version=23
+os=Linux

--- a/tools/conan/profiles/scwx-macos_clang-19
+++ b/tools/conan/profiles/scwx-macos_clang-19
@@ -1,0 +1,9 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=19
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-20
+++ b/tools/conan/profiles/scwx-macos_clang-20
@@ -1,0 +1,9 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=20
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-21
+++ b/tools/conan/profiles/scwx-macos_clang-21
@@ -1,0 +1,9 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=21
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-21
+++ b/tools/conan/profiles/scwx-macos_clang-21
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=21
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/conan/profiles/scwx-macos_clang-21_armv8
+++ b/tools/conan/profiles/scwx-macos_clang-21_armv8
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=21
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/conan/profiles/scwx-macos_clang-22
+++ b/tools/conan/profiles/scwx-macos_clang-22
@@ -1,0 +1,9 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=22
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-22
+++ b/tools/conan/profiles/scwx-macos_clang-22
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=22
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/conan/profiles/scwx-macos_clang-22_armv8
+++ b/tools/conan/profiles/scwx-macos_clang-22_armv8
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=22
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/conan/profiles/scwx-macos_clang-23
+++ b/tools/conan/profiles/scwx-macos_clang-23
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=23
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/conan/profiles/scwx-macos_clang-23
+++ b/tools/conan/profiles/scwx-macos_clang-23
@@ -1,0 +1,9 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=23
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-23_armv8
+++ b/tools/conan/profiles/scwx-macos_clang-23_armv8
@@ -1,0 +1,9 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=23
+os=Macos
+os.version=12.0

--- a/tools/conan/profiles/scwx-macos_clang-23_armv8
+++ b/tools/conan/profiles/scwx-macos_clang-23_armv8
@@ -6,4 +6,4 @@ compiler.cppstd=20
 compiler.libcxx=libc++
 compiler.version=23
 os=Macos
-os.version=12.0
+os.version=13.3

--- a/tools/configure-environment.sh
+++ b/tools/configure-environment.sh
@@ -49,11 +49,17 @@ if [[ "$(uname)" == "Darwin" ]]; then
     # macOS profiles
     conan_profiles=(
         "scwx-macos_clang-18"
+        "scwx-macos_clang-19"
+        "scwx-macos_clang-20"
+        "scwx-macos_clang-21"
+        "scwx-macos_clang-22"
+        "scwx-macos_clang-23"
         "scwx-macos_clang-18_armv8"
         "scwx-macos_clang-19_armv8"
         "scwx-macos_clang-20_armv8"
         "scwx-macos_clang-21_armv8"
         "scwx-macos_clang-22_armv8"
+        "scwx-macos_clang-23_armv8"
     )
 else
     # Linux profiles
@@ -70,6 +76,8 @@ else
         "scwx-linux_clang-21_armv8"
         "scwx-linux_clang-22"
         "scwx-linux_clang-22_armv8"
+        "scwx-linux_clang-23"
+        "scwx-linux_clang-23_armv8"
         "scwx-linux_gcc-11"
         "scwx-linux_gcc-11_armv8"
         "scwx-linux_gcc-12"

--- a/tools/lib/run-cmake-configure.sh
+++ b/tools/lib/run-cmake-configure.sh
@@ -40,5 +40,11 @@ else
     )
 fi
 
+if [[ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]]; then
+    cmake_args+=(
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}"
+    )
+fi
+
 mkdir -p "${build_dir}"
 cmake "${cmake_args[@]}"

--- a/tools/setup-macos-ninja-debug.sh
+++ b/tools/setup-macos-ninja-debug.sh
@@ -22,6 +22,9 @@ export PATH="${llvm_prefix}/bin:$PATH"
 export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
 export CPPFLAGS="-I${llvm_prefix}/include"
 
+# Clang 21+ requires macOS 13.3
+export MACOSX_DEPLOYMENT_TARGET=13.3
+
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then
     unset venv_path

--- a/tools/setup-macos-ninja-debug.sh
+++ b/tools/setup-macos-ninja-debug.sh
@@ -4,19 +4,19 @@ script_dir="$(cd "$(dirname "${script_source}")" && pwd)"
 
 export build_dir="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${1:-${script_dir}/../build-debug}")"
 export build_type=Debug
-export conan_profile=${2:-scwx-macos_clang-18_armv8}
+export conan_profile=${2:-scwx-macos_clang-22_armv8}
 export generator=Ninja
 export qt_base="/Users/${USER}/Qt"
 export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@18)/bin/clang
-export CXX=$(brew --prefix llvm@18)/bin/clang++
-export PATH="$(brew --prefix llvm@18)/bin:$PATH"
+export CC=$(brew --prefix llvm@22)/bin/clang
+export CXX=$(brew --prefix llvm@22)/bin/clang++
+export PATH="$(brew --prefix llvm@22)/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@18)/lib -L$(brew --prefix llvm@18)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@18)/include"
+export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
+export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-ninja-debug.sh
+++ b/tools/setup-macos-ninja-debug.sh
@@ -11,12 +11,16 @@ export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@22)/bin/clang
-export CXX=$(brew --prefix llvm@22)/bin/clang++
-export PATH="$(brew --prefix llvm@22)/bin:$PATH"
+if ! llvm_prefix="$(brew --prefix llvm@22)"; then
+    echo "error: failed to resolve Homebrew prefix for llvm@22" >&2
+    exit 1
+fi
+export CC="${llvm_prefix}/bin/clang"
+export CXX="${llvm_prefix}/bin/clang++"
+export PATH="${llvm_prefix}/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
+export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
+export CPPFLAGS="-I${llvm_prefix}/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-ninja-release.sh
+++ b/tools/setup-macos-ninja-release.sh
@@ -22,6 +22,9 @@ export PATH="${llvm_prefix}/bin:$PATH"
 export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
 export CPPFLAGS="-I${llvm_prefix}/include"
 
+# Clang 21+ requires macOS 13.3
+export MACOSX_DEPLOYMENT_TARGET=13.3
+
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then
     unset venv_path

--- a/tools/setup-macos-ninja-release.sh
+++ b/tools/setup-macos-ninja-release.sh
@@ -4,19 +4,19 @@ script_dir="$(cd "$(dirname "${script_source}")" && pwd)"
 
 export build_dir="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${1:-${script_dir}/../build-release}")"
 export build_type=Release
-export conan_profile=${2:-scwx-macos_clang-18_armv8}
+export conan_profile=${2:-scwx-macos_clang-22_armv8}
 export generator=Ninja
 export qt_base="/Users/${USER}/Qt"
 export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@18)/bin/clang
-export CXX=$(brew --prefix llvm@18)/bin/clang++
-export PATH="$(brew --prefix llvm@18)/bin:$PATH"
+export CC=$(brew --prefix llvm@22)/bin/clang
+export CXX=$(brew --prefix llvm@22)/bin/clang++
+export PATH="$(brew --prefix llvm@22)/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@18)/lib -L$(brew --prefix llvm@18)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@18)/include"
+export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
+export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-ninja-release.sh
+++ b/tools/setup-macos-ninja-release.sh
@@ -11,12 +11,16 @@ export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@22)/bin/clang
-export CXX=$(brew --prefix llvm@22)/bin/clang++
-export PATH="$(brew --prefix llvm@22)/bin:$PATH"
+if ! llvm_prefix="$(brew --prefix llvm@22)"; then
+    echo "error: failed to resolve Homebrew prefix for llvm@22" >&2
+    exit 1
+fi
+export CC="${llvm_prefix}/bin/clang"
+export CXX="${llvm_prefix}/bin/clang++"
+export PATH="${llvm_prefix}/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
+export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
+export CPPFLAGS="-I${llvm_prefix}/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-debug.sh
+++ b/tools/setup-macos-xcode-debug.sh
@@ -4,19 +4,19 @@ script_dir="$(cd "$(dirname "${script_source}")" && pwd)"
 
 export build_dir="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${1:-${script_dir}/../build-xcode-debug}")"
 export build_type=Debug
-export conan_profile=${2:-scwx-macos_clang-18_armv8}
+export conan_profile=${2:-scwx-macos_clang-22_armv8}
 export generator=Xcode
 export qt_base="/Users/${USER}/Qt"
 export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@18)/bin/clang
-export CXX=$(brew --prefix llvm@18)/bin/clang++
-export PATH="$(brew --prefix llvm@18)/bin:$PATH"
+export CC=$(brew --prefix llvm@22)/bin/clang
+export CXX=$(brew --prefix llvm@22)/bin/clang++
+export PATH="$(brew --prefix llvm@22)/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@18)/lib -L$(brew --prefix llvm@18)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@18)/include"
+export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
+export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-debug.sh
+++ b/tools/setup-macos-xcode-debug.sh
@@ -22,6 +22,9 @@ export PATH="${llvm_prefix}/bin:$PATH"
 export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
 export CPPFLAGS="-I${llvm_prefix}/include"
 
+# Clang 21+ requires macOS 13.3
+export MACOSX_DEPLOYMENT_TARGET=13.3
+
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then
     unset venv_path

--- a/tools/setup-macos-xcode-debug.sh
+++ b/tools/setup-macos-xcode-debug.sh
@@ -11,12 +11,16 @@ export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@22)/bin/clang
-export CXX=$(brew --prefix llvm@22)/bin/clang++
-export PATH="$(brew --prefix llvm@22)/bin:$PATH"
+if ! llvm_prefix="$(brew --prefix llvm@22)"; then
+    echo "error: failed to resolve Homebrew prefix for llvm@22" >&2
+    exit 1
+fi
+export CC="${llvm_prefix}/bin/clang"
+export CXX="${llvm_prefix}/bin/clang++"
+export PATH="${llvm_prefix}/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
+export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
+export CPPFLAGS="-I${llvm_prefix}/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-multi.sh
+++ b/tools/setup-macos-xcode-multi.sh
@@ -3,19 +3,19 @@ script_source="${BASH_SOURCE[0]:-$0}"
 script_dir="$(cd "$(dirname "${script_source}")" && pwd)"
 
 export build_dir="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${1:-${script_dir}/../build-xcode}")"
-export conan_profile=${2:-scwx-macos_clang-18_armv8}
+export conan_profile=${2:-scwx-macos_clang-22_armv8}
 export generator=Xcode
 export qt_base=/opt/Qt
 export qt_arch=gcc_64
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@18)/bin/clang
-export CXX=$(brew --prefix llvm@18)/bin/clang++
-export PATH="$(brew --prefix llvm@18)/bin:$PATH"
+export CC=$(brew --prefix llvm@22)/bin/clang
+export CXX=$(brew --prefix llvm@22)/bin/clang++
+export PATH="$(brew --prefix llvm@22)/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@18)/lib -L$(brew --prefix llvm@18)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@18)/include"
+export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
+export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-multi.sh
+++ b/tools/setup-macos-xcode-multi.sh
@@ -21,6 +21,9 @@ export PATH="${llvm_prefix}/bin:$PATH"
 export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
 export CPPFLAGS="-I${llvm_prefix}/include"
 
+# Clang 21+ requires macOS 13.3
+export MACOSX_DEPLOYMENT_TARGET=13.3
+
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then
     unset venv_path

--- a/tools/setup-macos-xcode-multi.sh
+++ b/tools/setup-macos-xcode-multi.sh
@@ -10,12 +10,16 @@ export qt_arch=gcc_64
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@22)/bin/clang
-export CXX=$(brew --prefix llvm@22)/bin/clang++
-export PATH="$(brew --prefix llvm@22)/bin:$PATH"
+if ! llvm_prefix="$(brew --prefix llvm@22)"; then
+    echo "error: failed to resolve Homebrew prefix for llvm@22" >&2
+    exit 1
+fi
+export CC="${llvm_prefix}/bin/clang"
+export CXX="${llvm_prefix}/bin/clang++"
+export PATH="${llvm_prefix}/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
+export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
+export CPPFLAGS="-I${llvm_prefix}/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-release.sh
+++ b/tools/setup-macos-xcode-release.sh
@@ -4,19 +4,19 @@ script_dir="$(cd "$(dirname "${script_source}")" && pwd)"
 
 export build_dir="$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${1:-${script_dir}/../build-xcode-release}")"
 export build_type=Release
-export conan_profile=${2:-scwx-macos_clang-18_armv8}
+export conan_profile=${2:-scwx-macos_clang-22_armv8}
 export generator=Xcode
 export qt_base="/Users/${USER}/Qt"
 export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@18)/bin/clang
-export CXX=$(brew --prefix llvm@18)/bin/clang++
-export PATH="$(brew --prefix llvm@18)/bin:$PATH"
+export CC=$(brew --prefix llvm@22)/bin/clang
+export CXX=$(brew --prefix llvm@22)/bin/clang++
+export PATH="$(brew --prefix llvm@22)/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@18)/lib -L$(brew --prefix llvm@18)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@18)/include"
+export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
+export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/tools/setup-macos-xcode-release.sh
+++ b/tools/setup-macos-xcode-release.sh
@@ -22,6 +22,9 @@ export PATH="${llvm_prefix}/bin:$PATH"
 export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
 export CPPFLAGS="-I${llvm_prefix}/include"
 
+# Clang 21+ requires macOS 13.3
+export MACOSX_DEPLOYMENT_TARGET=13.3
+
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then
     unset venv_path

--- a/tools/setup-macos-xcode-release.sh
+++ b/tools/setup-macos-xcode-release.sh
@@ -11,12 +11,16 @@ export qt_arch=macos
 export address_sanitizer=${4:-disabled}
 
 # Set explicit compiler paths
-export CC=$(brew --prefix llvm@22)/bin/clang
-export CXX=$(brew --prefix llvm@22)/bin/clang++
-export PATH="$(brew --prefix llvm@22)/bin:$PATH"
+if ! llvm_prefix="$(brew --prefix llvm@22)"; then
+    echo "error: failed to resolve Homebrew prefix for llvm@22" >&2
+    exit 1
+fi
+export CC="${llvm_prefix}/bin/clang"
+export CXX="${llvm_prefix}/bin/clang++"
+export PATH="${llvm_prefix}/bin:$PATH"
 
-export LDFLAGS="-L$(brew --prefix llvm@22)/lib -L$(brew --prefix llvm@22)/lib/c++"
-export CPPFLAGS="-I$(brew --prefix llvm@22)/include"
+export LDFLAGS="-L${llvm_prefix}/lib -L${llvm_prefix}/lib/c++"
+export CPPFLAGS="-I${llvm_prefix}/include"
 
 # Assign user-specified Python Virtual Environment
 if [ "${3:-}" = "none" ]; then

--- a/wxdata/source/scwx/provider/iem_api_provider.cpp
+++ b/wxdata/source/scwx/provider/iem_api_provider.cpp
@@ -76,18 +76,21 @@ IemApiProvider::ProcessTextProductLists(
 
       if (response.status_code == cpr::status::HTTP_OK)
       {
-         try
+         // Get AFOS list from response
+         auto converted = boost::json::try_value_to<types::iem::AfosList>(json);
+
+         if (!converted.has_error())
          {
-            // Get AFOS list from response
-            auto entries = boost::json::value_to<types::iem::AfosList>(json);
+            types::iem::AfosList entries = std::move(*converted);
+
             textProducts.insert(textProducts.end(),
                                 std::make_move_iterator(entries.data_.begin()),
                                 std::make_move_iterator(entries.data_.end()));
          }
-         catch (const std::exception& ex)
+         else
          {
-            // Unexpected bad response
-            logger_->warn("Error parsing JSON: {}", ex.what());
+            logger_->warn("Error parsing JSON: {}",
+                          converted.error().message());
             return boost::system::errc::make_error_code(
                boost::system::errc::bad_message);
          }
@@ -95,18 +98,20 @@ IemApiProvider::ProcessTextProductLists(
       else if (response.status_code == cpr::status::HTTP_BAD_REQUEST &&
                json != nullptr)
       {
-         try
+         // Log bad request details
+         const auto badRequest =
+            boost::json::try_value_to<types::iem::BadRequest>(json);
+
+         if (!badRequest.has_error())
          {
-            // Log bad request details
-            auto badRequest =
-               boost::json::value_to<types::iem::BadRequest>(json);
             logger_->warn("ListTextProducts bad request: {}",
-                          badRequest.detail_);
+                          badRequest->detail_);
          }
-         catch (const std::exception& ex)
+         else
          {
             // Unexpected bad response
-            logger_->warn("Error parsing bad response: {}", ex.what());
+            logger_->warn("Error parsing bad response: {}",
+                          badRequest.error().message());
          }
 
          return boost::system::errc::make_error_code(
@@ -115,18 +120,20 @@ IemApiProvider::ProcessTextProductLists(
       else if (response.status_code == cpr::status::HTTP_UNPROCESSABLE_ENTITY &&
                json != nullptr)
       {
-         try
+         // Log validation error details
+         const auto error =
+            boost::json::try_value_to<types::iem::ValidationError>(json);
+
+         if (!error.has_error())
          {
-            // Log validation error details
-            auto error =
-               boost::json::value_to<types::iem::ValidationError>(json);
             logger_->warn("ListTextProducts validation error: {}",
-                          error.detail_.at(0).msg_);
+                          error->detail_.at(0).msg_);
          }
-         catch (const std::exception& ex)
+         else
          {
             // Unexpected bad response
-            logger_->warn("Error parsing validation error: {}", ex.what());
+            logger_->warn("Error parsing validation error: {}",
+                          error.error().message());
          }
 
          return boost::system::errc::make_error_code(

--- a/wxdata/source/scwx/provider/iem_api_provider.cpp
+++ b/wxdata/source/scwx/provider/iem_api_provider.cpp
@@ -126,8 +126,15 @@ IemApiProvider::ProcessTextProductLists(
 
          if (!error.has_error())
          {
-            logger_->warn("ListTextProducts validation error: {}",
-                          error->detail_.at(0).msg_);
+            if (error->detail_.empty())
+            {
+               logger_->warn("ListTextProducts validation error");
+            }
+            else
+            {
+               logger_->warn("ListTextProducts validation error: {}",
+                             error->detail_.at(0).msg_);
+            }
          }
          else
          {

--- a/wxdata/source/scwx/provider/nws_api_provider.cpp
+++ b/wxdata/source/scwx/provider/nws_api_provider.cpp
@@ -106,50 +106,49 @@ NwsApiProvider::Impl::RequestData(std::string_view       endpointUrl,
 
    if (response.status_code == cpr::status::HTTP_OK)
    {
-      try
+      auto converted = boost::json::try_value_to<T>(json);
+      if (!converted.has_error())
       {
-         data = boost::json::value_to<T>(json);
+         data = std::move(*converted);
       }
-      catch (const std::exception& ex)
+      else
       {
-         // Unexpected bad response
-         logger_->warn("Error parsing JSON: {}", ex.what());
+         logger_->warn("Error parsing JSON: {}", converted.error().message());
          return boost::system::errc::make_error_code(
             boost::system::errc::bad_message);
       }
    }
    else if (json != nullptr)
    {
-      try
+      // Log error response details
+      const auto errorResponse =
+         boost::json::try_value_to<types::nws::ErrorResponse>(json);
+
+      if (!errorResponse.has_error())
       {
-         // Log error response details
-         const auto errorResponse =
-            boost::json::value_to<types::nws::ErrorResponse>(json);
          logger_->warn("GetRadarStations error response ({}): {} ({})",
                        response.status_code,
-                       errorResponse.title_,
-                       errorResponse.detail_);
+                       errorResponse->title_,
+                       errorResponse->detail_);
 
-         for (auto& parameterError : errorResponse.parameterErrors_)
+         for (auto& parameterError : errorResponse->parameterErrors_)
          {
             logger_->warn(" Parameter error: {} {}",
                           parameterError.parameter_,
                           parameterError.message_);
          }
-
-         return boost::system::errc::make_error_code(
-            boost::system::errc::no_message);
       }
-      catch (const std::exception& ex)
+      else
       {
+
          // Unexpected bad response
          logger_->warn("Error parsing error response ({}): {}",
                        response.status_code,
-                       ex.what());
-
-         return boost::system::errc::make_error_code(
-            boost::system::errc::no_message);
+                       errorResponse.error().message());
       }
+
+      return boost::system::errc::make_error_code(
+         boost::system::errc::no_message);
    }
    else if (running_)
    {


### PR DESCRIPTION
Make the following updates:

- Remove VS 2022 from CI matrix
- Support clang-23
- Update clang-tidy-18 to clang-tidy-21
- Update default macOS configuration to clang-20 (clang-21+ requires bumping minimum target to macOS 13.3).