### PR TITLE
Add Custom Radars GIS command line option

### DIFF
--- a/scwx-qt/source/scwx/qt/config/radar_site.cpp
+++ b/scwx-qt/source/scwx/qt/config/radar_site.cpp
@@ -1,4 +1,5 @@
 #include <scwx/qt/config/radar_site.hpp>
+#include <scwx/qt/main/program_options.hpp>
 #include <scwx/qt/util/geographic_lib.hpp>
 #include <scwx/qt/util/json.hpp>
 #include <scwx/common/sites.hpp>
@@ -312,6 +313,9 @@ void RadarSite::Initialize()
       const std::string level3Url =
          scwx::util::GetEnvironment("SCWX_LEVEL3_DATA_PROVIDER_URL");
 
+      const auto& programOptions = scwx::qt::main::ProgramOptions::GetOptions();
+      const std::string customRadarsGis = programOptions.customRadarsGis_;
+
       if (boost::icontains(level2Url, "iastate.edu") ||
           boost::icontains(level3Url, "iastate.edu"))
       {
@@ -328,6 +332,11 @@ void RadarSite::Initialize()
          // Detected Weather Pulse data provider URL in environment
          // variables. Load radar sites from Weather Pulse GIS config.
          ReadConfig(":/res/config/radars_weatherpulse.gis");
+      }
+
+      if (!customRadarsGis.empty())
+      {
+         ReadConfig(customRadarsGis);
       }
 
       initialized_ = true;

--- a/scwx-qt/source/scwx/qt/main/program_options.cpp
+++ b/scwx-qt/source/scwx/qt/main/program_options.cpp
@@ -137,6 +137,11 @@ const boost::program_options::options_description& GetVisibleOptions()
           boost::program_options::bool_switch(&programOptions_.enableConsole_),
           "Enable console output") //
 #endif
+         ("custom-radars-gis",
+          boost::program_options::value<std::string>(
+             &programOptions_.customRadarsGis_)
+             ->value_name("path"),
+          "Path to custom radar sites GIS configuration file.") //
          ("level2-provider",
           boost::program_options::value<std::string>(
              &programOptions_.level2Provider_)

--- a/scwx-qt/source/scwx/qt/main/program_options.hpp
+++ b/scwx-qt/source/scwx/qt/main/program_options.hpp
@@ -12,6 +12,7 @@ struct Options
    bool                     showHelp_ {false};
    bool                     enableConsole_ {false};
    bool                     portableMode_ {false};
+   std::string              customRadarsGis_ {};
    std::string              level2Provider_ {};
    std::string              level3Provider_ {};
    std::string              settingsDirectory_ {};


### PR DESCRIPTION
Add a Custom Radars GIS command line option.

```
Usage:
  supercell-wx [qt options] [options]

Options:
  --custom-radars-gis path  Path to custom radar sites GIS configuration file.
```

The custom radar will either need to be available on the default source, or be available at the Level 2 or Level 3 Provider URL specified via separate command line option, until the application supports multiple providers. The data feed must also be in a supported format.

A hypothetical custom radar site, CSTM, located in Lake Michigan:
<img width="314" height="97" alt="image" src="https://github.com/user-attachments/assets/f21006ea-b120-4ba5-84da-69f119c4989b" />